### PR TITLE
Fix for #369

### DIFF
--- a/lib/connectors/memory.js
+++ b/lib/connectors/memory.js
@@ -436,7 +436,7 @@ function applyFilter(filter) {
       return undefined;
     }
 
-    if (typeof example === 'object') {
+    if (typeof example === 'object' && example !== null) {
       // ignore geo near filter
       if (example.near) {
         return true;


### PR DESCRIPTION
Remember, folks, `typeof null === 'object'`. Fixes #369.