### PR TITLE
Fill ModelClass.http.path

### DIFF
--- a/lib/model-builder.js
+++ b/lib/model-builder.js
@@ -109,7 +109,8 @@ ModelBuilder.prototype.getModelDefinition = function(name) {
 ModelBuilder.prototype.define = function defineClass(className, properties, settings, parent) {
     var modelBuilder = this;
     var args = slice.call(arguments);
-    var pluralName = settings && settings.plural;
+    var pluralName = (settings && settings.plural) ||
+                        inflection.pluralize(className);
 
     if (!className) {
         throw new Error('Class name required');
@@ -186,8 +187,9 @@ ModelBuilder.prototype.define = function defineClass(className, properties, sett
     // Add metadata to the ModelClass
     hiddenProperty(ModelClass, 'modelBuilder', modelBuilder);
     hiddenProperty(ModelClass, 'dataSource', modelBuilder); // Keep for back-compatibility
-    hiddenProperty(ModelClass, 'pluralModelName', pluralName || inflection.pluralize(className));
+    hiddenProperty(ModelClass, 'pluralModelName', pluralName);
     hiddenProperty(ModelClass, 'relations', {});
+    hiddenProperty(ModelClass, 'http', { path: '/' + pluralName });
 
     // inherit ModelBaseClass static methods
     for (var i in ModelBaseClass) {


### PR DESCRIPTION
Set the HTTP route to `'/' + pluralModelName` so that we don't have to duplicate this bit of logic in strong-remoting and other places.

Related to strongloop/strong-remoting#37.

/to: @ritch or @raymondfeng please review
