### PR TITLE
Fix EventEmitter mixin

### DIFF
--- a/lib/model-builder.js
+++ b/lib/model-builder.js
@@ -118,7 +118,7 @@ ModelBuilder.prototype.define = function defineClass(className, properties, sett
     // mix in EventEmitter (don't inherit from)
     var events = new EventEmitter();
     for (var f in EventEmitter.prototype) {
-        if (typeof EventEmitter.prototype[f]) {
+        if (typeof EventEmitter.prototype[f] === 'function') {
             ModelClass[f] = events[f].bind(events);
         }
     }


### PR DESCRIPTION
/to @raymondfeng 

Mixin is missing a check for typeof function... Breaks code generated by `slc lb model`.
