### PR TITLE
Coerce query values of where clause based on property types

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -10,7 +10,6 @@ var util = require('util');
 var jutil = require('./jutil');
 var validations = require('./validations.js');
 var ValidationError = validations.ValidationError;
-var List = require('./list.js');
 require('./relations.js');
 var Inclusion = require('./include.js');
 var Relation = require('./relations.js');
@@ -376,17 +375,31 @@ DataAccessObject._coerce = function (where) {
             continue;
         }
         if (Array.isArray(DataType) || DataType === Array) {
-            DataType = List;
-        } else if (DataType.name === 'Date') {
+            DataType = DataType[0];
+        }
+        if (DataType === Date) {
             var OrigDate = Date;
             DataType = function Date(arg) {
                 return new OrigDate(arg);
             };
+        } else if (DataType === Boolean) {
+          DataType = function(val) {
+            if(val === 'true') {
+              return true;
+            } else if(val === 'false') {
+              return false;
+            } else {
+              return Boolean(val);
+            }
+          };
+        }
+        if (!DataType) {
+          continue;
         }
         var val = where[p];
         // Check there is an operator
         var operator = null;
-        if ('object' === typeof val) {
+        if ('object' === typeof val && Object.keys(val).length === 1) {
             for (var op in operators) {
                 if (op in val) {
                     val = val[op];

--- a/test/loopback-dl.test.js
+++ b/test/loopback-dl.test.js
@@ -573,15 +573,27 @@ describe('Load models with relations', function () {
 });
 
 describe('DataAccessObject', function () {
-  it('should be able to coerce where clause based on the types', function () {
-    var ds = new DataSource('memory');
-    var model = ds.createModel('M1', {
-      id: {type: String, id: true},
-      age: Number
-    });
-    var where = model._coerce({id: 1});
-    assert.deepEqual(where, {id: '1'});
+  var ds, model, where;
 
+  before(function () {
+    ds = new DataSource('memory');
+    model = ds.createModel('M1', {
+      id: {type: String, id: true},
+      age: Number,
+      vip: Boolean,
+      date: Date,
+      scores: [Number]
+    });
+  });
+
+  it('should be able to coerce where clause for string types', function () {
+    where = model._coerce({id: 1});
+    assert.deepEqual(where, {id: '1'});
+    where = model._coerce({id: '1'});
+    assert.deepEqual(where, {id: '1'});
+  });
+
+  it('should be able to coerce where clause for number types', function () {
     where = model._coerce({age: '10'});
     assert.deepEqual(where, {age: 10});
 
@@ -596,6 +608,44 @@ describe('DataAccessObject', function () {
 
     where = model._coerce({age: {between: ['10', '20']}});
     assert.deepEqual(where, {age: {between: [10, 20]}});
+  });
+
+  it('should be able to coerce where clause for array types', function () {
+    where = model._coerce({scores: ['10', '20']});
+    assert.deepEqual(where, {scores: [10, 20]});
+  });
+
+  it('should be able to coerce where clause for date types', function () {
+    var d = new Date();
+    where = model._coerce({date: d});
+    assert.deepEqual(where, {date: d});
+
+    where = model._coerce({date: d.toISOString()});
+    assert.deepEqual(where, {date: d});
+  });
+
+  it('should be able to coerce where clause for boolean types', function () {
+    where = model._coerce({vip: 'true'});
+    assert.deepEqual(where, {vip: true});
+
+    where = model._coerce({vip: true});
+    assert.deepEqual(where, {vip: true});
+
+    where = model._coerce({vip: 'false'});
+    assert.deepEqual(where, {vip: false});
+
+    where = model._coerce({vip: false});
+    assert.deepEqual(where, {vip: false});
+
+    where = model._coerce({vip: '1'});
+    assert.deepEqual(where, {vip: true});
+
+    where = model._coerce({vip: 0});
+    assert.deepEqual(where, {vip: false});
+
+    where = model._coerce({vip: ''});
+    assert.deepEqual(where, {vip: false});
+
   });
 });
 


### PR DESCRIPTION
filter.where from HTTP query strings are coerced based on the format matching. For example, 
filter[where][a]=1 is parsed as {filter: {where: {a: 1}} no matter what type for property 'a' is.

Please see the discussion at:
https://groups.google.com/forum/#!topic/loopbackjs/0EX2T-CxVlU
