### PR TITLE
fix default include in default scope fails findById

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -58,7 +58,6 @@ function byIdQuery(m, id) {
   var pk = idName(m);
   var query = { where: {} };
   query.where[pk] = id;
-  m.applyScope(query);
   return query;
 }
 


### PR DESCRIPTION
If there is an include option in default scope, `findById()` will complaint:

> Relation "things" is not defined for Thing model

I think it's because the default scope is applied twice, the first is in `byIdQuery()` which is called by `findById()`, the second is in `find()`. This will cause `mergeQuery()` to nest the include option:

``` js
{ scope: { include: { things: { 'things' } } } }
```

Signed-off-by: Clark Wang clark.wangs@gmail.com
