### PR TITLE
validations: support multi-key unique constraint

### DIFF
--- a/lib/validations.js
+++ b/lib/validations.js
@@ -197,9 +197,19 @@ Validatable.validateAsync = getConfigurator('custom', {async: true});
  *  - Oracle
  *  - MongoDB
  *
+ * ```
+ * // The login must be unique across all User instances.
+ * User.validatesUniquenessOf('login');
+ *
+ * // Assuming SiteUser.belongsTo(Site)
+ * // The login must be unique within each Site.
+ * SiteUser.validateUniquenessOf('login', { scopedTo: ['siteId'] });
+ * ```
+
  * @param {String} propertyName  Property name to validate.
  * @options {Object} Options 
  * @property {RegExp} with Regular expression to validate format.
+ * @property {Array.<String>} scopedTo List of properties defining the scope.
  * @property {String} message Optional error message if property is not valid.  Default error message: "is not unique".
  */
 Validatable.validatesUniquenessOf = getConfigurator('uniqueness', {async: true});
@@ -297,6 +307,15 @@ function validateCustom(attr, conf, err, done) {
 function validateUniqueness(attr, conf, err, done) {
   var cond = {where: {}};
   cond.where[attr] = this[attr];
+
+  if (conf && conf.scopedTo) {
+    conf.scopedTo.forEach(function(k) {
+      var val = this[k];
+      if (val !== undefined)
+        cond.where[k] = this[k];
+    }, this);
+  }
+
   this.constructor.find(cond, function (error, found) {
     if (error) {
       return err();


### PR DESCRIPTION
Modify the "unique" validator to accept additional property names to
narrow the space of rows searched for duplicates.

Example:

Consider `SiteUser` belongsTo `Site` via `siteId` foreign key.
Inside every site, the user email must be unique. It is allowed to
register the same email with multiple sites.

```
SiteUser.validateUniquenessOf('email', { scopedTo: ['siteId'] });
```

/to @raymondfeng or @ritch please review.

This feature will be very useful for loopback-workspace to implement validations like "the model name must be unique within a project". At the moment, we have "the model name must be unique", which does not work when there was more than one project loaded during the app life.
