### PR TITLE
enhance the warning message sent to the client

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -223,7 +223,7 @@ DataSource._resolveConnector = function (name, loader) {
   var connector = tryModules(names, loader);
   var error = null;
   if (!connector) {
-    error = util.format('\nWARNING: LoopBack connector "%s" is not installed ' +
+    error = util.format('\nWARNING: LoopBack connector "%s" is referenced in a DataSource but is not installed ' +
       'as any of the following modules:\n\n %s\n\nTo fix, run:\n\n    npm install %s\n',
       name, names.join('\n'), names[names.length -1]);
   }
@@ -433,11 +433,11 @@ DataSource.prototype.defineRelations = function (modelClass, relations) {
       var r = relations[rn];
       assert(DataSource.relationTypes.indexOf(r.type) !== -1, "Invalid relation type: " + r.type);
       var targetModel, polymorphicName;
-      
+
       if (r.polymorphic && r.type !== 'belongsTo' && !r.model) {
         throw new Error('No model specified for polymorphic ' + r.type + ': ' + rn);
       }
-      
+
       if (r.polymorphic) {
         polymorphicName = typeof r.model === 'string' ? r.model : rn;
         if (typeof r.polymorphic === 'string') {
@@ -446,17 +446,17 @@ DataSource.prototype.defineRelations = function (modelClass, relations) {
           polymorphicName = r.polymorphic.as;
         }
       }
-      
+
       if (r.model) {
         targetModel = isModelClass(r.model) ? r.model : self.getModel(r.model, true);
       }
-      
+
       var throughModel = null;
       if (r.through) {
         throughModel = isModelClass(r.through) ? r.through : self.getModel(r.through, true);
       }
-      
-      if ((targetModel && !isModelDataSourceAttached(targetModel)) 
+
+      if ((targetModel && !isModelDataSourceAttached(targetModel))
         || (throughModel && !isModelDataSourceAttached(throughModel))) {
         // Create a listener to defer the relation set up
         createListener(rn, r, targetModel, throughModel);
@@ -525,7 +525,7 @@ DataSource.prototype.setupDataAccess = function (modelClass, settings) {
  * The first (String) argument specifying the model name is required.
  * You can provide one or two JSON object arguments, to provide configuration options.
  * See [Model definition reference](http://docs.strongloop.com/display/DOC/Model+definition+reference) for details.
- * 
+ *
  * Simple example:
  * ```
  * var User = dataSource.createModel('User', {
@@ -546,7 +546,7 @@ DataSource.prototype.setupDataAccess = function (modelClass, settings) {
  * });
  * ```
  * You can also define an ACL when you create a new data source with the `DataSource.create()` method. For example:
- * 
+ *
  * ```js
  * var Customer = ds.createModel('Customer', {
  *       name: {
@@ -749,9 +749,9 @@ DataSource.prototype.defineProperty = function (model, prop, params) {
 /**
  * Drop each model table and re-create.
  * This method applies only to database connectors.  For MongoDB, it drops and creates indexes.
- * 
+ *
  * **WARNING**: Calling this function deletes all data! Use `autoupdate()` to preserve data.
- * 
+ *
  * @param {String} model Model to migrate.  If not present, apply to all models.  Can also be an array of Strings.
  * @param {Function} [callback] Callback function. Optional.
  *
@@ -965,7 +965,7 @@ DataSource.prototype.discoverForeignKeysSync = function (modelName, options) {
 /**
  * Retrieves a description of the foreign key columns that reference the given table's primary key columns
  * (the foreign keys exported by a table), ordered by fkTableOwner, fkTableName, and keySeq.
- * 
+ *
  * Callback function return value is an object that can have the following properties:
  *
  *| Key | Type | Description |
@@ -1786,7 +1786,7 @@ DataSource.prototype.enableRemote = function (operation) {
 /**
  * Disable remote access to a data source operation. Each [connector](#connector) has its own set of set enabled
  * and disabled operations. To list the operations, call `dataSource.operations()`.
- * 
+ *
  *```js
  * var oracle = loopback.createDataSource({
  *   connector: require('loopback-connector-oracle'),
@@ -1796,7 +1796,7 @@ DataSource.prototype.enableRemote = function (operation) {
  * oracle.disableRemote('destroyAll');
  * ```
  * **Notes:**
- * 
+ *
  * - Disabled operations will not be added to attached models.
  * - Disabling the remoting for a method only affects client access (it will still be available from server models).
  * - Data sources must enable / disable operations before attaching or creating models.


### PR DESCRIPTION
- when a  datasource connector is referenced but is not
  installed a warning message may be sent to the client
  out of context so it can be confusing to the user if
  they are not in the context of the offending connector
- adding a small phrase explaining that the connector
  that is not installed is referenced in one of the users
  datasource definitions

@raymondfeng 

Fixes https://github.com/strongloop/strong-studio/issues/373
