### PR TITLE
Expose validation metadata

### DIFF
--- a/lib/validations.js
+++ b/lib/validations.js
@@ -1,4 +1,6 @@
 var util = require('util');
+var extend = util._extend;
+
 /*!
  * Module exports
  */
@@ -22,6 +24,18 @@ exports.Validatable = Validatable;
  */
 function Validatable() {
 }
+
+Validatable.validations = function() {
+  var validations = {};
+  (this._validations || []).forEach(function(v) {
+    var key = v[0], validation = v[1], options = v[3];
+    var copy = extend({}, validation);
+    copy.options = options || {};
+    validations[key] = validations[key] || [];
+    validations[key].push(copy);
+  });
+  return validations;
+};
 
 /**
  * Validate presence of one or more specified properties. 

--- a/test/validations.test.js
+++ b/test/validations.test.js
@@ -130,6 +130,14 @@ describe('validations', function () {
           done();
         });
       });
+      
+      it('should return validation metadata', function() {
+        var expected = {name:[{validation: 'presence', options: {}}]};
+        delete User._validations;
+        User.validatesPresenceOf('name');
+        var validations = User.validations();
+        validations.should.eql(expected);
+      });
     });
   });
 


### PR DESCRIPTION
The new Validatable.validations mixin method returns the validations as an object indexed by property name.

Fixes #232
