### PR TITLE
Refactor relations

### DIFF
--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -448,8 +448,8 @@ RelationDefinition.hasMany = function hasMany(modelFrom, modelTo, params) {
   
   var relationName = params.as || i8n.camelize(modelTo.pluralModelName, true);
   var fk = params.foreignKey || i8n.camelize(thisClassName + '_id', true);
-
   var pk = params.primaryKey || modelFrom.dataSource.idName(modelFrom.modelName) || 'id';
+  
   var discriminator;
   
   if (params.polymorphic) {
@@ -973,8 +973,8 @@ RelationDefinition.belongsTo = function (modelFrom, modelTo, params) {
     
     modelTo = null; // will lookup dynamically
     
-    pk = params.primaryKey || 'id'; // same for all polymorphic models
     relationName = params.as || polymorphic.as;
+    pk = params.primaryKey || 'id'; // same for all polymorphic models
     fk = polymorphic.foreignKey;
     discriminator = polymorphic.discriminator;
     
@@ -986,8 +986,8 @@ RelationDefinition.belongsTo = function (modelFrom, modelTo, params) {
     
     modelFrom.dataSource.defineProperty(modelFrom.modelName, discriminator, { type: 'string', index: true });
   } else {
-    pk = params.primaryKey || modelFrom.dataSource.idName(modelTo.modelName) || 'id';
     relationName = params.as || i8n.camelize(modelTo.modelName, true);
+    pk = params.primaryKey || modelFrom.dataSource.idName(modelTo.modelName) || 'id';
     fk = params.foreignKey || relationName + 'Id';
     
     modelFrom.dataSource.defineForeignKey(modelFrom.modelName, fk, modelTo.modelName);
@@ -1252,11 +1252,11 @@ RelationDefinition.hasOne = function (modelFrom, modelTo, params) {
       modelTo = lookupModel(modelFrom.dataSource.modelBuilder.models, modelToName);
     }
   }
-
-  var pk = params.primaryKey || modelFrom.dataSource.idName(modelTo.modelName) || 'id';
+  
   var relationName = params.as || i8n.camelize(modelTo.modelName, true);
-
+  var pk = params.primaryKey || modelFrom.dataSource.idName(modelTo.modelName) || 'id';
   var fk = params.foreignKey || i8n.camelize(modelFrom.modelName + '_id', true);
+  
   var discriminator;
   
   if (params.polymorphic) {
@@ -1940,6 +1940,7 @@ RelationDefinition.referencesMany = function referencesMany(modelFrom, modelTo, 
   var relationName = params.as || i8n.camelize(modelTo.pluralModelName, true);
   var fk = params.foreignKey || i8n.camelize(modelTo.modelName + '_ids', true);
   var pk = params.primaryKey || modelTo.dataSource.idName(modelTo.modelName) || 'id';
+  
   var idType = modelTo.definition.properties[pk].type;
   
   var definition = modelFrom.relations[relationName] = new RelationDefinition({


### PR DESCRIPTION
Allow `params.primaryKey` option to explicitly set the primary key of the related model; this was sometimes deduced using `dataSource.idName()`, but lacked consistency and not all relations allowed this to be user-defined.

The old `params.idName` option was renamed to `params.primaryKey`, to mirror the `params.foreignKey` option.
