### PR TITLE
REST call of DataAccessObject.findById returns 404

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -331,9 +331,20 @@ setRemoting(DataAccessObject.findById, {
     description: 'Find a model instance by id from the data source',
     accepts: {arg: 'id', type: 'any', description: 'Model id', required: true},
     returns: {arg: 'data', type: 'any', root: true},
-    http: {verb: 'get', path: '/:id'}
+    http: {verb: 'get', path: '/:id'},
+    rest: {after: convertNullToNotFoundError}
 });
 
+function convertNullToNotFoundError(ctx, cb) {
+  if (ctx.result !== null) return cb();
+
+  var modelName = ctx.method.sharedClass.name;
+  var id = ctx.getArgByName('id');
+  var msg = 'Unkown "' + modelName + '" id "' + id + '".';
+  var error = new Error(msg);
+  error.statusCode = error.status = 404;
+  cb(error);
+}
 
 // alias function for backwards compat.
 DataAccessObject.all = function () {


### PR DESCRIPTION
Modify the remoting configuration of `DataAccessObject.findById()` and add a `rest.before` handler that converts `null` to 404 error.

The change is covered by a test in loopback project (see strongloop/loopback#75).

Requires strongloop/strong-remoting#22.

/to: @raymondfeng or @ritch - please review
/cc: @Schoonology FYI

BTW having unit-tests in a different project is a serious code smell. We should either consider moving configuration of remoting options to loopback, or write integration tests that setup a strong-remoting server to test this config.
