### PR TITLE
ValidationError messages include field value

### DIFF
--- a/lib/validations.js
+++ b/lib/validations.js
@@ -735,7 +735,7 @@ function ValidationError(obj) {
   this.message = util.format(
     'The %s instance is not valid. Details: %s.',
       context ? '`' + context + '`' : 'model',
-      formatErrors(obj.errors) || '(unknown)'
+      formatErrors(obj) || '(unknown)'
   );
 
   this.statusCode = 422;
@@ -760,10 +760,21 @@ function ValidationError(obj) {
 util.inherits(ValidationError, Error);
 
 var errorHasStackProperty = !!(new Error).stack;
+var inspect = require('util').inspect;
 
-function formatErrors(errors) {
+function formatProperty(obj, propertyName) {
+  var value = obj[propertyName];
+  if ((typeof value) === 'function')
+    return propertyName
+  else if ((typeof value) === 'string')
+    return propertyName + ': ' + inspect(value.substring(0, 32));
+  else
+    return propertyName + ': ' + inspect(value);
+}
+
+function formatErrors(obj) {
   var DELIM = '; ';
-  errors = errors || {};
+  var errors = obj.errors || {};
   return Object.getOwnPropertyNames(errors)
     .filter(function(propertyName) {
       return Array.isArray(errors[propertyName]);
@@ -771,7 +782,7 @@ function formatErrors(errors) {
     .map(function(propertyName) {
       var messages = errors[propertyName];
       return messages.map(function(msg) {
-        return '`' + propertyName + '` ' + msg;
+        return '`' + formatProperty(obj, propertyName) + '` ' + msg;
       }).join(DELIM);
     })
     .join(DELIM);

--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -66,7 +66,7 @@ describe('manipulation', function () {
     it('should not allow user-defined value for the id of object - create', function (done) {
       Person.create({id: 123456}, function (err, p) {
         err.should.be.instanceof(ValidationError);
-        err.message.should.equal('The `Person` instance is not valid. Details: `id` can\'t be set.');
+        err.message.should.equal('The `Person` instance is not valid. Details: `id: 123456` can\'t be set.');
         err.statusCode.should.equal(422);
         p.should.be.instanceof(Person);
         p.id.should.equal(123456);
@@ -80,7 +80,7 @@ describe('manipulation', function () {
       p.isNewRecord().should.be.true;
       p.save(function(err, inst) {
         err.should.be.instanceof(ValidationError);
-        err.message.should.equal('The `Person` instance is not valid. Details: `id` can\'t be set.');
+        err.message.should.equal('The `Person` instance is not valid. Details: `id: 123456` can\'t be set.');
         err.statusCode.should.equal(422);
         inst.id.should.equal(123456);
         inst.isNewRecord().should.be.true;

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -2112,7 +2112,7 @@ describe('relations', function () {
         should.exist(err);
         err.name.should.equal('ValidationError');
         var msg = 'The `Passport` instance is not valid.';
-        msg += ' Details: `name` can\'t be blank.';
+        msg += ' Details: `name: undefined` can\'t be blank.';
         err.message.should.equal(msg);
         done();
       });
@@ -2569,7 +2569,7 @@ describe('relations', function () {
       Person.create({ name: 'Wilma', addresses: addresses }, function(err, p) {
         err.name.should.equal('ValidationError');
         var expected = 'The `Person` instance is not valid. ';
-        expected += 'Details: `addresses` contains invalid item: `work` (`street` can\'t be blank).';
+        expected += 'Details: `addresses: [ { id: \u001b[32m\'home\'\u001b[39m, street: \u001b[32m\'Home Street\'\u001b[39m },\n  { id: \u001b[32m\'work\'\u001b[39m, street: \u001b[32m\'\'\u001b[39m } ]` contains invalid item: `work` (`street` can\'t be blank).';
         err.message.should.equal(expected);
         done();
       });
@@ -2769,7 +2769,7 @@ describe('relations', function () {
           err.name.should.equal('ValidationError');
           err.details.codes.street.should.eql(['presence']);
           var expected = 'The `Address` instance is not valid. ';
-          expected += 'Details: `street` can\'t be blank.';
+          expected += 'Details: `street: undefined` can\'t be blank.';
           err.message.should.equal(expected);
           done();
         });

--- a/test/validations.test.js
+++ b/test/validations.test.js
@@ -206,7 +206,7 @@ describe('validations', function () {
         User.validatesPresenceOf('name');
         User.create(function (e, u) {
           should.exist(e);
-          e.message.should.match(/`name` can't be blank/);
+          e.message.should.match(/`name: undefined` can't be blank/);
           done();
         });
       });


### PR DESCRIPTION
I modified the formatErrors() function to include the current value of the fields which have failed validation.

The format looks like this:

```
The `Person` instance is not valid. Details: `id: 123456` can\'t be set.
```

Please let me know if that format is good, and I will update the test expectations to match.