### PR TITLE
Fix ModelDefinition toJSON bug

### DIFF
--- a/lib/model-definition.js
+++ b/lib/model-definition.js
@@ -265,7 +265,7 @@ ModelDefinition.prototype.toJSON = function (forceRebuild) {
     this.json = null;
   }
   if (this.json) {
-    return json;
+    return this.json;
   }
   var json = {
     name: this.name,

--- a/test/model-definition.test.js
+++ b/test/model-definition.test.js
@@ -36,7 +36,9 @@ describe('ModelDefinition class', function () {
     assert.equal(json.properties.approved.type, "Boolean");
     assert.equal(json.properties.joinedAt.type, "Date");
     assert.equal(json.properties.age.type, "Number");
-
+    
+    assert.deepEqual(User.toJSON(), json);
+    
     done();
 
   });


### PR DESCRIPTION
When called a second time, it was supposed to return the cached json, but returned undefined instead.
