### PR TITLE
Fix scoped destroyAll: only use 'where', not full 'filter' args

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -221,7 +221,8 @@ function defineScope(cls, targetClass, name, params, methods) {
    - If fetching the Elements on which destroyAll is called results in an error
    */
   function destroyAll(cb) {
-    targetClass.destroyAll(this._scope, cb);
+    var where = (this._scope && this._scope.where) || {};
+    targetClass.destroyAll(where, cb);
   }
 }
 

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -437,7 +437,7 @@ describe('relations', function () {
       });
     });
     
-    it('should find record on scope', function (done) {
+    it('should find records on scope', function (done) {
       Category.findOne(function (err, c) {
         c.products(function(err, products) {
           products.should.have.length(2);
@@ -476,6 +476,15 @@ describe('relations', function () {
       });
     });
     
+    it('should find records on scope', function (done) {
+      Category.findOne(function (err, c) {
+        c.products(function(err, products) {
+          products.should.have.length(3);
+          done();
+        });
+      });
+    });
+    
     it('should find record on scope - scoped', function (done) {
       Category.findOne(function (err, c) {
         c.productType = 'book'; // temporary, for scoping
@@ -493,6 +502,24 @@ describe('relations', function () {
         c.products(function(err, products) {
           products.should.have.length(1);
           products[0].type.should.equal('tool');
+          done();
+        });
+      });
+    });
+    
+    it('should delete records on scope - scoped', function (done) {
+      Category.findOne(function (err, c) {
+        c.productType = 'tool'; // temporary, for scoping
+        c.products.destroyAll(function(err, result) {
+          done();
+        });
+      });
+    });
+    
+    it('should find record on scope - verify', function (done) {
+      Category.findOne(function (err, c) {
+        c.products(function(err, products) {
+          products.should.have.length(2);
           done();
         });
       });


### PR DESCRIPTION
The tests actually check for this fix as well (I discovered this bug with a custom scope that specified order); the MongoDB connector subsequently tried to cast the full filter object to native operators (prefixed with $) and threw an exception.
