### PR TITLE
Check the filter param to make sure we have a default value

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -469,6 +469,7 @@ DataAccessObject.findOne = function findOne(params, cb) {
         cb = params;
         params = {};
     }
+    params = params || {};
     params.limit = 1;
     this.find(params, function (err, collection) {
         if (err || !collection || !collection.length > 0) return cb(err, null);


### PR DESCRIPTION
sls-sample-app is failing if we hit http://localhost:3000/locations/findOne

In this case, a undefined param is passed in.

The fix now sets it to {} if the value is undefined/null

/to @ritch 
