### PR TITLE
Improve properties of ValidationError

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ exports.ModelBuilder = exports.LDL = require('./lib/model-builder.js').ModelBuil
 exports.DataSource = exports.Schema = require('./lib/datasource.js').DataSource;
 exports.ModelBaseClass = require('./lib/model.js');
 exports.Connector = require('./lib/connector.js');
+exports.ValidationError = require('./lib/validations.js').ValidationError;
 
 var baseSQL = './lib/sql';
 

--- a/lib/validations.js
+++ b/lib/validations.js
@@ -599,12 +599,16 @@ function ValidationError(obj) {
     if (!(this instanceof ValidationError)) return new ValidationError(obj);
 
     this.name = 'ValidationError';
-    this.message = 'Validation error';
-    this.statusCode = 400;
-    this.codes = obj.errors && obj.errors.codes;
-    this.context = obj && obj.constructor && obj.constructor.modelName;
+    this.message = 'The Model instance is not valid. ' +
+      'See `details` property of the error object for more info.';
+    this.statusCode = 422;
 
-    Error.call(this);
+    this.details = {
+      context: obj && obj.constructor && obj.constructor.modelName,
+      codes: obj.errors && obj.errors.codes,
+      messages: obj.errors
+    };
+
     Error.captureStackTrace(this, this.constructor);
 }
 

--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -2,6 +2,7 @@
 var should = require('./init.js');
 
 var db, Person;
+var ValidationError = require('..').ValidationError;
 
 describe('manipulation', function() {
 
@@ -173,7 +174,7 @@ describe('manipulation', function() {
                     p.save({
                         'throws': true
                     });
-                }).should.throw('Validation error');
+                }).should.throw(ValidationError);
             });
         });
 

--- a/test/validations.test.js
+++ b/test/validations.test.js
@@ -2,7 +2,7 @@
 var should = require('./init.js');
 
 var j = require('../'), db, User;
-var ValidationError = require('../lib/validations.js').ValidationError;
+var ValidationError = j.ValidationError;
 
 function getValidAttributes() {
     return {
@@ -98,7 +98,7 @@ describe('validations', function() {
                 User.validatesPresenceOf('name');
                 User.create(function(e, u) {
                     should.exist(e);
-                    e.codes.name.should.eql(['presence']);
+                    e.details.codes.name.should.eql(['presence']);
                     done();
                 });
             });


### PR DESCRIPTION
Improve properties of ValidationError:
- change `statusCode` from 400 to 422
- nest `context` and `codes` inside `details`
- add `details.messages`
- reword the main error message

Remove the call to Error's constructor from ValidationError constructor, because it's a no-op - Error's constructor creates a new instance when called via `.call()`.

/to: @raymondfeng or @ritch: please review
/cc: @Schoonology 

Close strongloop/loopback#21

**A sample response**

``` json
{
  "error": {
    "name": "ValidationError",
    "status": 422,
    "message": "The Model instance is not valid. See `details` property of the error object for more info.",
    "statusCode": 422,
    "details": {
      "context": "todo",
      "codes": {
        "owner": [
          "presence"
        ]
      },
      "messages": {
        "owner": [
          "can't be blank"
        ]
      }
    },
    "stack": "ValidationError: The Model instance is not valid. See `details` property of the error object for more info..\n    at [etc.]"
  }
}
```
