### PR TITLE
hasOne and belongsTo update/destroy methods on scope

### DIFF
--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -1084,9 +1084,11 @@ RelationDefinition.belongsTo = function (modelFrom, modelTo, params) {
     get: function() {
       var relation = new BelongsTo(definition, this);
       var relationMethod = relation.related.bind(relation);
-      relationMethod.create = relation.create.bind(relation);
-      relationMethod.build = relation.build.bind(relation);
-      if (definition.modelTo) {  
+      relationMethod.update = relation.update.bind(relation);
+      relationMethod.destroy = relation.destroy.bind(relation);
+      if (!polymorphic) { 
+        relationMethod.create = relation.create.bind(relation);
+        relationMethod.build = relation.build.bind(relation);
         relationMethod._targetClass = definition.modelTo.modelName;
       }
       return relationMethod;
@@ -1137,6 +1139,36 @@ BelongsTo.prototype.build = function(targetModelData) {
   var modelTo = this.definition.modelTo;
   this.definition.applyProperties(this.modelInstance, targetModelData || {});
   return new modelTo(targetModelData);
+};
+
+BelongsTo.prototype.update = function (targetModelData, cb) {
+  var definition = this.definition;
+  this.fetch(function(err, inst) {
+    if (inst instanceof ModelBaseClass) {
+      inst.updateAttributes(targetModelData, cb);
+    } else {
+      cb(new Error('BelongsTo relation ' + definition.name
+        + ' is empty'));
+    }
+  });
+};
+
+BelongsTo.prototype.destroy = function (cb) {
+  var modelTo = this.definition.modelTo;
+  var modelInstance = this.modelInstance;
+  var fk = this.definition.keyFrom;
+  this.fetch(function(err, targetModel) {
+    if (targetModel instanceof ModelBaseClass) {
+      modelInstance[fk] = null;
+      modelInstance.save(function(err, targetModel) {
+        if (cb && err) return cb && cb(err);
+        cb && cb(err, targetModel);
+      });
+    } else {
+      cb(new Error('BelongsTo relation ' + definition.name
+        + ' is empty'));
+    }
+  });
 };
 
 /**
@@ -1204,7 +1236,8 @@ BelongsTo.prototype.related = function (refresh, params) {
       var query = {where: {}};
       query.where[pk] = modelInstance[fk];
       
-      if (query.where[pk] === undefined) {
+      if (query.where[pk] === undefined 
+        || query.where[pk] === null) {
         // Foreign key is undefined
         return process.nextTick(cb);
       }
@@ -1420,9 +1453,9 @@ HasOne.prototype.create = function (targetModelData, cb) {
 
 HasOne.prototype.update = function (targetModelData, cb) {
   var definition = this.definition;
-  this.fetch(function(err, inst) {
-    if (inst instanceof ModelBaseClass) {
-      inst.updateAttributes(targetModelData, cb);
+  this.fetch(function(err, targetModel) {
+    if (targetModel instanceof ModelBaseClass) {
+      targetModel.updateAttributes(targetModelData, cb);
     } else {
       cb(new Error('HasOne relation ' + definition.name
         + ' is empty'));
@@ -1431,9 +1464,9 @@ HasOne.prototype.update = function (targetModelData, cb) {
 };
 
 HasOne.prototype.destroy = function (cb) {
-  this.fetch(function(err, inst) {
-    if (inst instanceof ModelBaseClass) {
-      inst.destroy(cb);
+  this.fetch(function(err, targetModel) {
+    if (targetModel instanceof ModelBaseClass) {
+      targetModel.destroy(cb);
     } else {
       cb(new Error('HasOne relation ' + definition.name
         + ' is empty'));


### PR DESCRIPTION
Note the following semantics:
- destroy on a hasOne relation will nullify the foreignKey (see also: #234)
- destroy on a belongsTo relation will effectively destroy the related item completely

Is this what's expected? Or should we introduce a flag to configure this?
