### PR TITLE
Allow hasOne relation to have a scope option

### DIFF
--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -1448,6 +1448,7 @@ RelationDefinition.hasOne = function (modelFrom, modelTo, params) {
     keyTo: fk,
     modelTo: modelTo,
     properties: params.properties,
+    scope: params.scope,
     options: params.options,
     polymorphic: polymorphic
   });


### PR DESCRIPTION
So a model could dynamically have one target model.

E.g.: A question have many answers, but it could only have one best answer. With this PR, we could just update the answer with a `{best:true}` flag, and define a hasOne relation with scope  `{where:{best:true}}`.

Signed-off-by: Clark Wang clark.wangs@gmail.com
