### PR TITLE
relation: add `scope._target` for `hasOne` (1.x, 2.x)

### DIFF
--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -1103,6 +1103,7 @@ RelationDefinition.hasOne = function (modelFrom, modelTo, params) {
       var relationMethod = relation.related.bind(relation)
       relationMethod.create = relation.create.bind(relation);
       relationMethod.build = relation.build.bind(relation);
+      relationMethod._targetClass = relationDef.modelTo.modelName;
       return relationMethod;
     }
   });

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -592,6 +592,9 @@ describe('relations', function () {
       });
     });
 
+    it('should set targetClass on scope property', function() {
+      should.equal(Supplier.prototype.account._targetClass, 'Account');
+    });
   });
 
   describe('hasAndBelongsToMany', function () {


### PR DESCRIPTION
Add `_target` property to the scope method created by `hasOne`
relationship. The `_target` property is used by loopback-sdk-angular.

/to @raymondfeng please review
/cc @ritch 
