### PR TITLE
Fix bug : add validators to upsert/updateOrCreate an object

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -210,32 +210,12 @@ DataAccessObject.updateOrCreate = DataAccessObject.upsert = function upsert(data
   }
 
   var Model = this;
-  if (!getIdValue(this, data)) {
+  var id = getIdValue(this, data);
+
+  if (!id) {
     return this.create(data, callback);
-  }
-  if (this.getDataSource().connector.updateOrCreate) {
-    var update = data;
-    var inst = data;
-    if(!(data instanceof Model)) {
-      inst = new Model(data);
-    }
-    update = inst.toObject(false);
-    update = removeUndefined(update);
-    this.getDataSource().connector.updateOrCreate(Model.modelName, update, function (err, data) {
-      var obj;
-      if (data && !(data instanceof Model)) {
-        inst._initProperties(data);
-        obj = inst;
-      } else {
-        obj = data;
-      }
-      callback(err, obj);
-      if(!err) {
-        Model.emit('changed', inst);
-      }
-    });
   } else {
-    this.findById(getIdValue(this, data), function (err, inst) {
+    this.findById(id, function(err, inst) {
       if (err) {
         return callback(err);
       }


### PR DESCRIPTION
Hi,

After studying the updateOrCreate function and loopback-connector-mongodb, it is possible to directly use updateAttributes without check this.getDataSource().connector, because updateAttributes use _adapter(), which use the good connector.

The base behavior is preserved and checks the validators when updated.
