### PR TITLE
replace deprecated function __defineGetter__

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,11 +4,11 @@ exports.ModelBaseClass = require('./lib/model.js');
 exports.GeoPoint = require('./lib/geo.js').GeoPoint;
 exports.ValidationError = require('./lib/validations.js').ValidationError;
 
-exports.__defineGetter__('version', function () {
-    return require('./package.json').version;
+Object.defineProperty(exports, 'version', {
+  get: function() {return require('./package.json').version;}
 });
 
 var commonTest = './test/common_test';
-exports.__defineGetter__('test', function () {
-    return require(commonTest);
+Object.defineProperty(exports, 'test', {
+  get: function() {return require(commonTest);}
 });


### PR DESCRIPTION
`__defineGetter__` is deprecated:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineGetter__

Replacing it with Object.defineProperty retains the same functionality but is ES5 standard:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#Specifications.

This was causing a failure in IE.