### PR TITLE
Add ability to apply a plugin multiple times from LDL

### DIFF
--- a/lib/model-builder.js
+++ b/lib/model-builder.js
@@ -439,7 +439,14 @@ ModelBuilder.prototype.define = function defineClass(className, properties, sett
     if (mixin === true) {
       mixin = {};
     }
-    if (typeof mixin === 'object') {
+    if (Array.isArray(mixin)) {
+      mixin.forEach(function(m) {
+        if (m === true) m = {};
+        if (typeof m === 'object') {
+          modelBuilder.mixins.applyMixin(ModelClass, name, m);
+        }
+      });
+    } else if (typeof mixin === 'object') {
       modelBuilder.mixins.applyMixin(ModelClass, name, mixin);
     }
   }

--- a/test/mixins.test.js
+++ b/test/mixins.test.js
@@ -49,7 +49,11 @@ describe('Model class', function () {
       };
     });
     mixins.define('Demo', function(Model, options) {
-      Model.demoMixin = options.ok;
+      Model.demoMixin = options.value;
+    });
+    mixins.define('Multi', function(Model, options) {
+      Model.multiMixin = Model.multiMixin || {};
+      Model.multiMixin[options.key] = options.value;
     });
   });
   
@@ -73,12 +77,21 @@ describe('Model class', function () {
   it('should apply mixins', function(done) {
     var memory = new DataSource('mem', {connector: Memory}, modelBuilder);
     var Item = memory.createModel('Item', { name: 'string' }, {
-      mixins: { TimeStamp: true, Demo: { ok: true } }
+      mixins: { 
+        TimeStamp: true, Demo: { value: true },
+        Multi: [
+          { key: 'foo', value: 'bar' }, 
+          { key: 'fox', value: 'baz' }
+        ]
+      }
     });
     
     Item.mixin('Example', { foo: 'bar' });
     
     Item.demoMixin.should.be.true;
+    
+    Item.multiMixin.foo.should.equal('bar');
+    Item.multiMixin.fox.should.equal('baz');
     
     var properties = Item.definition.properties;
     properties.createdAt.should.eql({ type: Date });


### PR DESCRIPTION
The array syntax allows a plugin to be applied several times, each with specific options:

```
mixins: { 
  Transform: [
    { property: 'name', action: 'lowercase' }, 
    { property: 'code', action: 'urlify' }
  ]
}
```
