### PR TITLE
Handle toObject in updateAttributes

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1175,6 +1175,10 @@ DataAccessObject.prototype.updateAttributes = function updateAttributes(data, cb
             // Convert the properties by type
             inst[key] = data[key];
             typedData[key] = inst[key];
+            if (typeof typedData[key] === 'object' 
+              && typeof typedData[key].toObject === 'function') {
+              typedData[key] = typedData[key].toObject();
+            }
           }
 
           inst._adapter().updateAttributes(model, getIdValue(inst.constructor, inst),


### PR DESCRIPTION
Since one can call updateAttributes with any kind of properties (as opposed to save, which uses toObject internally), any objects that correspond to toObject should be handled as such. This is particularly the case with List objects, as used by embedsMany. However, to be safe, instead of just fixing embedsMany to call toObject, it's best to do this in general. Otherwise, internal object properties might leak into the db.

This fixes #220
