### PR TITLE
Keep undefined values for the array type

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -134,8 +134,9 @@ ModelBaseClass.prototype._initProperties = function (data, options) {
     }
   }
 
+  var propertyName;
   if (applySetters === true) {
-    for (var propertyName in data) {
+    for (propertyName in data) {
       if (typeof data[propertyName] !== 'function' && ((propertyName in properties) || (propertyName in ctor.relations))) {
         self[propertyName] = self.__data[propertyName] || data[propertyName];
       }
@@ -144,7 +145,7 @@ ModelBaseClass.prototype._initProperties = function (data, options) {
 
   // Set the unknown properties as properties to the object
   if (strict === false) {
-    for (var propertyName in data) {
+    for (propertyName in data) {
       if (typeof data[propertyName] !== 'function' && !(propertyName in properties)) {
         self[propertyName] = self.__data[propertyName] || data[propertyName];
       }
@@ -174,8 +175,10 @@ ModelBaseClass.prototype._initProperties = function (data, options) {
         }
       }
       if (type.name === 'Array' || Array.isArray(type)) {
-        if (!(self.__data[propertyName] instanceof List)) {
-          self.__data[propertyName] = new List(self.__data[propertyName], type, self);
+        if (!(self.__data[propertyName] instanceof List)
+          && self.__data[propertyName] !== undefined
+          && self.__data[propertyName] !== null ) {
+          self.__data[propertyName] = List(self.__data[propertyName], type, self);
         }
       }
     }

--- a/test/loopback-dl.test.js
+++ b/test/loopback-dl.test.js
@@ -582,7 +582,8 @@ describe('Models attached to a dataSource', function() {
     var ds = new DataSource('memory');// define models
     Post = ds.define('Post', {
       title: { type: String, length: 255, index: true },
-      content: { type: String }
+      content: { type: String },
+      comments: [String]
     });
   });
 
@@ -613,9 +614,10 @@ describe('Models attached to a dataSource', function() {
   });
 
   it('updateOrCreate should update the instance without removing existing properties', function (done) {
-    Post.create({title: 'a', content: 'AAA'}, function (err, post) {
+    Post.create({title: 'a', content: 'AAA', comments: ['Comment1']}, function (err, post) {
       post = post.toObject();
       delete post.title;
+      delete post.comments;
       Post.updateOrCreate(post, function (err, p) {
         should.not.exist(err);
         p.id.should.be.equal(post.id);
@@ -627,7 +629,8 @@ describe('Models attached to a dataSource', function() {
           should.not.exist(p._id);
           p.content.should.be.equal(post.content);
           p.title.should.be.equal('a');
-
+          p.comments.length.should.be.equal(1);
+          p.comments[0].should.be.equal('Comment1');
           done();
         });
       });


### PR DESCRIPTION
/to @ritch 

This PR makes sure mongodb update doesn't override existing array values. Before the fix, we always set an empty array as the default value. As a consequence, the MongoDB driver will replace existing array properties with an empty array. The issue was reported by node-advisor.
