### PR TITLE
Track the greatest id to prevent records from being overriden

### DIFF
--- a/lib/connectors/memory.js
+++ b/lib/connectors/memory.js
@@ -38,7 +38,19 @@ Memory.prototype.define = function defineModel(descr) {
 };
 
 Memory.prototype.create = function create(model, data, callback) {
-    var id = data.id || this.ids[model]++;
+    var currentId = this.ids[model];
+    if(currentId === undefined) {
+        // First time
+        this.ids[model] = 1;
+        currentId = 1;
+    }
+    var id = data.id || currentId;
+    if(id > currentId) {
+        // If the id is passed in and the value is greater than the current id
+        currentId = id;
+    }
+    this.ids[model] = currentId + 1;
+
     data.id = id;
     this.cache[model][id] = JSON.stringify(data);
     process.nextTick(function() {


### PR DESCRIPTION
@ritch We found the problem during ios app testing as follows:
1. create 3 records by providing id 1, 2, and 3.
2. create a new record without id

Since the memory connector didn't track 1, 2, 3, it used 1 as the generated id for the newly created record and overwrote record 1 instead of creating a new one.

The fix makes sure the greatest id is tracked.
