### PR TITLE
ConvertNulltoNotFoundError when calling DataAccessObject.findOne via rest

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -78,7 +78,7 @@ DataAccessObject._forDB = function (data) {
  * });
  * ```
  * Note: You must include a callback and use the created model provided in the callback if your code depends on your model being
- * saved or having an ID.  
+ * saved or having an ID.
  *
  * @param {Object} data  Optional data object
  * @param {Function} callback  Callback function called with these arguments:
@@ -216,7 +216,7 @@ function stillConnecting(dataSource, obj, args) {
 /**
  * Update or insert a model instance: update exiting record if one is found, such that parameter `data.id` matches `id` of model instance;
  * otherwise, insert a new record.
- * 
+ *
  * NOTE: No setters, validations, or hooks are applied when using upsert.
  * `updateOrCreate` is an alias
  * @param {Object} data The model instance data
@@ -333,7 +333,7 @@ setRemoting(DataAccessObject.exists, {
 
 /**
  * Find model instance by ID.
- * 
+ *
  * Example:
  * ```js
  * User.findById(23, function(err, user) {
@@ -571,7 +571,7 @@ DataAccessObject._coerce = function (where) {
  * Find all instances of Model that match the specified query.
  * Fields used for filter and sort should be declared with `{index: true}` in model definition.
  * See [Querying models](http://docs.strongloop.com/display/DOC/Querying+models) for more information.
- * 
+ *
  * For example, find the second page of ten users over age 21 in descending order exluding the password property.
  *
  * ```js
@@ -588,7 +588,7 @@ DataAccessObject._coerce = function (where) {
  * ```
  *
  * @options {Object} [query] Optional JSON object that specifies query criteria and parameters.
- * @property {Object} where Search criteria in JSON format `{ key: val, key2: {gt: 'val2'}}`.  
+ * @property {Object} where Search criteria in JSON format `{ key: val, key2: {gt: 'val2'}}`.
  * Operations:
  * - gt: >
  * - gte: >=
@@ -600,7 +600,7 @@ DataAccessObject._coerce = function (where) {
  * - neq: !=
  * - like: LIKE
  * - nlike: NOT LIKE
- * 
+ *
  * You can also use `and` and `or` operations.  See [Querying models](http://docs.strongloop.com/display/DOC/Querying+models) for more information.
  * @property {String|Object|Array} include Allows you to load relations of several objects and optimize numbers of requests.
  * Format examples;
@@ -619,7 +619,7 @@ DataAccessObject._coerce = function (where) {
  *  - `['foo', 'bar']` - include the foo and bar properties.  Format:
  *  - `{foo: true}` - include only foo
  * - `{bat: false}` - include all properties, exclude bat
- * 
+ *
  * @param {Function} callback Required callback function.  Call this function with two arguments: `err` (null or Error) and an array of instances.
  */
 
@@ -767,7 +767,8 @@ setRemoting(DataAccessObject.findOne, {
   description: 'Find first instance of the model matched by filter from the data source',
   accepts: {arg: 'filter', type: 'object', description: 'Filter defining fields, where, orderBy, offset, and limit'},
   returns: {arg: 'data', type: 'object', root: true},
-  http: {verb: 'get', path: '/findOne'}
+  http: {verb: 'get', path: '/findOne'},
+  rest: {after: convertNullToNotFoundError}
 });
 
 /**
@@ -779,7 +780,7 @@ setRemoting(DataAccessObject.findOne, {
    // removed matching products
  * });
  * ````
- * 
+ *
  * @param {Object} [where] Optional object that defines the criteria.  This is a "where" object. Do NOT pass a filter object.
  * @param {Function} [cb] Callback called with (err)
  */
@@ -814,7 +815,7 @@ DataAccessObject.remove = DataAccessObject.deleteAll = DataAccessObject.destroyA
     };
 
 /**
- * Delete the record with the specified ID. 
+ * Delete the record with the specified ID.
  * Aliases are `destroyById` and `deleteById`.
  * @param {*} id The id value
  * @param {Function} cb Callback called with (err)
@@ -843,7 +844,7 @@ setRemoting(DataAccessObject.deleteById, {
 /**
  * Return count of matched records. Optional query parameter allows you to count filtered set of model instances.
  * Example:
- * 
+ *
  *```js
  * User.count({approved: true}, function(err, count) {
  *     console.log(count); // 2081


### PR DESCRIPTION
When we call the url `http://localhost:3000/api/cars/1` with an invalid id we get a 404 error:

``` javascript
{
error: {
name: "Error",
status: 404,
message: "Unknown "cars" id "1".",
statusCode: 404,
stack: "Error: Unknown "cars" id 1". at Function...
} 
} 
```

But, when we try to use filters, such as `http://localhost:3000/api/cars/findOne?filter%5Bwhere%5D%5Bid%5D=1`, we have another behavior:

``` javascript
null
```

This PR follows the same approach found in: https://github.com/strongloop/loopback-datasource-juggler/blob/master/lib/dao.js#L364-L371
