### PR TITLE
Allow to filter by null value

### DIFF
--- a/lib/connectors/memory.js
+++ b/lib/connectors/memory.js
@@ -403,6 +403,10 @@ function applyFilter(filter) {
   }
 
   function test(example, value) {
+    if (example === null) {
+      return value === undefined || value === null;
+    }
+
     if (typeof value === 'string' && (example instanceof RegExp)) {
       return value.match(example);
     }


### PR DESCRIPTION
There are cases where it's interesting to find all the elements that have a
property set to null, for example when a there's a relation and you want to
find all those objects without the relation.

I found out that mssql, mysql and I think also postresql provide this feature, just not the memory connector.