### PR TITLE
Provide feedback (result count) for updateAll and destroyAll

### DIFF
--- a/lib/connectors/memory.js
+++ b/lib/connectors/memory.js
@@ -527,17 +527,22 @@ Memory.prototype.destroyAll = function destroyAll(model, where, callback) {
   }
   var cache = this.collection(model);
   var filter = null;
+  var count = 0;
   if (where) {
     filter = applyFilter({where: where});
     Object.keys(cache).forEach(function (id) {
       if (!filter || filter(this.fromDb(model, cache[id]))) {
+        count++;
         delete cache[id];
       }
     }.bind(this));
   } else {
+    count = Object.keys(cache).length;
     this.collection(model, {});
   }
-  this.saveToFile(null, callback);
+  this.saveToFile(null, function(err) {
+    callback && callback(err, count);
+  });
 };
 
 Memory.prototype.count = function count(model, callback, where) {

--- a/lib/connectors/memory.js
+++ b/lib/connectors/memory.js
@@ -564,16 +564,20 @@ Memory.prototype.update =
     filter = applyFilter({where: where});
 
     var ids = Object.keys(cache);
+    var count = 0;
     async.each(ids, function (id, done) {
       var inst = self.fromDb(model, cache[id]);
       if (!filter || filter(inst)) {
+        count++;
         self.updateAttributes(model, id, data, done);
       } else {
         process.nextTick(done);
       }
     }, function (err) {
       if (!err) {
-        self.saveToFile(null, cb);
+        self.saveToFile(null, function(err) {
+          cb && cb(err, count);
+        });
       }
     });
   };

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -911,7 +911,7 @@ DataAccessObject.remove = DataAccessObject.deleteAll = DataAccessObject.destroyA
  * Delete the record with the specified ID.
  * Aliases are `destroyById` and `deleteById`.
  * @param {*} id The id value
- * @param {Function} cb Callback called with (err)
+ * @param {Function} cb Callback called with (err, deleted)
  */
 
 // [FIXME] rfeng: This is a hack to set up 'deleteById' first so that
@@ -921,11 +921,11 @@ DataAccessObject.removeById = DataAccessObject.destroyById = DataAccessObject.de
   if (stillConnecting(this.getDataSource(), this, arguments)) return;
   var Model = this;
   
-  this.remove(byIdQuery(this, id).where, function(err) {
+  this.remove(byIdQuery(this, id).where, function(err, count) {
     if ('function' === typeof cb) {
-      cb(err);
+      cb(err, !err && count > 0);
     }
-    if(!err) Model.emit('deleted', id);
+    if(!err && count > 0) Model.emit('deleted', id);
   });
 };
 

--- a/test/basic-querying.test.js
+++ b/test/basic-querying.test.js
@@ -609,7 +609,9 @@ describe('basic-querying', function () {
     beforeEach(seed);
 
     it('should only update instances that satisfy the where condition', function (done) {
-      User.update({name: 'John Lennon'}, {name: 'John Smith'}, function () {
+      User.update({name: 'John Lennon'}, {name: 'John Smith'}, function (err, count) {
+        should.not.exist(err);
+        count.should.equal(1);
         User.find({where: {name: 'John Lennon'}}, function (err, data) {
           should.not.exist(err);
           data.length.should.equal(0);
@@ -623,7 +625,9 @@ describe('basic-querying', function () {
     });
 
     it('should update all instances without where', function (done) {
-      User.update({name: 'John Smith'}, function () {
+      User.update({name: 'John Smith'}, function (err, count) {
+        should.not.exist(err);
+        count.should.equal(6);
         User.find({where: {name: 'John Lennon'}}, function (err, data) {
           should.not.exist(err);
           data.length.should.equal(0);

--- a/test/default-scope.test.js
+++ b/test/default-scope.test.js
@@ -426,22 +426,25 @@ describe('default scope', function () {
     });
     
     it('should apply default scope', function(done) {
-      Product.removeById(ids.widgetZ, function(err) {
+      Product.removeById(ids.widgetZ, function(err, deleted) {
         should.not.exist(err);
+        deleted.should.be.true;
         isDeleted(ids.widgetZ, done);
       });
     });
     
     it('should apply default scope - tool', function(done) {
-      Tool.removeById(ids.toolA, function(err) {
+      Tool.removeById(ids.toolA, function(err, deleted) {
         should.not.exist(err);
+        deleted.should.be.true;
         isDeleted(ids.toolA, done);
       });
     });
     
     it('should apply default scope - no match', function(done) {
-      Tool.removeById(ids.widgetA, function(err) {
+      Tool.removeById(ids.widgetA, function(err, deleted) {
         should.not.exist(err);
+        deleted.should.be.false;
         Product.exists(ids.widgetA, function(err, exists) {
           should.not.exist(err);
           exists.should.be.true;
@@ -451,8 +454,9 @@ describe('default scope', function () {
     });
     
     it('should apply default scope - widget', function(done) {
-      Widget.removeById(ids.widgetA, function(err) {
+      Widget.removeById(ids.widgetA, function(err, deleted) {
         should.not.exist(err);
+        deleted.should.be.true;
         isDeleted(ids.widgetA, done);
       });
     });

--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -253,8 +253,9 @@ describe('manipulation', function () {
     });
 
     it('should destroy all records', function (done) {
-      Person.destroyAll(function (err) {
+      Person.destroyAll(function (err, count) {
         should.not.exist(err);
+        count.should.equal(1);
         Person.all(function (err, posts) {
           posts.should.have.lengthOf(0);
           Person.count(function (err, count) {

--- a/test/memory.test.js
+++ b/test/memory.test.js
@@ -53,7 +53,8 @@ describe('Memory connector', function () {
       });
     }, function (err, results) {
       // Now try to delete one
-      User.deleteById(ids[0], function (err) {
+      User.deleteById(ids[0], function (err, deleted) {
+        assert(deleted);
         readModels(function (err, json) {
           assert.equal(Object.keys(json.models.User).length, 2);
           User.upsert({id: ids[1], name: 'John'}, function(err, result) {


### PR DESCRIPTION
This currently targets the Memory connector and fixes #294 - it appears that the MongoDB connector already does the right thing. We'd have to check the other connectors (running test/manipulation.test.js will fail if unsupported).

This is the first step towards more meaningful feedback from the (HTTP) API as well (needs loopback update, for remoting return values).