### PR TITLE
Fix remoting for IDs in URLs

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -298,7 +298,8 @@ DataAccessObject.exists = function exists(id, cb) {
 // exists ~ remoting attributes
 setRemoting(DataAccessObject.exists, {
   description: 'Check whether a model instance exists in the data source',
-  accepts: {arg: 'id', type: 'any', description: 'Model id', required: true},
+  accepts: {arg: 'id', type: 'any', description: 'Model id', required: true,
+            http: {source: 'path'}},
   returns: {arg: 'exists', type: 'any'},
   http: {verb: 'get', path: '/:id/exists'}
 });
@@ -328,7 +329,8 @@ DataAccessObject.findById = function find(id, cb) {
 // find ~ remoting attributes
 setRemoting(DataAccessObject.findById, {
   description: 'Find a model instance by id from the data source',
-  accepts: {arg: 'id', type: 'any', description: 'Model id', required: true},
+  accepts: {arg: 'id', type: 'any', description: 'Model id', required: true,
+            http: {source: 'path'}},
   returns: {arg: 'data', type: 'any', root: true},
   http: {verb: 'get', path: '/:id'},
   rest: {after: convertNullToNotFoundError}
@@ -674,7 +676,8 @@ DataAccessObject.removeById =
 // deleteById ~ remoting attributes
 setRemoting(DataAccessObject.deleteById, {
   description: 'Delete a model instance by id from the data source',
-  accepts: {arg: 'id', type: 'any', description: 'Model id', required: true},
+  accepts: {arg: 'id', type: 'any', description: 'Model id', required: true,
+            http: {source: 'path'}},
   http: {verb: 'del', path: '/:id'}
 });
 


### PR DESCRIPTION
/to @raymondfeng 

This adds more specific argument metadata for id params.

Strong remoting servers will parse the url for the attribute, but this is required for clients to create the correct URL.
