### PR TITLE
Don't coerce nested objects into Model instances

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -21,6 +21,7 @@ var setScopeValuesFromWhere = utils.setScopeValuesFromWhere;
 var mergeQuery = utils.mergeQuery;
 var util = require('util');
 var assert = require('assert');
+var Model = require('./model');
 
 /**
  * Base class for all persistent objects.
@@ -590,6 +591,10 @@ DataAccessObject._coerce = function (where) {
     }
 
     if (!DataType) {
+      continue;
+    }
+
+    if (DataType.prototype instanceof Model) {
       continue;
     }
 

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -21,7 +21,7 @@ var setScopeValuesFromWhere = utils.setScopeValuesFromWhere;
 var mergeQuery = utils.mergeQuery;
 var util = require('util');
 var assert = require('assert');
-var Model = require('./model');
+var BaseModel = require('./model');
 
 /**
  * Base class for all persistent objects.
@@ -594,7 +594,7 @@ DataAccessObject._coerce = function (where) {
       continue;
     }
 
-    if (DataType.prototype instanceof Model) {
+    if (DataType.prototype instanceof BaseModel) {
       continue;
     }
 

--- a/test/datatype.test.js
+++ b/test/datatype.test.js
@@ -7,13 +7,16 @@ describe('datatypes', function () {
 
   before(function (done) {
     db = getSchema();
+    Nested = db.define('Nested', {});
+    
     Model = db.define('Model', {
       str: String,
       date: Date,
       num: Number,
       bool: Boolean,
       list: {type: [String]},
-      arr: Array
+      arr: Array,
+      nested: Nested
     });
     db.automigrate(function () {
       Model.destroyAll(done);
@@ -114,4 +117,10 @@ describe('datatypes', function () {
       });
     }
   });
+  
+  it('should not coerce nested objects into ModelConstructor types', function() {
+      var coerced = Model._coerce({ nested: { foo: 'bar' } });
+      coerced.nested.constructor.name.should.equal('Object');
+  });
+  
 });


### PR DESCRIPTION
For queries, this is undesirable. It also affects loopback-connector-mongodb's ability to perform nested queries (it expects plain objects to work correctly, and to allow $elemMatch for example).

Related issue: https://github.com/strongloop/loopback/issues/953