### PR TITLE
Export RelationClasses

### DIFF
--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -11,9 +11,6 @@ var applyFilter = require('./connectors/memory').applyFilter;
 var ValidationError = require('./validations.js').ValidationError;
 var debug = require('debug')('loopback:relations');
 
-exports.Relation = Relation;
-exports.RelationDefinition = RelationDefinition;
-
 var RelationTypes = {
   belongsTo: 'belongsTo',
   hasMany: 'hasMany',
@@ -23,16 +20,6 @@ var RelationTypes = {
   embedsOne: 'embedsOne',
   embedsMany: 'embedsMany'
 };
-
-exports.RelationTypes = RelationTypes;
-exports.HasMany = HasMany;
-exports.HasManyThrough = HasManyThrough;
-exports.HasOne = HasOne;
-exports.HasAndBelongsToMany = HasAndBelongsToMany;
-exports.BelongsTo = BelongsTo;
-exports.ReferencesMany = ReferencesMany;
-exports.EmbedsOne = EmbedsOne;
-exports.EmbedsMany = EmbedsMany;
 
 var RelationClasses = {
   belongsTo: BelongsTo,
@@ -44,6 +31,21 @@ var RelationClasses = {
   embedsOne: EmbedsOne,
   embedsMany: EmbedsMany
 };
+
+exports.Relation = Relation;
+exports.RelationDefinition = RelationDefinition;
+
+exports.RelationTypes = RelationTypes;
+exports.RelationClasses = RelationClasses;
+
+exports.HasMany = HasMany;
+exports.HasManyThrough = HasManyThrough;
+exports.HasOne = HasOne;
+exports.HasAndBelongsToMany = HasAndBelongsToMany;
+exports.BelongsTo = BelongsTo;
+exports.ReferencesMany = ReferencesMany;
+exports.EmbedsOne = EmbedsOne;
+exports.EmbedsMany = EmbedsMany;
 
 function normalizeType(type) {
   if (!type) {


### PR DESCRIPTION
Without this being exported, it was impossible to define custom relation types. However, there are still limitations - not all helper methods are public to really handle this scenario.

Perhaps this should be refactored at a later stage.
