### PR TITLE
datasource: support connectors without `getTypes`

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -647,7 +647,8 @@ DataSource.prototype.getModelDefinition = function (name) {
  * ['rest'], or ['db', 'rdbms', 'mysql']
  */
 DataSource.prototype.getTypes = function () {
-  var types = this.connector && this.connector.getTypes() || [];
+  var getTypes = this.connector && this.connector.getTypes;
+  var types = getTypes && getTypes() || [];
   if (typeof types === 'string') {
     types = types.split(/[\s,\/]+/);
   }


### PR DESCRIPTION
Asking connectors to provide `getTypes` function is a breaking change, connectors working with loopback 1.3 no longer work in newer versions.

The bug does not occur in loopback version prior to 643293 (v2.0.0) as long as `dataSource.getTypes` was not called, which explains why nobody noticed this problem for so long. As of 643293, `dataSource.getTypes` is called from `registry.createDataSource` and the process crashes.

I have discovered this issue in loopback-component-storage, loopback-component-push seems to be affected too. While it is certainly possible to fix this problem in those two connectors, there are other (community maintained) connectors vulnerable to this issue too. Therefore I'd rather have the issue fixed in the juggler first.

/to @raymondfeng 
