### PR TITLE
Fix, model builder setter will not try to cast value if already the proper type

### DIFF
--- a/lib/model-builder.js
+++ b/lib/model-builder.js
@@ -380,7 +380,7 @@ ModelBuilder.prototype.define = function defineClass(className, properties, sett
             } else {
               // Assume the type constructor handles Constructor() call
               // If not, we should call new DataType(value).valueOf();
-              this.__data[propertyName] = DataType(value);
+              this.__data[propertyName] = (value instanceof DataType) ? value : DataType(value);
             }
           }
         }


### PR DESCRIPTION
Data source juggler can deal with many different type of data, coming from datasource connectors.

In the model definition, each property can be defined with its type, which , in the end, will drive the behavior of the default setter.

When a value is back from the connector source, it will be casted to this type, to keep model typing correct.

This fix adds a check on that value in case the returned value is already of the property type. In this case, it will just pass the value as is.

This avoid errors to be thrown by type constructors that cannot convert themselves.
