### PR TITLE
[2.0] validations: support non-V8 browsers

### DIFF
--- a/lib/validations.js
+++ b/lib/validations.js
@@ -703,10 +703,20 @@ function ValidationError(obj) {
     messages: obj.errors
   };
 
-  Error.captureStackTrace(this, this.constructor);
+  if (Error.captureStackTrace) {
+    // V8 (Chrome, Opera, Node)
+    Error.captureStackTrace(this, this.constructor);
+  } else if (errorHasStackProperty) {
+    // Firefox
+    this.stack = (new Error).stack;
+  }
+  // Safari and PhantomJS initializes `error.stack` on throw
+  // Internet Explorer does not support `error.stack`
 }
 
 util.inherits(ValidationError, Error);
+
+var errorHasStackProperty = !!(new Error).stack;
 
 function formatErrors(errors) {
   var DELIM = '; ';


### PR DESCRIPTION
Call `Error.captureStackTrace()` only when it is available.

Use `this.stack = (new Error).stack` when `captureStackTrace` is not
available but the `stack` property is (Firefox).

/to @ritch please review.
