### PR TITLE
Fix removeUndefined to bypass non-plain objects

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -69,7 +69,7 @@ function selectFields(fields) {
       result[key] = obj[key];
     }
     return result;
-  }
+  };
 }
 
 /**
@@ -78,13 +78,22 @@ function selectFields(fields) {
  * @returns {exports.map|*}
  */
 function removeUndefined(query) {
-    if(typeof query !== 'object' || query === null) {
+    if (typeof query !== 'object' || query === null) {
         return query;
     }
-    return traverse(query).map(function (x) {
-        if(x === undefined) {
+    // WARNING: [rfeng] Use map() will cause mongodb to produce invalid BSON
+    // as traverse doesn't transform the ObjectId correctly
+    return traverse(query).forEach(function (x) {
+        if (x === undefined) {
             this.remove();
         }
+
+        if (!Array.isArray(x) && (typeof x === 'object' && x !== null && x.constructor !== Object)) {
+            // This object is not a plain object
+            this.update(x, true); // Stop navigating into this object
+            return x;
+        }
+
         return x;
     });
 }

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -46,6 +46,10 @@ describe('util.removeUndefined', function(){
 
         should.equal(removeUndefined('x'), 'x');
 
+        var date = new Date();
+        var q4 = {where: {x: 1, y: date}};
+        should.deepEqual(removeUndefined(q4), {where: {x: 1, y: date}});
+
     });
 });
 


### PR DESCRIPTION
/to @ritch 

traverse.map() transform custom objects such as Date or ObjectID into
plain objects and it breaks the BSON serialization
