### PR TITLE
Validate upserts

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -221,11 +221,17 @@ function stillConnecting(dataSource, obj, args) {
  * `updateOrCreate` is an alias
  * @param {Object} data The model instance data
  * @param {Function} callback The callback function (optional).
+ * @options {Object} options Optional options to use.
+ * @property {Boolean} validate Default is true.
+ * @property {Boolean} throws  Default is false.
  */
-DataAccessObject.upsert = DataAccessObject.updateOrCreate = function upsert(data, callback) {
+DataAccessObject.upsert = DataAccessObject.updateOrCreate = function upsert(data, callback, options) {
   if (stillConnecting(this.getDataSource(), this, arguments)) {
     return;
   }
+
+  var that = this;
+  options = options || {};
 
   var Model = this;
   if (!getIdValue(this, data)) {
@@ -237,21 +243,41 @@ DataAccessObject.upsert = DataAccessObject.updateOrCreate = function upsert(data
     if(!(data instanceof Model)) {
       inst = new Model(data);
     }
-    update = inst.toObject(false);
-    update = removeUndefined(update);
-    this.getDataSource().connector.updateOrCreate(Model.modelName, update, function (err, data) {
-      var obj;
-      if (data && !(data instanceof Model)) {
-        inst._initProperties(data);
-        obj = inst;
+
+    if (options.validate === false) {
+      return save();
+    }
+
+    inst.isValid(function (valid) {
+      if (valid) {
+        save();
       } else {
-        obj = data;
-      }
-      callback(err, obj);
-      if(!err) {
-        Model.emit('changed', inst);
+        var err = new ValidationError(inst);
+        // throws option is dangerous for async usage
+        if (options.throws) {
+          throw err;
+        }
+        callback(err, inst);
       }
     });
+
+    function save() {
+      update = inst.toObject(false);
+      update = removeUndefined(update);
+      that.getDataSource().connector.updateOrCreate(Model.modelName, update, function (err, data) {
+        var obj;
+        if (data && !(data instanceof Model)) {
+          inst._initProperties(data);
+          obj = inst;
+        } else {
+          obj = data;
+        }
+        callback(err, obj);
+        if(!err) {
+          Model.emit('changed', inst);
+        }
+      });
+    }
   } else {
     this.findById(getIdValue(this, data), function (err, inst) {
       if (err) {


### PR DESCRIPTION
Previously, during an upsert, if the underlying connector had an `updateOrCreate` method, `isValid` would not be called.

This is a good one to view with [w=1](https://github.com/strongloop/loopback-datasource-juggler/pull/134/files?w=1)

Fix #262