### PR TITLE
Fix prototype mixin bug

### DIFF
--- a/lib/jutil.js
+++ b/lib/jutil.js
@@ -57,7 +57,7 @@ exports.mixin = function (newClass, mixinClass, options) {
     if (options.instanceProperties) {
         if (mixinClass.prototype) {
             Object.keys(mixinClass.prototype).forEach(function (instanceProp) {
-                if (!newClass.hasOwnProperty(instanceProp) || options.override) {
+                if (!newClass.prototype.hasOwnProperty(instanceProp) || options.override) {
                     var pd = Object.getOwnPropertyDescriptor(mixinClass.prototype, instanceProp);
                     Object.defineProperty(newClass.prototype, instanceProp, pd);
                 }


### PR DESCRIPTION
/to @raymondfeng 

Mixin utility is currently checking for existing properties on the new class instead of the new class prototype.

This means a class that defines the same static method and instance method will only mixin the static method.
