### PR TITLE
Allows default model class to be configured

### DIFF
--- a/lib/model-builder.js
+++ b/lib/model-builder.js
@@ -37,6 +37,7 @@ function ModelBuilder() {
   // create blank models pool
   this.models = {};
   this.definitions = {};
+  this.defaultModelBaseClass = DefaultModelBaseClass;
 }
 
 // Inherit from EventEmitter
@@ -131,7 +132,7 @@ ModelBuilder.prototype.define = function defineClass(className, properties, sett
   }
 
   // Set up the base model class
-  var ModelBaseClass = parent || DefaultModelBaseClass;
+  var ModelBaseClass = parent || this.defaultModelBaseClass;
   var baseClass = settings.base || settings['super'];
   if (baseClass) {
     if (isModelClass(baseClass)) {

--- a/test/loopback-dl.test.js
+++ b/test/loopback-dl.test.js
@@ -1285,6 +1285,39 @@ describe('Load models from json', function () {
     }
   });
 
+  it('should allow customization of default model base class', function () {
+    var modelBuilder = new ModelBuilder();
+
+    var User = modelBuilder.define('User', {
+      name: String,
+      bio: ModelBuilder.Text,
+      approved: Boolean,
+      joinedAt: Date,
+      age: Number
+    });
+
+    modelBuilder.defaultModelBaseClass = User;
+
+    var Customer = modelBuilder.define('Customer', {customerId: {type: String, id: true}});
+    assert(Customer.prototype instanceof User);
+  });
+
+  it('should allow model base class', function () {
+    var modelBuilder = new ModelBuilder();
+
+    var User = modelBuilder.define('User', {
+      name: String,
+      bio: ModelBuilder.Text,
+      approved: Boolean,
+      joinedAt: Date,
+      age: Number
+    });
+
+    var Customer = modelBuilder.define('Customer',
+      {customerId: {type: String, id: true}}, {}, User);
+    assert(Customer.prototype instanceof User);
+  });
+
   it('should be able to extend models', function (done) {
     var modelBuilder = new ModelBuilder();
 


### PR DESCRIPTION
The PR introduces defaultModelBaseClass to ModelBuilder.prototype. It will allow each instance of ModelBuilder to have a default model base class configured. For example, loopback can configure it to use Model.

/to @bajtos 
/cc @fabien
