### PR TITLE
handle relationship create with [array]

### DIFF
--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -3,6 +3,7 @@
  */
 var assert = require('assert');
 var util = require('util');
+var async = require('async');
 var utils = require('./utils');
 var i8n = require('inflection');
 var defineScope = require('./scope.js').defineScope;
@@ -910,39 +911,46 @@ HasManyThrough.prototype.create = function create(data, done) {
     done = data;
     data = {};
   }
+  done = done || function(){};
 
   var modelInstance = this.modelInstance;
 
   // First create the target model
   modelTo.create(data, function (err, to) {
     if (err) {
-      return done && done(err, to);
+      return done(err, to);
     }
     // The primary key for the target model
     var pk2 = definition.modelTo.definition.idName();
-    
     var keys = throughKeys(definition);
     var fk1 = keys[0];
     var fk2 = keys[1];
     
-    var d = {};
-    d[fk1] = modelInstance[definition.keyFrom];
-    d[fk2] = to[pk2];
-    
-    definition.applyProperties(modelInstance, d);
-    
-    // Then create the through model
-    modelThrough.create(d, function (e, through) {
-      if (e) {
-        // Undo creation of the target model
-        to.destroy(function () {
-          done && done(e);
-        });
-      } else {
-        self.addToCache(to);
-        done && done(err, to);
-      }
-    });
+    function createRelation(to, next) {
+      var d = {};
+      d[fk1] = modelInstance[definition.keyFrom];
+      d[fk2] = to[pk2];
+      definition.applyProperties(modelInstance, d);
+      
+      // Then create the through model
+      modelThrough.create(d, function (e, through) {
+        if (e) {
+          // Undo creation of the target model
+          to.destroy(function () {
+            next(e);
+          });
+        } else {
+          self.addToCache(to);
+          next(err, to);
+        }
+      });
+    }
+
+    // process array or single item
+    if (!Array.isArray(to))
+      createRelation(to, done);
+    else
+      async.map(to, createRelation, done);
   });
 };
 

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -294,6 +294,29 @@ describe('relations', function () {
       });
     });
 
+    it('should create multiple records on scope', function (done) {
+      var async = require('async');
+      Physician.create(function (err, physician) {
+        physician.patients.create([{}, {}], function (err, patients) {
+          should.not.exist(err);
+          should.exist(patients);
+          patients.should.have.lengthOf(2);
+          function verifyPatient(patient, next) {
+            Appointment.find({where: {
+              physicianId: physician.id,
+              patientId: patient.id
+            }},
+              function(err, apps) {
+                should.not.exist(err);
+                apps.should.have.lengthOf(1);
+                next();
+            });
+          }
+          async.forEach(patients, verifyPatient, done);
+        });
+      });
+    });
+
     it('should fetch all scoped instances', function (done) {
       Physician.create(function (err, physician) {
         physician.patients.create({name: 'a'}, function () {


### PR DESCRIPTION
For a hasAndBelongsToMany relationship, [model].[relationship].create was failing when passed an array.  The underlying [model].create supports an array, but the code creating the 'through' record assumes that it's working with an object.

I added a failing test, and a fix.
