### PR TITLE
Don't inherit settings.base when extending a model

### DIFF
--- a/lib/model-builder.js
+++ b/lib/model-builder.js
@@ -140,6 +140,10 @@ ModelBuilder.prototype.define = function defineClass(className, properties, sett
   var ModelBaseClass = parent || this.defaultModelBaseClass;
   var baseClass = settings.base || settings['super'];
   if (baseClass) {
+    // Normalize base model property
+    settings.base = baseClass;
+    delete settings['super'];
+
     if (isModelClass(baseClass)) {
       ModelBaseClass = baseClass;
     } else {
@@ -337,7 +341,14 @@ ModelBuilder.prototype.define = function defineClass(className, properties, sett
     }
 
     // Merge the settings
+    var originalSubclassSettings = subclassSettings;
     subclassSettings = mergeSettings(settings, subclassSettings);
+
+    // Ensure 'base' is not inherited. Note we don't have to delete 'super'
+    // as that is removed from settings by modelBuilder.define and thus
+    // it is never inherited
+    if (!originalSubclassSettings.base)
+      delete subclassSettings.base;
 
     // Define the subclass
     var subClass = modelBuilder.define(className, subclassProperties, subclassSettings, ModelClass);

--- a/test/model-definition.test.js
+++ b/test/model-definition.test.js
@@ -250,6 +250,26 @@ describe('ModelDefinition class', function () {
     assert(anotherChild.prototype instanceof baseChild);
   });
 
+  it('should ignore inherited options.base', function() {
+    var memory = new DataSource({connector: Memory});
+    var modelBuilder = memory.modelBuilder;
+    var base = modelBuilder.define('base');
+    var child = base.extend('child', {}, { base: 'base' });
+    var grandChild = child.extend('grand-child');
+    assert.equal('child', grandChild.base.modelName);
+    assert(grandChild.prototype instanceof child);
+  });
+
+  it('should ignore inherited options.super', function() {
+    var memory = new DataSource({connector: Memory});
+    var modelBuilder = memory.modelBuilder;
+    var base = modelBuilder.define('base');
+    var child = base.extend('child', {}, { super: 'base' });
+    var grandChild = child.extend('grand-child');
+    assert.equal('child', grandChild.base.modelName);
+    assert(grandChild.prototype instanceof child);
+  });
+
   it('should not serialize hidden properties into JSON', function () {
     var memory = new DataSource({connector: Memory});
     var modelBuilder = memory.modelBuilder;


### PR DESCRIPTION
Fix the bug in `ModelClass.extend` where the `base` option used
in the new class was inherited from ModelClass. As a result
the extended model was incorrectly based on ModelClass's parent.

Fix #322.

/to @raymondfeng @ritch please review
