### PR TITLE
Fix detection of `util.inspect` version

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -441,8 +441,9 @@ ModelBaseClass.prototype.reset = function () {
 // Node v0.11+ allows custom inspect functions to return an object
 // instead of string. That way options like `showHidden` and `colors`
 // can be preserved.
-var versionParts = process.versions.node
-  .split(/\./g).map(function(v) { return +v; });
+var versionParts = process.versions && process.versions.node ?
+  process.versions.node.split(/\./g).map(function(v) { return +v; }) :
+  [1, 0, 0]; // browserify ships 1.0-compatible version of util.inspect
 
 var INSPECT_SUPPORTS_OBJECT_RETVAL =
  versionParts[0] > 0 ||


### PR DESCRIPTION
Improve the detection to work in browser too. This fixes a regression
introduced in e4fc3878 (#389)

/cc @rmg @raymondfeng I'll merge without review to push the fix to npmjs ASAP.