### PR TITLE
Use the correct dataSource for modelFrom/modelTo

### DIFF
--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -1078,7 +1078,7 @@ RelationDefinition.belongsTo = function (modelFrom, modelTo, params) {
     
     modelFrom.dataSource.defineProperty(modelFrom.modelName, discriminator, { type: 'string', index: true });
   } else {
-    idName = modelFrom.dataSource.idName(modelTo.modelName) || 'id';
+    idName = modelTo.dataSource.idName(modelTo.modelName) || 'id';
     relationName = params.as || i8n.camelize(modelTo.modelName, true);
     fk = params.foreignKey || relationName + 'Id';
     
@@ -1368,7 +1368,7 @@ RelationDefinition.hasOne = function (modelFrom, modelTo, params) {
   params = params || {};
   modelTo = lookupModelTo(modelFrom, modelTo, params);
 
-  var pk = modelFrom.dataSource.idName(modelTo.modelName) || 'id';
+  var pk = modelTo.dataSource.idName(modelTo.modelName) || 'id';
   var relationName = params.as || i8n.camelize(modelTo.modelName, true);
 
   var fk = params.foreignKey || i8n.camelize(modelFrom.modelName + '_id', true);
@@ -1395,7 +1395,7 @@ RelationDefinition.hasOne = function (modelFrom, modelTo, params) {
     polymorphic: polymorphic
   });
 
-  modelFrom.dataSource.defineForeignKey(modelTo.modelName, fk, modelFrom.modelName);
+  modelTo.dataSource.defineForeignKey(modelTo.modelName, fk, modelFrom.modelName);
 
   // Define a property for the scope so that we have 'this' for the scoped methods
   Object.defineProperty(modelFrom.prototype, relationName, {


### PR DESCRIPTION
This caused hasOne to fail in mixed dataSource/connector setups:

```
Uncaught TypeError: Cannot read property 'properties' of undefined at
Memory.Connector.defineProperty (../node_modules/loopback-datasource-juggler/node_modules/loopback-connector/lib/connector.js:131:22)
```
