### PR TITLE
HasMany exists should use internal findById

### DIFF
--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -692,12 +692,11 @@ HasMany.prototype.findById = function (fkId, cb) {
  * @param {Function} cb The callback function
  */
 HasMany.prototype.exists = function (fkId, cb) {
-  var modelTo = this.definition.modelTo;
   var fk = this.definition.keyTo;
   var pk = this.definition.keyFrom;
   var modelInstance = this.modelInstance;
 
-  modelTo.findById(fkId, function (err, inst) {
+  this.findById(fkId, function (err, inst) {
     if (err) {
       return cb(err);
     }


### PR DESCRIPTION
This limits the scope correctly, taking polymorphics into account.

(the foreign key check is actually obsolete I think)
