### PR TITLE
Fix options for hasManyThrough doesn't apply

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -417,7 +417,7 @@ DataSource.prototype.defineRelations = function (modelClass, relations) {
       throughModel.once('dataAccessConfigured', function (model) {
         if (isModelDataSourceAttached(targetModel)) {
           // The target model is resolved
-          var params = traverse(relations).clone();
+          var params = traverse(relation).clone();
           params.as = name;
           params.model = targetModel;
           params.through = model;

--- a/test/loopback-dl.test.js
+++ b/test/loopback-dl.test.js
@@ -1110,6 +1110,27 @@ describe('Load models with relations', function () {
     done();
   });
 
+  it('should handle hasMany through options', function (done) {
+    var ds = new DataSource('memory');
+    var Physician = ds.createModel('Physician', {
+      name: String
+    }, {relations: {patients: {model: 'Patient', type: 'hasMany', foreignKey: 'leftId', through: 'Appointment'}}});
+
+    var Patient = ds.createModel('Patient', {
+      name: String
+    }, {relations: {physicians: {model: 'Physician', type: 'hasMany', foreignKey: 'rightId', through: 'Appointment'}}});
+
+    var Appointment = ds.createModel('Appointment', {
+      physicianId: Number,
+      patientId: Number,
+      appointmentDate: Date
+    }, {relations: {patient: {type: 'belongsTo', model: 'Patient'}, physician: {type: 'belongsTo', model: 'Physician'}}});
+
+    assert(Physician.relations['patients'].keyTo === 'leftId');
+    assert(Patient.relations['physicians'].keyTo === 'rightId');
+    done();
+  });
+
   it('should set up relations after attach', function (done) {
     var ds = new DataSource('memory');
     var modelBuilder = new ModelBuilder();


### PR DESCRIPTION
e.g., the `foreignKey` option in a **HasMany Through** relation. See the test.

Signed-off-by: Clark Wang clark.wangs@gmail.com
