### PR TITLE
Implement scope.defineMethod/relation.defineMethod

### DIFF
--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -63,12 +63,15 @@ function extendScopeMethods(definition, scopeMethods, ext) {
   if (typeof ext === 'function') {
     customMethods = ext.call(definition, scopeMethods, relationClass);
   } else if (typeof ext === 'object') {
-    for (var key in ext) {
-      var relationMethod = ext[key];
-      var method = scopeMethods[key] = function () {
+    function createFunc(definition, relationMethod) {
+      return function() {
         var relation = new relationClass(definition, this);
         return relationMethod.apply(relation, arguments);
       };
+    };
+    for (var key in ext) {
+      var relationMethod = ext[key];
+      var method = scopeMethods[key] = createFunc(definition, relationMethod);
       if (relationMethod.shared) {
         sharedMethod(definition, key, method, relationMethod);
       }
@@ -126,6 +129,29 @@ RelationDefinition.prototype.toJSON = function () {
     json.keyThrough = this.keyThrough;
   }
   return json;
+};
+
+/**
+ * Define a relation scope method
+ * @param {String} name of the method
+ * @param {Function} function to define
+ */
+RelationDefinition.prototype.defineMethod = function(name, fn) {
+  var relationClass = RelationClasses[this.type];
+  var relationName = this.name;
+  var modelFrom = this.modelFrom;
+  var definition = this;
+  var scope = this.modelFrom.scopes[this.name];
+  if (!scope) throw new Error('Unknown relation scope: ' + this.name);
+  var method = scope.defineMethod(name, function() {
+    var relation = new relationClass(definition, this);
+    return fn.apply(relation, arguments);
+  });
+  if (fn.shared) {
+    sharedMethod(definition, name, method, fn);
+    modelFrom.prototype['__' + name + '__' + relationName] = method;
+  }
+  return method;
 };
 
 /**
@@ -199,6 +225,15 @@ Relation.prototype.resetCache = function (cache) {
 
 Relation.prototype.getCache = function () {
   return this.modelInstance.__cachedRelations[this.definition.name];
+};
+
+/**
+ * Fetch the related model(s) - this is a helper method to unify access.
+ * @param (Boolean|Object} condOrRefresh refresh or conditions object
+ * @param {Function} cb callback
+ */
+Relation.prototype.fetch = function(condOrRefresh, cb) {
+  this.modelInstance[this.definition.name].apply(this.modelInstance, arguments);
 };
 
 /**
@@ -554,7 +589,8 @@ RelationDefinition.hasMany = function hasMany(modelFrom, modelTo, params) {
     
     return filter;
   }, scopeMethods, definition.options);
-
+  
+  return definition;
 };
 
 function scopeMethod(definition, methodName) {
@@ -993,7 +1029,7 @@ RelationDefinition.belongsTo = function (modelFrom, modelTo, params) {
     modelFrom.dataSource.defineForeignKey(modelFrom.modelName, fk, modelTo.modelName);
   }
   
-  var relationDef = modelFrom.relations[relationName] = new RelationDefinition({
+  var definition = modelFrom.relations[relationName] = new RelationDefinition({
     name: relationName,
     type: RelationTypes.belongsTo,
     modelFrom: modelFrom,
@@ -1011,12 +1047,12 @@ RelationDefinition.belongsTo = function (modelFrom, modelTo, params) {
     enumerable: true,
     configurable: true,
     get: function() {
-      var relation = new BelongsTo(relationDef, this);
+      var relation = new BelongsTo(definition, this);
       var relationMethod = relation.related.bind(relation);
       relationMethod.create = relation.create.bind(relation);
       relationMethod.build = relation.build.bind(relation);
-      if (relationDef.modelTo) {  
-        relationMethod._targetClass = relationDef.modelTo.modelName;
+      if (definition.modelTo) {  
+        relationMethod._targetClass = definition.modelTo.modelName;
       }
       return relationMethod;
     }
@@ -1030,6 +1066,8 @@ RelationDefinition.belongsTo = function (modelFrom, modelTo, params) {
     f.apply(this, arguments);
   };
   modelFrom.prototype['__get__' + relationName] = fn;
+  
+  return definition;
 };
 
 BelongsTo.prototype.create = function(targetModelData, cb) {
@@ -1222,8 +1260,7 @@ RelationDefinition.hasAndBelongsToMany = function hasAndBelongsToMany(modelFrom,
   
   params.through.belongsTo(modelTo);
   
-  this.hasMany(modelFrom, modelTo, options);
-
+  return this.hasMany(modelFrom, modelTo, options);
 };
 
 /**
@@ -1268,7 +1305,7 @@ RelationDefinition.hasOne = function (modelFrom, modelTo, params) {
     }
   }
   
-  var relationDef = modelFrom.relations[relationName] = new RelationDefinition({
+  var definition = modelFrom.relations[relationName] = new RelationDefinition({
     name: relationName,
     type: RelationTypes.hasOne,
     modelFrom: modelFrom,
@@ -1287,11 +1324,11 @@ RelationDefinition.hasOne = function (modelFrom, modelTo, params) {
     enumerable: true,
     configurable: true,
     get: function() {
-      var relation = new HasOne(relationDef, this);
+      var relation = new HasOne(definition, this);
       var relationMethod = relation.related.bind(relation)
       relationMethod.create = relation.create.bind(relation);
       relationMethod.build = relation.build.bind(relation);
-      relationMethod._targetClass = relationDef.modelTo.modelName;
+      relationMethod._targetClass = definition.modelTo.modelName;
       return relationMethod;
     }
   });
@@ -1304,6 +1341,8 @@ RelationDefinition.hasOne = function (modelFrom, modelTo, params) {
     f.apply(this, arguments);
   };
   modelFrom.prototype['__get__' + relationName] = fn;
+  
+  return definition;
 };
 
 /**
@@ -1603,6 +1642,8 @@ RelationDefinition.embedsMany = function embedsMany(modelFrom, modelTo, params) 
   }, scopeMethods, definition.options);
 
   scopeDefinition.related = scopeMethods.related;
+  
+  return definition;
 };
 
 EmbedsMany.prototype.related = function(receiver, scopeParams, condOrRefresh, cb) {
@@ -2017,6 +2058,8 @@ RelationDefinition.referencesMany = function referencesMany(modelFrom, modelTo, 
   }, scopeMethods, definition.options);
   
   scopeDefinition.related = scopeMethods.related; // bound to definition
+  
+  return definition;
 };
 
 ReferencesMany.prototype.related = function(receiver, scopeParams, condOrRefresh, cb) {

--- a/lib/relations.js
+++ b/lib/relations.js
@@ -65,7 +65,7 @@ function RelationMixin() {
  * @property {Object} model Model object
  */
 RelationMixin.hasMany = function hasMany(modelTo, params) {
-  RelationDefinition.hasMany(this, modelTo, params);
+  return RelationDefinition.hasMany(this, modelTo, params);
 };
 
 /**
@@ -120,7 +120,7 @@ RelationMixin.hasMany = function hasMany(modelTo, params) {
  * 
  */
 RelationMixin.belongsTo = function (modelTo, params) {
-  RelationDefinition.belongsTo(this, modelTo, params);
+  return RelationDefinition.belongsTo(this, modelTo, params);
 };
 
 /**
@@ -155,17 +155,17 @@ RelationMixin.belongsTo = function (modelTo, params) {
  * @property {Object} model Model object
  */
 RelationMixin.hasAndBelongsToMany = function hasAndBelongsToMany(modelTo, params) {
-  RelationDefinition.hasAndBelongsToMany(this, modelTo, params);
+  return RelationDefinition.hasAndBelongsToMany(this, modelTo, params);
 };
 
 RelationMixin.hasOne = function hasMany(modelTo, params) {
-  RelationDefinition.hasOne(this, modelTo, params);
+  return RelationDefinition.hasOne(this, modelTo, params);
 };
 
 RelationMixin.referencesMany = function hasMany(modelTo, params) {
-  RelationDefinition.referencesMany(this, modelTo, params);
+  return RelationDefinition.referencesMany(this, modelTo, params);
 };
 
 RelationMixin.embedsMany = function hasMany(modelTo, params) {
-  RelationDefinition.embedsMany(this, modelTo, params);
+  return RelationDefinition.embedsMany(this, modelTo, params);
 };

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -56,6 +56,15 @@ ScopeDefinition.prototype.related = function(receiver, scopeParams, condOrRefres
 }
 
 /**
+ * Define a scope method
+ * @param {String} name of the method
+ * @param {Function} function to define
+ */
+ScopeDefinition.prototype.defineMethod = function(name, fn) {
+  return this.methods[name] = fn;
+}
+
+/**
  * Define a scope to the class
  * @param {Model} cls The class where the scope method is added
  * @param {Model} targetClass The class that a query to run against


### PR DESCRIPTION
This allows one to easily add custom scope/relation methods, defined in a mixin for example.

All relation definition methods (hasMany, belongsTo) now return the definition, for further configuration.

Finally, a new relation method `fetch` was introduced to help access the relation's models easily (from a custom method for example - see the tests).
