### PR TITLE
Fix typo of keyThrough and get from params

### DIFF
--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -572,7 +572,7 @@ RelationDefinition.hasMany = function hasMany(modelFrom, modelTo, params) {
   
   definition.modelThrough = params.through;
   
-  var keyThrough = definition.throughKey || i8n.camelize(modelTo.modelName + '_id', true);
+  var keyThrough = params.keyThrough || i8n.camelize(modelTo.modelName + '_id', true);
   definition.keyThrough = keyThrough;
   
   modelFrom.relations[relationName] = definition;


### PR DESCRIPTION
1. fix typo: `throughKey` -> `keyThrough`
2. get value from `params`

Signed-off-by: Clark Wang clark.wangs@gmail.com
