### PR TITLE
docs.json: add lib/model.js

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1,10 +1,11 @@
 {
     "content": [
         "lib/datasource.js",
-        "lib/geo.js",        
+        "lib/model.js",
+        "lib/geo.js",
         "lib/hooks.js",
         "lib/include.js",
-        "lib/model-builder.js",        
+        "lib/model-builder.js",
         "lib/relations.js",
         "lib/validations.js"
     ],


### PR DESCRIPTION
I noticed that `ModelBaseClass` was missing from our API docs. The class provides some useful methods like `ModelBaseClass.defineProperty(prop, params)`.

![screen shot 2014-12-02 at 8 29 36](https://cloud.githubusercontent.com/assets/1140553/5259222/61c7fab0-79fd-11e4-8563-e5d8ad2ba9f1.png)

/to @raymondfeng @crandmck please review
