### PR TITLE
Allow to set collect key from relation definition.

### DIFF
--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -356,7 +356,7 @@ RelationDefinition.hasMany = function hasMany(modelFrom, modelTo, params) {
     filter.where = {};
     filter.where[fk] = this[idName];
     if (params.through) {
-      filter.collect = i8n.camelize(modelTo.modelName, true);
+      filter.collect = params.collect || i8n.camelize(modelTo.modelName, true);
       filter.include = filter.collect;
     }
     return filter;


### PR DESCRIPTION
This is needed when declaring a relation hasManyThrough from and to the same classe.

Exemple: 
2 class Profile and Follow

Follow have 2 columns: followingId, followeeId

```
app.models.profile.hasMany(app.models.profile, {
   through: app.models.follow,
   as: 'followers',
   foreignKey: 'followerId',
   collect: 'follower'
});

app.models.profile.hasMany(app.models.profile, {
    through: app.models.follow,
    as: 'followees',
    foreignKey: 'followeeId',
    collect: 'followee'
});
```
