### PR TITLE
Expose base model class as `base` property

### DIFF
--- a/lib/model-builder.js
+++ b/lib/model-builder.js
@@ -186,6 +186,7 @@ ModelBuilder.prototype.define = function defineClass(className, properties, sett
   hiddenProperty(ModelClass, 'pluralModelName', pluralName);
   hiddenProperty(ModelClass, 'relations', {});
   hiddenProperty(ModelClass, 'http', { path: '/' + pluralName });
+  hiddenProperty(ModelClass, 'base', ModelBaseClass);
 
   // inherit ModelBaseClass static methods
   for (var i in ModelBaseClass) {

--- a/test/loopback-dl.test.js
+++ b/test/loopback-dl.test.js
@@ -552,7 +552,7 @@ describe('DataSource define model', function () {
 });
 
 describe('Load models with base', function () {
-  it('should set up base class', function (done) {
+  it('should set up base class via base option', function () {
     var ds = new ModelBuilder();
 
     var User = ds.define('User', {name: String});
@@ -567,14 +567,33 @@ describe('Load models with base', function () {
     assert(Customer.prototype instanceof User);
     assert(Customer.staticMethod === User.staticMethod);
     assert(Customer.prototype.instanceMethod === User.prototype.instanceMethod);
+    assert.equal(Customer.base, User);
+    assert.equal(Customer.base, Customer.super_);
 
     try {
       var Customer1 = ds.define('Customer1', {vip: Boolean}, {base: 'User1'});
     } catch (e) {
       assert(e);
     }
+  });
 
-    done();
+  it('should set up base class via parent arg', function () {
+    var ds = new ModelBuilder();
+
+    var User = ds.define('User', {name: String});
+
+    User.staticMethod = function staticMethod() {
+    };
+    User.prototype.instanceMethod = function instanceMethod() {
+    };
+
+    var Customer = ds.define('Customer', {vip: Boolean}, {}, User);
+
+    assert(Customer.prototype instanceof User);
+    assert(Customer.staticMethod === User.staticMethod);
+    assert(Customer.prototype.instanceMethod === User.prototype.instanceMethod);
+    assert.equal(Customer.base, User);
+    assert.equal(Customer.base, Customer.super_);
   });
 });
 


### PR DESCRIPTION
/to @bajtos 

This PR exposes the model base class as the `base` property. (I end up using `base` instead of `Base` to be consistent with other meta properties)
