### PR TITLE
Pass callback to hooks so that next can be skipped

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -178,8 +178,8 @@ DataAccessObject.create = function (data, callback) {
             });
           });
         }, obj);
-      }, obj);
-    }, obj);
+      }, obj, callback);
+    }, obj, callback);
   }
 
   // for chaining
@@ -1032,8 +1032,8 @@ DataAccessObject.prototype.save = function (options, callback) {
             });
           });
         });
-      }, data);
-    }, data);
+      }, data, callback);
+    }, data, callback);
   }
 };
 
@@ -1136,7 +1136,7 @@ DataAccessObject.prototype.remove =
             Model.emit('deleted', id);
           });
         }.bind(this));
-      });
+      }, null, cb);
     };
 
 /**
@@ -1198,7 +1198,8 @@ DataAccessObject.prototype.updateAttributes = function updateAttributes(data, cb
             typedData[key] = inst[key];
           }
 
-          inst._adapter().updateAttributes(model, getIdValue(inst.constructor, inst), inst.constructor._forDB(typedData), function (err) {
+          inst._adapter().updateAttributes(model, getIdValue(inst.constructor, inst),
+            inst.constructor._forDB(typedData), function (err) {
             done.call(inst, function () {
               saveDone.call(inst, function () {
                 if(cb) cb(err, inst);
@@ -1206,8 +1207,8 @@ DataAccessObject.prototype.updateAttributes = function updateAttributes(data, cb
               });
             });
           });
-        }, data);
-      }, data);
+        }, data, cb);
+      }, data, cb);
     }
   }, data);
 };

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -27,7 +27,7 @@ Hookable.beforeDestroy = null;
 Hookable.afterDestroy = null;
 
 // TODO: Evaluate https://github.com/bnoguchi/hooks-js/
-Hookable.prototype.trigger = function trigger(actionName, work, data) {
+Hookable.prototype.trigger = function trigger(actionName, work, data, callback) {
   var capitalizedName = capitalize(actionName);
   var beforeHook = this.constructor["before" + capitalizedName]
     || this.constructor["pre" + capitalizedName];
@@ -42,8 +42,13 @@ Hookable.prototype.trigger = function trigger(actionName, work, data) {
   // we only call "before" hook when we have actual action (work) to perform
   if (work) {
     if (beforeHook) {
-      // before hook should be called on instance with one param: callback
+      // before hook should be called on instance with two parameters: next and data
       beforeHook.call(inst, function () {
+        // Check arguments to next(err, result)
+        if (arguments.length) {
+          return callback && callback.apply(null, arguments);
+        }
+        // No err & result is present, proceed with the real work
         // actual action also have one param: callback
         work.call(inst, next);
       }, data);

--- a/lib/validations.js
+++ b/lib/validations.js
@@ -389,7 +389,7 @@ Validatable.prototype.isValid = function (callback, data) {
         validationsDone.call(inst, function () {
           callback(valid);
         });
-      });
+      }, data, callback);
     }
     return valid;
   }
@@ -440,7 +440,7 @@ Validatable.prototype.isValid = function (callback, data) {
       }
     }
 
-  }, data);
+  }, data, callback);
 
   if (async) {
     // in case of async validation we should return undefined here,


### PR DESCRIPTION
/to @bajtos 
/cc @ritch 

See https://groups.google.com/forum/#!topic/loopbackjs/8zcmbxBjYeM

The PR passes the callback func to hooks, for example:

``` js
User.beforeCreate = function(next, data, cb) {
// skip next();
cb('Error: invalid email');
};
```
