### PR TITLE
validations: include more details in `err.message`

### DIFF
--- a/lib/validations.js
+++ b/lib/validations.js
@@ -687,12 +687,18 @@ function ValidationError(obj) {
   if (!(this instanceof ValidationError)) return new ValidationError(obj);
 
   this.name = 'ValidationError';
-  this.message = 'The Model instance is not valid. ' +
-    'See `details` property of the error object for more info.';
+
+  var context = obj && obj.constructor && obj.constructor.modelName;
+  this.message = util.format(
+    'The %s instance is not valid. Details: %s.',
+      context ? '`' + context + '`' : 'model',
+      formatErrors(obj.errors) || '(unknown)'
+  );
+
   this.statusCode = 422;
 
   this.details = {
-    context: obj && obj.constructor && obj.constructor.modelName,
+    context: context,
     codes: obj.errors && obj.errors.codes,
     messages: obj.errors
   };
@@ -701,3 +707,19 @@ function ValidationError(obj) {
 }
 
 util.inherits(ValidationError, Error);
+
+function formatErrors(errors) {
+  var DELIM = '; ';
+  errors = errors || {};
+  return Object.getOwnPropertyNames(errors)
+    .filter(function(propertyName) {
+      return Array.isArray(errors[propertyName]);
+    })
+    .map(function(propertyName) {
+      var messages = errors[propertyName];
+      return messages.map(function(msg) {
+        return '`' + propertyName + '` ' + msg;
+      }).join(DELIM);
+    })
+    .join(DELIM);
+}

--- a/test/validations.test.js
+++ b/test/validations.test.js
@@ -111,6 +111,25 @@ describe('validations', function () {
         done();
       });
 
+      it('should include validation messages in err.message', function(done) {
+        delete User._validations;
+        User.validatesPresenceOf('name');
+        User.create(function (e, u) {
+          should.exist(e);
+          e.message.should.match(/`name` can't be blank/);
+          done();
+        });
+      });
+
+      it('should include model name in err.message', function(done) {
+        delete User._validations;
+        User.validatesPresenceOf('name');
+        User.create(function (e, u) {
+          should.exist(e);
+          e.message.should.match(/`User` instance/i);
+          done();
+        });
+      });
     });
   });
 


### PR DESCRIPTION
Modify ValidationError constructor to include the model name and
a human-readable representation of the validation errors (messages)
in the error message.

Before this change, the message was pointing the reader
to `err.details`.  Most frameworks (e.g. express, mocha) log only
`err.message` but not other error properties, thus the logs were
rather unhelpful.

Example of the new error message:

```
The `User` instance is not valid. Details: `name` can't be blank.
```

/to @ritch or @raymondfeng please review
