### PR TITLE
use connector.findOrCreate() if possible

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,41 @@
+2015-02-02, Version 2.15.0
+==========================
+
+ * Fix id type issue for update (Raymond Feng)
+
+ * Rename hook "query" to "access" (Miroslav Bajtoš)
+
+ * Implement intent hook `before delete` (Miroslav Bajtoš)
+
+ * Remove redundant `.toObject()` call from `upsert` (Miroslav Bajtoš)
+
+ * Fix regression in `.save()` from 1fd6eff1 (Miroslav Bajtoš)
+
+ * Fix hasOne remoting (Raymond Feng)
+
+ * Make sure batch create calls back with correct data (Raymond Feng)
+
+ * Intent-based hooks for persistence (Miroslav Bajtoš)
+
+ * ModelBaseClass: implement async observe/notify (Miroslav Bajtoš)
+
+ * Upgrade `should` to the latest 1.x version (Miroslav Bajtoš)
+
+ * Fixed nullCheck in validations to correct behavior when dealing with undefined attributes (James Billingham)
+
+ * Supply target to applyProperties function (Fabien Franzen)
+
+ * fix id property for composite ids (Clark Wang)
+
+ * fix id properties should sort by its index (Clark Wang)
+
+ * Fixed typos and logic for protected properties (Christian Enevoldsen)
+
+ * adds support for protected properties. (Christian Enevoldsen)
+
+ * support embeds data for belongsTo relation Signed-off-by: Clark Wang <clark.wangs@gmail.com> (Clark Wang)
+
+
 2015-01-15, Version 2.14.1
 ==========================
 
@@ -395,6 +433,13 @@
 
  * Properly handle LDL for polymorphic relations (Fabien Franzen)
 
+ * Check null (Raymond Feng)
+
+
+2014-08-15, Version 2.4.0
+=========================
+
+
 
 2014-08-15, Version 2.4.1
 =========================
@@ -402,12 +447,6 @@
  * Bump version (Raymond Feng)
 
  * Check null (Raymond Feng)
-
-
-2014-08-15, Version 2.4.0
-=========================
-
- * Bump version (Raymond Feng)
 
  * Fix the test cases to avoid hard-coded ids (Raymond Feng)
 
@@ -455,18 +494,15 @@
 
  * Cleanup mixin tests (Fabien Franzen)
 
- * Fix a name conflict in scope metadata (Raymond Feng)
-
-
-2014-08-08, Version 2.3.0
-=========================
-
-
 
 2014-08-08, Version 2.3.1
 =========================
 
  * Fix a name conflict in scope metadata (Raymond Feng)
+
+
+2014-08-08, Version 2.3.0
+=========================
 
  * Fix the test case so that it works with other DBs (Raymond Feng)
 
@@ -580,8 +616,6 @@
 
  * Implemented embedsMany relation (Fabien Franzen)
 
- * Fix a regression where undefined id should not match any record (Raymond Feng)
-
  * Minor tweaks; pass-through properties/scope for hasAndBelongsToMany (Fabien Franzen)
 
  * Implemented polymorphic hasMany through inverse (Fabien Franzen)
@@ -597,17 +631,18 @@
  * Implemented polymorphic hasMany (Fabien Franzen)
 
 
-2014-07-27, Version 2.1.0
-=========================
-
-
-
 2014-07-27, Version 2.1.1
 =========================
 
  * Bump version (Raymond Feng)
 
  * Fix a regression where undefined id should not match any record (Raymond Feng)
+
+
+2014-07-27, Version 2.1.0
+=========================
+
+ * Bump version (Raymond Feng)
 
  * datasource: support connectors without `getTypes` (Miroslav Bajtoš)
 

--- a/lib/connectors/memory.js
+++ b/lib/connectors/memory.js
@@ -582,6 +582,9 @@ Memory.prototype.update =
     async.each(ids, function (id, done) {
       var inst = self.fromDb(model, cache[id]);
       if (!filter || filter(inst)) {
+        // The id value from the cache is string
+        // Get the real id from the inst
+        id = self.getIdValue(model, inst);
         self.updateAttributes(model, id, data, done);
       } else {
         process.nextTick(done);

--- a/lib/connectors/memory.js
+++ b/lib/connectors/memory.js
@@ -228,6 +228,15 @@ Memory.prototype.updateOrCreate = function (model, data, callback) {
   });
 };
 
+Memory.prototype.findOrCreate = function (model, query, data, callback) {
+  this.all(model, query, function (err, list) {
+    if (err || (list && list[0])) return callback(err, list && list[0], false);
+    this.create(model, data, function (err) {
+      callback(err, data, true);
+    });
+  }.bind(this));
+};
+
 Memory.prototype.save = function save(model, data, callback) {
   var id = this.getIdValue(model, data);
   var cachedModels = this.collection(model);

--- a/lib/connectors/memory.js
+++ b/lib/connectors/memory.js
@@ -603,6 +603,9 @@ Memory.prototype.updateAttributes = function updateAttributes(model, id, data, c
     }
   }
 
+  // Do not modify the data object passed in arguments
+  data = Object.create(data);
+
   this.setIdValue(model, data, id);
 
   var cachedModels = this.collection(model);

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -995,7 +995,11 @@ DataAccessObject.remove = DataAccessObject.deleteAll = DataAccessObject.destroyA
       { Model: Model, query: query },
       function(err, ctx) {
         if (err) return cb(err);
-        doDelete(ctx.query.where);
+        var context = { Model: Model, where: ctx.query.where };
+        Model.notifyObserversOf('before delete', context, function(err, ctx) {
+          if (err) return cb(err);
+          doDelete(ctx.where);
+        });
       });
   }
 
@@ -1311,7 +1315,13 @@ DataAccessObject.prototype.remove =
         { Model: Model, query: byIdQuery(Model, id) },
         function(err, ctx) {
           if (err) return cb(err);
-          doDeleteInstance(ctx.query.where);
+          Model.notifyObserversOf(
+            'before delete',
+            { Model: Model, where: ctx.query.where },
+            function(err, ctx) {
+              if (err) return cb(err);
+              doDeleteInstance(ctx.where);
+            });
         });
 
       function doDeleteInstance(where) {

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -160,39 +160,38 @@ DataAccessObject.create = function (data, callback) {
   }
 
   if (Array.isArray(data)) {
-    var instances = [];
-    var errors = Array(data.length);
-    var gotError = false;
-    var wait = data.length;
-    if (wait === 0) {
-      callback(null, []);
-    }
-
-    for (var i = 0; i < data.length; i += 1) {
-      (function (d, i) {
-        Model = self.lookupModel(d); // data-specific
-        instances.push(Model.create(d, function (err, inst) {
-          if (err) {
-            errors[i] = err;
-            gotError = true;
-          }
-          modelCreated();
-        }));
-      })(data[i], i);
-    }
-
-    return instances;
-
-    function modelCreated() {
-      if (--wait === 0) {
-        callback(gotError ? errors : null, instances);
-        if(!gotError) {
-          instances.forEach(function(inst) {
-            inst.constructor.emit('changed');
-          });
-        }
+    // Undefined item will be skipped by async.map() which internally uses
+    // Array.prototype.map(). The following loop makes sure all items are
+    // iterated
+    for (var i = 0, n = data.length; i < n; i++) {
+      if (data[i] === undefined) {
+        data[i] = {};
       }
     }
+    async.map(data, function(item, done) {
+      self.create(item, function(err, result) {
+        // Collect all errors and results
+        done(null, {err: err, result: result || item});
+      });
+    }, function(err, results) {
+      if (err) {
+        return callback && callback(err, results);
+      }
+      // Convert the results into two arrays
+      var errors = null;
+      var data = [];
+      for (var i = 0, n = results.length; i < n; i++) {
+        if (results[i].err) {
+          if (!errors) {
+            errors = [];
+          }
+          errors[i] = results[i].err;
+        }
+        data[i] = results[i].result;
+      }
+      callback && callback(errors, data);
+    });
+    return data;
   }
 
   var enforced = {};

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -7,6 +7,7 @@ module.exports = DataAccessObject;
 /*!
  * Module dependencies
  */
+var async = require('async');
 var jutil = require('./jutil');
 var ValidationError = require('./validations').ValidationError;
 var Relation = require('./relations.js');
@@ -60,6 +61,16 @@ function byIdQuery(m, id) {
   var query = { where: {} };
   query.where[pk] = id;
   return query;
+}
+
+function isWhereByGivenId(Model, where, idValue) {
+  var keys = Object.keys(where);
+  if (keys.length != 1) return false;
+
+  var pk = idName(Model);
+  if (keys[0] !== pk) return false;
+
+  return where[pk] === idValue;
 }
 
 DataAccessObject._forDB = function (data) {
@@ -133,7 +144,7 @@ DataAccessObject.create = function (data, callback) {
 
   var Model = this;
   var self = this;
-  
+
   if (typeof data === 'function') {
     callback = data;
     data = {};
@@ -183,39 +194,42 @@ DataAccessObject.create = function (data, callback) {
       }
     }
   }
-  
+
   var enforced = {};
   var obj;
   var idValue = getIdValue(this, data);
-  
+
   // if we come from save
   if (data instanceof Model && !idValue) {
     obj = data;
   } else {
     obj = new Model(data);
   }
-  
+
   this.applyProperties(enforced, obj);
   obj.setAttributes(enforced);
-  
+
   Model = this.lookupModel(data); // data-specific
   if (Model !== obj.constructor) obj = new Model(data);
-  
-  data = obj.toObject(true);
-  
-  // validation required
-  obj.isValid(function (valid) {
-    if (valid) {
-      create();
-    } else {
-      callback(new ValidationError(obj), obj);
-    }
-  }, data);
-  
+
+  Model.notifyObserversOf('before save', { Model: Model, instance: obj }, function(err) {
+    if (err) return callback(err);
+
+    data = obj.toObject(true);
+
+    // validation required
+    obj.isValid(function (valid) {
+      if (valid) {
+        create();
+      } else {
+        callback(new ValidationError(obj), obj);
+      }
+    }, data);
+  });
+
   function create() {
     obj.trigger('create', function (createDone) {
       obj.trigger('save', function (saveDone) {
-
         var _idName = idName(Model);
         var modelName = Model.modelName;
         this._adapter().create(modelName, this.constructor._forDB(obj.toObject(true)), function (err, id, rev) {
@@ -232,8 +246,13 @@ DataAccessObject.create = function (data, callback) {
           obj.__persisted = true;
           saveDone.call(obj, function () {
             createDone.call(obj, function () {
-              callback(err, obj);
-              if(!err) Model.emit('changed', obj);
+              if (err) {
+                return callback(err, obj);
+              }
+              Model.notifyObserversOf('after save', { Model: Model, instance: obj }, function(err) {
+                callback(err, obj);
+                if(!err) Model.emit('changed', obj);
+              });
             });
           });
         }, obj);
@@ -267,45 +286,83 @@ DataAccessObject.updateOrCreate = DataAccessObject.upsert = function upsert(data
   }
   var self = this;
   var Model = this;
-  if (!getIdValue(this, data)) {
+  var id = getIdValue(this, data);
+  if (!id) {
     return this.create(data, callback);
   }
-  if (this.getDataSource().connector.updateOrCreate) {
-    var update = data;
-    var inst = data;
-    if(!(data instanceof Model)) {
-      inst = new Model(data);
+
+  Model.notifyObserversOf('query', { Model: Model, query: byIdQuery(Model, id) }, doUpdateOrCreate);
+
+  function doUpdateOrCreate(err, ctx) {
+    if (err) return callback(err);
+
+    var isOriginalQuery = isWhereByGivenId(Model, ctx.query.where, id)
+    if (Model.getDataSource().connector.updateOrCreate && isOriginalQuery) {
+      var context = { Model: Model, where: ctx.query.where, data: data };
+      Model.notifyObserversOf('before save', context, function(err, ctx) {
+        if (err) return callback(err);
+
+        data = ctx.data;
+        var update = data;
+        var inst = data;
+        if(!(data instanceof Model)) {
+          inst = new Model(data);
+        }
+        update = inst.toObject(false);
+
+        Model.applyProperties(update, inst);
+        Model = Model.lookupModel(update);
+
+        // FIXME(bajtos) validate the model!
+        // https://github.com/strongloop/loopback-datasource-juggler/issues/262
+
+        update = inst.toObject(true);
+        update = removeUndefined(update);
+        self.getDataSource().connector
+          .updateOrCreate(Model.modelName, update, done);
+
+        function done(err, data) {
+          var obj;
+          if (data && !(data instanceof Model)) {
+            inst._initProperties(data);
+            obj = inst;
+          } else {
+            obj = data;
+          }
+          if (err) {
+            callback(err, obj);
+            if(!err) {
+              Model.emit('changed', inst);
+            }
+          } else {
+            Model.notifyObserversOf('after save', { Model: Model, instance: obj }, function(err) {
+              callback(err, obj);
+              if(!err) {
+                Model.emit('changed', inst);
+              }
+            });
+          }
+        }
+      });
+    } else {
+      Model.findOne({ where: ctx.query.where }, { notify: false }, function (err, inst) {
+        if (err) {
+          return callback(err);
+        }
+        if (!isOriginalQuery) {
+          // The custom query returned from a hook may hide the fact that
+          // there is already a model with `id` value `data[idName(Model)]`
+          delete data[idName(Model)];
+        }
+        if (inst) {
+          inst.updateAttributes(data, callback);
+        } else {
+          Model = self.lookupModel(data);
+          var obj = new Model(data);
+          obj.save(data, callback);
+        }
+      });
     }
-    update = inst.toObject(false);
-    this.applyProperties(update, inst);
-    update = removeUndefined(update);
-    Model = this.lookupModel(update);
-    this.getDataSource().connector.updateOrCreate(Model.modelName, update, function (err, data) {
-      var obj;
-      if (data && !(data instanceof Model)) {
-        inst._initProperties(data);
-        obj = inst;
-      } else {
-        obj = data;
-      }
-      callback(err, obj);
-      if(!err) {
-        Model.emit('changed', inst);
-      }
-    });
-  } else {
-    this.findById(getIdValue(this, data), function (err, inst) {
-      if (err) {
-        return callback(err);
-      }
-      if (inst) {
-        inst.updateAttributes(data, callback);
-      } else {
-        Model = self.lookupModel(data);
-        var obj = new Model(data);
-        obj.save(data, callback);
-      }
-    });
   }
 };
 
@@ -332,64 +389,14 @@ DataAccessObject.findOrCreate = function findOrCreate(query, data, callback) {
     };
   }
 
-  var self = this;
-
-  if (this.getDataSource().connector.findOrCreate) {
-
-    try {
-      this._normalize(query);
-    } catch (err) {
-      return process.nextTick(function () {
-        callback && callback(err);
-      });
-    }
-
-    this.applyScope(query);
-
-    var enforced = {};
-    var Model = this.lookupModel(data);
-    var obj = data instanceof Model ? data : new Model(data);
-
-    this.applyProperties(enforced, obj);
-    obj.setAttributes(enforced);
-
-    data = obj.toObject(true);
-
-    // validation required
-    obj.isValid(function (valid) {
-      if (valid) {
-        findOrCreate();
-      } else {
-        callback(new ValidationError(obj), obj);
-      }
-    }, data);
-
-    function findOrCreate() {
-      var modelName = Model.modelName;
-      self.getDataSource().connector.findOrCreate(modelName, query, self._forDB(data), function (err, data, created) {
-        var obj, Model = self.lookupModel(data);
-
-        if (data) {
-          obj = new Model(data, {fields: query.fields, applySetters: false, persisted: true});
-        }
-
-        callback(err, obj, created);
-
-        if (obj && created) {
-          Model.emit('created', obj);
-        }
-      });
-    }
-
-  } else {
-    this.findOne(query, function (err, record) {
-      if (err) return callback(err);
-      if (record) return callback(null, record, false);
-      self.create(data, function (err, record) {
-        callback(err, record, record != null);
-      });
+  var Model = this;
+  Model.findOne(query, function (err, record) {
+    if (err) return callback(err);
+    if (record) return callback(null, record, false);
+    Model.create(data, function (err, record) {
+      callback(err, record, record != null);
     });
-  }
+  });
 };
 
 /**
@@ -433,13 +440,13 @@ DataAccessObject.findByIds = function(ids, cond, cb) {
     cb = cond;
     cond = {};
   }
-  
+
   var pk = idName(this);
   if (ids.length === 0) {
     process.nextTick(function() { cb(null, []); });
     return;
   }
-  
+
   var filter = { where: {} };
   filter.where[pk] = { inq: [].concat(ids) };
   mergeQuery(filter, cond || {});
@@ -781,17 +788,26 @@ DataAccessObject._coerce = function (where) {
  * @param {Function} callback Required callback function.  Call this function with two arguments: `err` (null or Error) and an array of instances.
  */
 
-DataAccessObject.find = function find(query, cb) {
+DataAccessObject.find = function find(query, options, cb) {
   if (stillConnecting(this.getDataSource(), this, arguments)) return;
 
   if (arguments.length === 1) {
     cb = query;
     query = null;
+    options = {};
   }
+
+  if (cb === undefined && typeof options === 'function') {
+    cb = options;
+    options = {};
+  }
+
+  if (!options) options = {};
+
   var self = this;
 
   query = query || {};
-  
+
   try {
     this._normalize(query);
   } catch (err) {
@@ -801,7 +817,7 @@ DataAccessObject.find = function find(query, cb) {
   }
 
   this.applyScope(query);
-  
+
   var near = query && geo.nearFilter(query.where);
   var supportsGeo = !!this.getDataSource().connector.buildNearFilter;
 
@@ -813,42 +829,48 @@ DataAccessObject.find = function find(query, cb) {
       // do in memory query
       // using all documents
       // TODO [fabien] use default scope here?
-      this.getDataSource().connector.all(this.modelName, {}, function (err, data) {
-        var memory = new Memory();
-        var modelName = self.modelName;
 
-        if (err) {
-          cb(err);
-        } else if (Array.isArray(data)) {
-          memory.define({
-            properties: self.dataSource.definitions[self.modelName].properties,
-            settings: self.dataSource.definitions[self.modelName].settings,
-            model: self
-          });
+      self.notifyObserversOf('query', { Model: self, query: query }, function(err, ctx) {
+        if (err) return cb(err);
 
-          data.forEach(function (obj) {
-            memory.create(modelName, obj, function () {
-              // noop
+        self.getDataSource().connector.all(self.modelName, {}, function (err, data) {
+          var memory = new Memory();
+          var modelName = self.modelName;
+
+          if (err) {
+            cb(err);
+          } else if (Array.isArray(data)) {
+            memory.define({
+              properties: self.dataSource.definitions[self.modelName].properties,
+              settings: self.dataSource.definitions[self.modelName].settings,
+              model: self
             });
-          });
 
-          memory.all(modelName, query, cb);
-        } else {
-          cb(null, []);
-        }
-      }.bind(this));
+            data.forEach(function (obj) {
+              memory.create(modelName, obj, function () {
+                // noop
+              });
+            });
+
+            // FIXME: apply "includes" and other transforms - see allCb below
+            memory.all(modelName, ctx.query, cb);
+          } else {
+            cb(null, []);
+          }
+        });
+      });
 
       // already handled
       return;
     }
   }
 
-  this.getDataSource().connector.all(this.modelName, query, function (err, data) {
+  var allCb = function (err, data) {
     if (data && data.forEach) {
       data.forEach(function (d, i) {
         var Model = self.lookupModel(d);
         var obj = new Model(d, {fields: query.fields, applySetters: false, persisted: true});
-        
+
         if (query && query.include) {
           if (query.collect) {
             // The collect property indicates that the query is to return the
@@ -865,7 +887,7 @@ DataAccessObject.find = function find(query, cb) {
               if (utils.isPlainObject(inc)) {
                 relationName = Object.keys(inc)[0];
               }
-              
+
               // Promote the included model as a direct property
               var data = obj.__cachedRelations[relationName];
               if(Array.isArray(data)) {
@@ -890,7 +912,18 @@ DataAccessObject.find = function find(query, cb) {
     }
     else
       cb(err, []);
-  });
+  }
+
+  var self = this;
+  if (options.notify === false) {
+    self.getDataSource().connector.all(self.modelName, query, allCb);
+  } else {
+    this.notifyObserversOf('query', { Model: this, query: query }, function(err, ctx) {
+      if (err) return cb(err);
+      var query = ctx.query;
+      self.getDataSource().connector.all(self.modelName, query, allCb);
+    });
+  }
 };
 
 /**
@@ -900,16 +933,22 @@ DataAccessObject.find = function find(query, cb) {
  * For example: `{where: {test: 'me'}}`.
  * @param {Function} cb Callback function called with (err, instance)
  */
-DataAccessObject.findOne = function findOne(query, cb) {
+DataAccessObject.findOne = function findOne(query, options, cb) {
   if (stillConnecting(this.getDataSource(), this, arguments)) return;
 
   if (typeof query === 'function') {
     cb = query;
     query = {};
   }
+
+  if (cb === undefined && typeof options === 'function') {
+    cb = options;
+    options = {};
+  }
+
   query = query || {};
   query.limit = 1;
-  this.find(query, function (err, collection) {
+  this.find(query, options, function (err, collection) {
     if (err || !collection || !collection.length > 0) return cb(err, null);
     cb(err, collection[0]);
   });
@@ -928,40 +967,78 @@ DataAccessObject.findOne = function findOne(query, cb) {
  * @param {Object} [where] Optional object that defines the criteria.  This is a "where" object. Do NOT pass a filter object.
  * @param {Function} [cb] Callback called with (err)
  */
-DataAccessObject.remove = DataAccessObject.deleteAll = DataAccessObject.destroyAll = function destroyAll(where, cb) {
+DataAccessObject.remove = DataAccessObject.deleteAll = DataAccessObject.destroyAll = function destroyAll(where, options, cb) {
   if (stillConnecting(this.getDataSource(), this, arguments)) return;
+
   var Model = this;
 
-  if (!cb && 'function' === typeof where) {
+  if (!cb && !options && 'function' === typeof where) {
     cb = where;
     where = undefined;
   }
-  
+
+  if (!cb && typeof options === 'function') {
+    cb = options;
+  }
+
+  if (!cb) cb = function(){};
+  if (!options) options = {};
+
   var query = { where: where };
   this.applyScope(query);
   where = query.where;
-  
-  if (!where || (typeof where === 'object' && Object.keys(where).length === 0)) {
-    this.getDataSource().connector.destroyAll(this.modelName, function (err, data) {
-      cb && cb(err, data);
-      if(!err) Model.emit('deletedAll');
-    }.bind(this));
+
+  var context = { Model: Model, where: whereIsEmpty(where) ? {} : where };
+  if (options.notify === false) {
+    doDelete(where);
   } else {
-    try {
-      // Support an optional where object
-      where = removeUndefined(where);
-      where = this._coerce(where);
-    } catch (err) {
-      return process.nextTick(function() {
-        cb && cb(err);
+    query = { where: whereIsEmpty(where) ? {} : where };
+    Model.notifyObserversOf('query',
+      { Model: Model, query: query },
+      function(err, ctx) {
+        if (err) return cb(err);
+        doDelete(ctx.query.where);
+      });
+  }
+
+  function doDelete(where) {
+    if (whereIsEmpty(where)) {
+      Model.getDataSource().connector.destroyAll(Model.modelName, done);
+    } else {
+      try {
+        // Support an optional where object
+        where = removeUndefined(where);
+        where = Model._coerce(where);
+      } catch (err) {
+        return process.nextTick(function() {
+          cb && cb(err);
+        });
+      }
+
+      Model.getDataSource().connector.destroyAll(Model.modelName, where, done);
+
+    }
+
+    function done(err, data) {
+      if (err) return cb(er);
+
+      if (options.notify === false) {
+        return cb(err, data);
+      }
+
+      Model.notifyObserversOf('after delete', { Model: Model, where: where }, function(err) {
+        cb(err, data);
+        if (!err)
+          Model.emit('deletedAll', whereIsEmpty(where) ? undefined : where);
       });
     }
-    this.getDataSource().connector.destroyAll(this.modelName, where, function (err, data) {
-      cb && cb(err, data);
-      if(!err) Model.emit('deletedAll', where);
-    }.bind(this));
   }
 };
+
+function whereIsEmpty(where) {
+  return !where ||
+     (typeof where === 'object' && Object.keys(where).length === 0)
+}
 
 /**
  * Delete the record with the specified ID.
@@ -976,7 +1053,7 @@ DataAccessObject.remove = DataAccessObject.deleteAll = DataAccessObject.destroyA
 DataAccessObject.removeById = DataAccessObject.destroyById = DataAccessObject.deleteById = function deleteById(id, cb) {
   if (stillConnecting(this.getDataSource(), this, arguments)) return;
   var Model = this;
-  
+
   this.remove(byIdQuery(this, id).where, function(err) {
     if ('function' === typeof cb) {
       cb(err);
@@ -1005,11 +1082,11 @@ DataAccessObject.count = function (where, cb) {
     cb = where;
     where = null;
   }
-  
+
   var query = { where: where };
   this.applyScope(query);
   where = query.where;
-  
+
   try {
     where = removeUndefined(where);
     where = this._coerce(where);
@@ -1018,8 +1095,13 @@ DataAccessObject.count = function (where, cb) {
       cb && cb(err);
     });
   }
-  
-  this.getDataSource().connector.count(this.modelName, cb, where);
+
+  var Model = this;
+  this.notifyObserversOf('query', { Model: Model, query: { where: where } }, function(err, ctx) {
+      if (err) return cb(err);
+      where = ctx.query.where;
+      Model.getDataSource().connector.count(Model.modelName, cb, where);
+    });
 };
 
 /**
@@ -1049,59 +1131,67 @@ DataAccessObject.prototype.save = function (options, callback) {
   if (!('throws' in options)) {
     options.throws = false;
   }
-  
+
   var inst = this;
   var data = inst.toObject(true);
   var modelName = Model.modelName;
-  
+
   Model.applyProperties(data, this);
-  
+
   if (this.isNewRecord()) {
     return Model.create(this, callback);
   } else {
     inst.setAttributes(data);
   }
 
-  // validate first
-  if (!options.validate) {
-    return save();
-  }
+  Model.notifyObserversOf('before save', { Model: Model, instance: inst }, function(err) {
+    if (err) return callback(err);
+    data = inst.toObject(true);
 
-  inst.isValid(function (valid) {
-    if (valid) {
-      save();
-    } else {
-      var err = new ValidationError(inst);
-      // throws option is dangerous for async usage
-      if (options.throws) {
-        throw err;
-      }
-      callback(err, inst);
+    // validate first
+    if (!options.validate) {
+      return save();
     }
-  });
 
-  // then save
-  function save() {
-    inst.trigger('save', function (saveDone) {
-      inst.trigger('update', function (updateDone) {
-        data = removeUndefined(data);
-        inst._adapter().save(modelName, inst.constructor._forDB(data), function (err) {
-          if (err) {
-            return callback(err, inst);
-          }
-          inst._initProperties(data, { persisted: true });
-          updateDone.call(inst, function () {
-            saveDone.call(inst, function () {
-              callback(err, inst);
-              if(!err) {
-                Model.emit('changed', inst);
-              }
+    inst.isValid(function (valid) {
+      if (valid) {
+        save();
+      } else {
+        var err = new ValidationError(inst);
+        // throws option is dangerous for async usage
+        if (options.throws) {
+          throw err;
+        }
+        callback(err, inst);
+      }
+    });
+
+    // then save
+    function save() {
+      inst.trigger('save', function (saveDone) {
+        inst.trigger('update', function (updateDone) {
+          data = removeUndefined(data);
+          inst._adapter().save(modelName, inst.constructor._forDB(data), function (err) {
+            if (err) {
+              return callback(err, inst);
+            }
+            inst._initProperties(data, { persisted: true });
+            Model.notifyObserversOf('after save', { Model: Model, instance: inst }, function(err) {
+              if (err) return callback(err, inst);
+              updateDone.call(inst, function () {
+                saveDone.call(inst, function () {
+                  callback(err, inst);
+                  if(!err) {
+                    Model.emit('changed', inst);
+                  }
+                });
+              });
             });
           });
-        });
+        }, data, callback);
       }, data, callback);
-    }, data, callback);
-  }
+    }
+  });
 };
 
 /**
@@ -1143,24 +1233,56 @@ DataAccessObject.updateAll = function (where, data, cb) {
   assert(typeof where === 'object', 'The where argument should be an object');
   assert(typeof data === 'object', 'The data argument should be an object');
   assert(cb === null || typeof cb === 'function', 'The cb argument should be a function');
-  
+
   var query = { where: where };
   this.applyScope(query);
   this.applyProperties(data);
-  
+
   where = query.where;
-  
-  try {
-    where = removeUndefined(where);
-    where = this._coerce(where);
-  } catch (err) {
-    return process.nextTick(function () {
-      cb && cb(err);
+
+  var Model = this;
+
+  Model.notifyObserversOf('query', { Model: Model, query: { where: where } }, function(err, ctx) {
+    if (err) return cb && cb(err);
+    Model.notifyObserversOf(
+      'before save',
+      {
+        Model: Model,
+        where: ctx.query.where,
+        data: data
+      },
+      function(err, ctx) {
+        if (err) return cb && cb(err);
+        doUpdate(ctx.where, ctx.data);
+      });
+  });
+
+
+  function doUpdate(where, data) {
+    try {
+      where = removeUndefined(where);
+      where = Model._coerce(where);
+    } catch (err) {
+      return process.nextTick(function () {
+        cb && cb(err);
+      });
+    }
+
+    var connector = Model.getDataSource().connector;
+    connector.update(Model.modelName, where, data, function(err, count) {
+      if (err) return cb && cb (err);
+      Model.notifyObserversOf(
+        'after save',
+        {
+          Model: Model,
+          where: where,
+          data: data
+        },
+        function(err, ctx) {
+          return cb && cb(err, count);
+        });
     });
   }
-  
-  var connector = this.getDataSource().connector;
-  connector.update(this.modelName, where, data, cb);
 };
 
 DataAccessObject.prototype.isNewRecord = function () {
@@ -1184,23 +1306,50 @@ DataAccessObject.prototype.remove =
   DataAccessObject.prototype.delete =
     DataAccessObject.prototype.destroy = function (cb) {
       if (stillConnecting(this.getDataSource(), this, arguments)) return;
+      var self = this;
       var Model = this.constructor;
       var id = getIdValue(this.constructor, this);
 
-      this.trigger('destroy', function (destroyed) {
-        this._adapter().destroy(this.constructor.modelName, id, function (err) {
-          if (err) {
-            return cb(err);
-          }
+      Model.notifyObserversOf(
+        'query',
+        { Model: Model, query: byIdQuery(Model, id) },
+        function(err, ctx) {
+          if (err) return cb(err);
+          doDeleteInstance(ctx.query.where);
+        });
 
-          destroyed(function () {
-            if (cb) cb();
-            Model.emit('deleted', id);
+      function doDeleteInstance(where) {
+        if (!isWhereByGivenId(Model, where, id)) {
+          // A hook modified the query, it is no longer
+          // a simple 'delete model with the given id'.
+          // We must switch to full query-based delete.
+          Model.deleteAll(where, { notify: false }, function(err) {
+            if (err) return cb && cb(err);
+            Model.notifyObserversOf('after delete', { Model: Model, where: where }, function(err) {
+              cb && cb(err);
+              if (!err) Model.emit('deleted', id);
+            });
           });
-        }.bind(this));
-      }, null, cb);
+          return;
+        }
+
+        self.trigger('destroy', function (destroyed) {
+          self._adapter().destroy(self.constructor.modelName, id, function (err) {
+            if (err) {
+              return cb(err);
+            }
+
+            destroyed(function () {
+              Model.notifyObserversOf('after delete', { Model: Model, where: where }, function(err) {
+                cb && cb(err);
+                if (!err) Model.emit('deleted', id);
+              });
+            });
+          });
+        }, null, cb);
+      }
     };
-    
+
 /**
  * Set a single attribute.
  * Equivalent to `setAttributes({name: value})`
@@ -1210,7 +1359,7 @@ DataAccessObject.prototype.remove =
  */
 DataAccessObject.prototype.setAttribute = function setAttribute(name, value) {
   this[name] = value; // TODO [fabien] - currently not protected by applyProperties
-};    
+};
 
 /**
  * Update a single attribute.
@@ -1234,17 +1383,17 @@ DataAccessObject.prototype.updateAttribute = function updateAttribute(name, valu
  */
 DataAccessObject.prototype.setAttributes = function setAttributes(data) {
   if (typeof data !== 'object') return;
-  
+
   this.constructor.applyProperties(data, this);
-  
+
   var Model = this.constructor;
   var inst = this;
-  
+
   // update instance's properties
   for (var key in data) {
     inst.setAttribute(key, data[key]);
   }
-  
+
   Model.emit('set', inst);
 };
 
@@ -1281,15 +1430,29 @@ DataAccessObject.prototype.updateAttributes = function updateAttributes(data, cb
     data = {};
   }
 
-  // update instance's properties
-  inst.setAttributes(data);
+  if (!cb) {
+    cb = function() {};
+  }
 
-  inst.isValid(function (valid) {
-    if (!valid) {
-      if (cb) {
+  var context = {
+    Model: Model,
+    where: byIdQuery(Model, getIdValue(Model, inst)).where,
+    data: data
+  };
+
+  Model.notifyObserversOf('before save', context, function(err, ctx) {
+    if (err) return cb(err);
+    data = ctx.data;
+
+    // update instance's properties
+    inst.setAttributes(data);
+
+    inst.isValid(function (valid) {
+      if (!valid) {
         cb(new ValidationError(inst), inst);
+        return;
       }
-    } else {
+
       inst.trigger('save', function (saveDone) {
         inst.trigger('update', function (done) {
           var typedData = {};
@@ -1298,7 +1461,7 @@ DataAccessObject.prototype.updateAttributes = function updateAttributes(data, cb
             // Convert the properties by type
             inst[key] = data[key];
             typedData[key] = inst[key];
-            if (typeof typedData[key] === 'object' 
+            if (typeof typedData[key] === 'object'
               && typedData[key] !== null
               && typeof typedData[key].toObject === 'function') {
               typedData[key] = typedData[key].toObject();
@@ -1310,15 +1473,18 @@ DataAccessObject.prototype.updateAttributes = function updateAttributes(data, cb
             if (!err) inst.__persisted = true;
             done.call(inst, function () {
               saveDone.call(inst, function () {
-                if(cb) cb(err, inst);
-                if(!err) Model.emit('changed', inst);
+                if (err) return cb(err, inst);
+                Model.notifyObserversOf('after save', { Model: Model, instance: inst }, function(err) {
+                  if(!err) Model.emit('changed', inst);
+                  cb(err, inst);
+                });
               });
             });
           });
         }, data, cb);
       }, data, cb);
-    }
-  }, data);
+    }, data);
+  });
 };
 
 /**

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -315,7 +315,6 @@ DataAccessObject.updateOrCreate = DataAccessObject.upsert = function upsert(data
         // FIXME(bajtos) validate the model!
         // https://github.com/strongloop/loopback-datasource-juggler/issues/262
 
-        update = inst.toObject(true);
         update = removeUndefined(update);
         self.getDataSource().connector
           .updateOrCreate(Model.modelName, update, done);

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -372,9 +372,11 @@ DataAccessObject.updateOrCreate = DataAccessObject.upsert = function upsert(data
  * @param {Object} query Search conditions. See [find](#dataaccessobjectfindquery-callback) for query format.
  * For example: `{where: {test: 'me'}}`.
  * @param {Object} data Object to create.
- * @param {Function} cb Callback called with (err, instance, created)
+ * @param {Function} callback Callback called with (err, instance, created)
  */
 DataAccessObject.findOrCreate = function findOrCreate(query, data, callback) {
+  if (stillConnecting(this.getDataSource(), this, arguments)) return;
+
   if (query === undefined) {
     query = {where: {}};
   }
@@ -387,14 +389,80 @@ DataAccessObject.findOrCreate = function findOrCreate(query, data, callback) {
     };
   }
 
+  var self = this;
   var Model = this;
-  Model.findOne(query, function (err, record) {
-    if (err) return callback(err);
-    if (record) return callback(null, record, false);
-    Model.create(data, function (err, record) {
-      callback(err, record, record != null);
+
+  if (this.getDataSource().connector.findOrCreate) {
+    query.limit = 1;
+
+    try {
+      this._normalize(query);
+    } catch (err) {
+      return process.nextTick(function () {
+        callback && callback(err);
+      });
+    }
+
+    this.applyScope(query);
+
+    Model.notifyObserversOf('access', { Model: Model, query: query }, function (err, ctx) {
+      if (err) return callback(err);
+
+      var query = ctx.query;
+
+      var enforced = {};
+      var Model = self.lookupModel(data);
+      var obj = data instanceof Model ? data : new Model(data);
+
+      Model.applyProperties(enforced, obj);
+      obj.setAttributes(enforced);
+
+      Model.notifyObserversOf('before save', { Model: Model, instance: obj }, function(err, ctx) {
+        if (err) return callback(err);
+
+        var obj = ctx.instance;
+        var data = obj.toObject(true);
+
+        // validation required
+        obj.isValid(function (valid) {
+          if (valid) {
+            findOrCreate(query, data);
+          } else {
+            callback(new ValidationError(obj), obj);
+          }
+        }, data);
+      });
+
     });
-  });
+
+    function findOrCreate(query, data) {
+      var modelName = Model.modelName;
+      self.getDataSource().connector.findOrCreate(modelName, query, self._forDB(data), function (err, data, created) {
+        var obj, Model = self.lookupModel(data);
+
+        if (data) {
+          obj = new Model(data, {fields: query.fields, applySetters: false, persisted: true});
+        }
+
+        if (created) {
+          Model.notifyObserversOf('after save', { Model: Model, instance: obj }, function(err) {
+            callback(err, obj, created);
+            if(!err) Model.emit('changed', obj);
+          });
+        } else {
+          callback(err, obj, created);
+        }
+      });
+    }
+  } else {
+    Model.findOne(query, function (err, record) {
+      if (err) return callback(err);
+      if (record) return callback(null, record, false);
+      Model.create(data, function (err, record) {
+        callback(err, record, record != null);
+      });
+    });
+  }
 };
 
 /**

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1433,6 +1433,12 @@ DataAccessObject.prototype.updateAttributes = function updateAttributes(data, cb
     cb = function() {};
   }
 
+  // Convert the data to be plain object so that update won't be confused
+  if (data instanceof Model) {
+    data = data.toObject(false);
+  }
+  data = removeUndefined(data);
+
   var context = {
     Model: Model,
     where: byIdQuery(Model, getIdValue(Model, inst)).where,

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1131,21 +1131,19 @@ DataAccessObject.prototype.save = function (options, callback) {
     options.throws = false;
   }
 
-  var inst = this;
-  var data = inst.toObject(true);
-  var modelName = Model.modelName;
-
-  Model.applyProperties(data, this);
-
   if (this.isNewRecord()) {
     return Model.create(this, callback);
-  } else {
-    inst.setAttributes(data);
   }
+
+  var inst = this;
+  var modelName = Model.modelName;
 
   Model.notifyObserversOf('before save', { Model: Model, instance: inst }, function(err) {
     if (err) return callback(err);
-    data = inst.toObject(true);
+
+    var data = inst.toObject(true);
+    Model.applyProperties(data, inst);
+    inst.setAttributes(data);
 
     // validate first
     if (!options.validate) {

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -332,14 +332,64 @@ DataAccessObject.findOrCreate = function findOrCreate(query, data, callback) {
     };
   }
 
-  var t = this;
-  this.findOne(query, function (err, record) {
-    if (err) return callback(err);
-    if (record) return callback(null, record, false);
-    t.create(data, function (err, record) {
-      callback(err, record, record != null);
+  var self = this;
+
+  if (this.getDataSource().connector.findOrCreate) {
+
+    try {
+      this._normalize(query);
+    } catch (err) {
+      return process.nextTick(function () {
+        callback && callback(err);
+      });
+    }
+
+    this.applyScope(query);
+
+    var enforced = {};
+    var Model = this.lookupModel(data);
+    var obj = data instanceof Model ? data : new Model(data);
+
+    this.applyProperties(enforced, obj);
+    obj.setAttributes(enforced);
+
+    data = obj.toObject(true);
+
+    // validation required
+    obj.isValid(function (valid) {
+      if (valid) {
+        findOrCreate();
+      } else {
+        callback(new ValidationError(obj), obj);
+      }
+    }, data);
+
+    function findOrCreate() {
+      var modelName = Model.modelName;
+      self.getDataSource().connector.findOrCreate(modelName, query, self._forDB(data), function (err, data, created) {
+        var obj, Model = self.lookupModel(data);
+
+        if (data) {
+          obj = new Model(data, {fields: query.fields, applySetters: false, persisted: true});
+        }
+
+        callback(err, obj, created);
+
+        if (obj && created) {
+          Model.emit('created', obj);
+        }
+      });
+    }
+
+  } else {
+    this.findOne(query, function (err, record) {
+      if (err) return callback(err);
+      if (record) return callback(null, record, false);
+      self.create(data, function (err, record) {
+        callback(err, record, record != null);
+      });
     });
-  });
+  }
 };
 
 /**

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -290,7 +290,7 @@ DataAccessObject.updateOrCreate = DataAccessObject.upsert = function upsert(data
     return this.create(data, callback);
   }
 
-  Model.notifyObserversOf('query', { Model: Model, query: byIdQuery(Model, id) }, doUpdateOrCreate);
+  Model.notifyObserversOf('access', { Model: Model, query: byIdQuery(Model, id) }, doUpdateOrCreate);
 
   function doUpdateOrCreate(err, ctx) {
     if (err) return callback(err);
@@ -828,7 +828,7 @@ DataAccessObject.find = function find(query, options, cb) {
       // using all documents
       // TODO [fabien] use default scope here?
 
-      self.notifyObserversOf('query', { Model: self, query: query }, function(err, ctx) {
+      self.notifyObserversOf('access', { Model: self, query: query }, function(err, ctx) {
         if (err) return cb(err);
 
         self.getDataSource().connector.all(self.modelName, {}, function (err, data) {
@@ -916,7 +916,7 @@ DataAccessObject.find = function find(query, options, cb) {
   if (options.notify === false) {
     self.getDataSource().connector.all(self.modelName, query, allCb);
   } else {
-    this.notifyObserversOf('query', { Model: this, query: query }, function(err, ctx) {
+    this.notifyObserversOf('access', { Model: this, query: query }, function(err, ctx) {
       if (err) return cb(err);
       var query = ctx.query;
       self.getDataSource().connector.all(self.modelName, query, allCb);
@@ -991,7 +991,7 @@ DataAccessObject.remove = DataAccessObject.deleteAll = DataAccessObject.destroyA
     doDelete(where);
   } else {
     query = { where: whereIsEmpty(where) ? {} : where };
-    Model.notifyObserversOf('query',
+    Model.notifyObserversOf('access',
       { Model: Model, query: query },
       function(err, ctx) {
         if (err) return cb(err);
@@ -1099,7 +1099,7 @@ DataAccessObject.count = function (where, cb) {
   }
 
   var Model = this;
-  this.notifyObserversOf('query', { Model: Model, query: { where: where } }, function(err, ctx) {
+  this.notifyObserversOf('access', { Model: Model, query: { where: where } }, function(err, ctx) {
       if (err) return cb(err);
       where = ctx.query.where;
       Model.getDataSource().connector.count(Model.modelName, cb, where);
@@ -1242,7 +1242,7 @@ DataAccessObject.updateAll = function (where, data, cb) {
 
   var Model = this;
 
-  Model.notifyObserversOf('query', { Model: Model, query: { where: where } }, function(err, ctx) {
+  Model.notifyObserversOf('access', { Model: Model, query: { where: where } }, function(err, ctx) {
     if (err) return cb && cb(err);
     Model.notifyObserversOf(
       'before save',
@@ -1311,7 +1311,7 @@ DataAccessObject.prototype.remove =
       var id = getIdValue(this.constructor, this);
 
       Model.notifyObserversOf(
-        'query',
+        'access',
         { Model: Model, query: byIdQuery(Model, id) },
         function(err, ctx) {
           if (err) return cb(err);

--- a/lib/list.js
+++ b/lib/list.js
@@ -72,11 +72,11 @@ List.prototype.push = function (obj) {
   return item;
 };
 
-List.prototype.toObject = function (onlySchema, removeHidden) {
+List.prototype.toObject = function (onlySchema, removeHidden, removeProtected) {
   var items = [];
   this.forEach(function (item) {
     if (item && typeof item === 'object' && item.toObject) {
-      items.push(item.toObject(onlySchema, removeHidden));
+      items.push(item.toObject(onlySchema, removeHidden, removeProtected));
     } else {
       items.push(item);
     }

--- a/lib/model-builder.js
+++ b/lib/model-builder.js
@@ -29,7 +29,7 @@ var slice = Array.prototype.slice;
 
 /**
  * ModelBuilder - A builder to define data models.
- * 
+ *
  * @property {Object} definitions Definitions of the models.
  * @property {Object} models Model constructors
  * @class
@@ -57,7 +57,7 @@ function isModelClass(cls) {
 
 /**
  * Get a model by name.
- * 
+ *
  * @param {String} name The model name
  * @param {Boolean} forceCreate Whether the create a stub for the given name if a model doesn't exist.
  * @returns {*} The model class
@@ -101,7 +101,7 @@ ModelBuilder.prototype.getModelDefinition = function (name) {
  * });
  * ```
  *
- * @param {String} className Name of class 
+ * @param {String} className Name of class
  * @param {Object} properties Hash of class properties in format `{property: Type, property2: Type2, ...}` or `{property: {type: Type}, property2: {type: Type2}, ...}`
  * @param {Object} settings Other configuration of class
  * @return newly created class
@@ -112,10 +112,10 @@ ModelBuilder.prototype.define = function defineClass(className, properties, sett
   var args = slice.call(arguments);
   var pluralName = (settings && settings.plural) ||
     inflection.pluralize(className);
-  
+
   var httpOptions = (settings && settings.http) || {};
   var pathName = httpOptions.path || pluralName;
-  
+
   if (!className) {
     throw new Error('Class name required');
   }
@@ -199,6 +199,7 @@ ModelBuilder.prototype.define = function defineClass(className, properties, sett
   hiddenProperty(ModelClass, 'relations', {});
   hiddenProperty(ModelClass, 'http', { path: '/' + pathName });
   hiddenProperty(ModelClass, 'base', ModelBaseClass);
+  hiddenProperty(ModelClass, '_observers', {});
 
   // inherit ModelBaseClass static methods
   for (var i in ModelBaseClass) {
@@ -305,12 +306,12 @@ ModelBuilder.prototype.define = function defineClass(className, properties, sett
    * ```js
    * var user = loopback.Model.extend('user', properties, options);
    * ```
-   * 
+   *
    * @param {String} className Name of the new model being defined.
    * @options {Object} properties Properties to define for the model, added to properties of model being extended.
    * @options {Object} settings Model settings, such as relations and acls.
    *
-   */ 
+   */
   ModelClass.extend = function (className, subclassProperties, subclassSettings) {
     var properties = ModelClass.definition.properties;
     var settings = ModelClass.definition.settings;
@@ -462,7 +463,7 @@ ModelBuilder.prototype.define = function defineClass(className, properties, sett
       modelBuilder.mixins.applyMixin(ModelClass, name, mixin);
     }
   }
-  
+
   ModelClass.emit('defined', ModelClass);
 
   return ModelClass;
@@ -500,7 +501,7 @@ ModelBuilder.prototype.defineValueType = function(type, aliases) {
  *
  * Example:
  * Instead of extending a model with attributes like this (for example):
- * 
+ *
  * ```js
  *     db.defineProperty('Content', 'competitionType',
  *       { type: String });
@@ -519,7 +520,7 @@ ModelBuilder.prototype.defineValueType = function(type, aliases) {
  *```
  *
  * @param {String} model Name of model
- * @options {Object} properties JSON object specifying properties.  Each property is a key whos value is 
+ * @options {Object} properties JSON object specifying properties.  Each property is a key whos value is
  * either the [type](http://docs.strongloop.com/display/LB/LoopBack+types) or `propertyName: {options}`
  * where the options are described below.
  * @property {String} type Datatype of property: Must be an [LDL type](http://docs.strongloop.com/display/LB/LoopBack+types).

--- a/lib/model-builder.js
+++ b/lib/model-builder.js
@@ -266,7 +266,8 @@ ModelBuilder.prototype.define = function defineClass(className, properties, sett
       get: function () {
         var compositeId = {};
         var idNames = ModelClass.definition.idNames();
-        for (var p in idNames) {
+        for (var i = 0, p; i < idNames.length; i++) {
+          p = idNames[i];
           compositeId[p] = this.__data[p];
         }
         return compositeId;

--- a/lib/model-definition.js
+++ b/lib/model-definition.js
@@ -141,7 +141,7 @@ ModelDefinition.prototype.ids = function () {
     ids.push({name: key, id: id, property: props[key]});
   }
   ids.sort(function (a, b) {
-    return a.key - b.key;
+    return a.id - b.id;
   });
   this._ids = ids;
   return ids;

--- a/lib/model.js
+++ b/lib/model.js
@@ -13,6 +13,8 @@ var List = require('./list');
 var Hookable = require('./hooks');
 var validations = require('./validations');
 var _extend = util._extend;
+var utils = require('./utils');
+var fieldsToArray = utils.fieldsToArray;
 
 // Set up an object for quick lookup
 var BASE_TYPES = {
@@ -170,7 +172,16 @@ ModelBaseClass.prototype._initProperties = function (data, options) {
       if (relationType === 'belongsTo' && propVal != null) {
         // If the related model is populated
         self.__data[ctor.relations[p].keyFrom] = propVal[ctor.relations[p].keyTo];
+
+        if (ctor.relations[p].options.embedsProperties) {
+          var fields = fieldsToArray(ctor.relations[p].properties, modelTo.definition.properties);
+          if (!~fields.indexOf(ctor.relations[p].keyTo)) {
+            fields.push(ctor.relations[p].keyTo);
+          }
+          self.__data[p] = new modelTo(propVal, { fields: fields, applySetters: false, persisted: options.persisted });
+        }
       }
+
       self.__cachedRelations[p] = propVal;
     } else {
       // Un-managed property

--- a/lib/model.js
+++ b/lib/model.js
@@ -302,7 +302,7 @@ ModelBaseClass.toString = function () {
  *
  * @param {Boolean} onlySchema Restrict properties to dataSource only.  Default is false.  If true, the function returns only properties defined in the schema;  Otherwise it returns all enumerable properties.
  */
-ModelBaseClass.prototype.toObject = function (onlySchema, removeHidden) {
+ModelBaseClass.prototype.toObject = function (onlySchema, removeHidden, removeProtected) {
   if (onlySchema === undefined) {
     onlySchema = true;
   }
@@ -334,11 +334,15 @@ ModelBaseClass.prototype.toObject = function (onlySchema, removeHidden) {
       continue;
     }
 
+    if (removeProtected && Model.isProtectedProperty(propertyName)) {
+      continue;
+    }
+
     if (val instanceof List) {
-      data[propertyName] = val.toObject(!schemaLess, removeHidden);
+      data[propertyName] = val.toObject(!schemaLess, removeHidden, true);
     } else {
       if (val !== undefined && val !== null && val.toObject) {
-        data[propertyName] = val.toObject(!schemaLess, removeHidden);
+        data[propertyName] = val.toObject(!schemaLess, removeHidden, true);
       } else {
         data[propertyName] = val;
       }
@@ -362,13 +366,16 @@ ModelBaseClass.prototype.toObject = function (onlySchema, removeHidden) {
       if (removeHidden && Model.isHiddenProperty(propertyName)) {
         continue;
       }
+      if (removeProtected && Model.isProtectedProperty(propertyName)) {
+        continue;
+      }
       val = self[propertyName];
       if (val !== undefined && data[propertyName] === undefined) {
         if (typeof val === 'function') {
           continue;
         }
         if (val !== null && val.toObject) {
-          data[propertyName] = val.toObject(!schemaLess, removeHidden);
+          data[propertyName] = val.toObject(!schemaLess, removeHidden, true);
         } else {
           data[propertyName] = val;
         }
@@ -386,16 +393,18 @@ ModelBaseClass.prototype.toObject = function (onlySchema, removeHidden) {
         if (removeHidden && Model.isHiddenProperty(propertyName)) {
           continue;
         }
+        if (removeHidden && Model.isProtectedProperty(propertyName)) {
+          continue;
+        }
         var ownVal = self[propertyName];
         // The ownVal can be a relation function
-        val = (ownVal !== undefined && (typeof ownVal !== 'function'))
-          ? ownVal : self.__data[propertyName];
+        val = (ownVal !== undefined && (typeof ownVal !== 'function')) ? ownVal : self.__data[propertyName];
         if (typeof val === 'function') {
           continue;
         }
 
         if (val !== undefined && val !== null && val.toObject) {
-          data[propertyName] = val.toObject(!schemaLess, removeHidden);
+          data[propertyName] = val.toObject(!schemaLess, removeHidden, true);
         } else {
           data[propertyName] = val;
         }
@@ -404,6 +413,25 @@ ModelBaseClass.prototype.toObject = function (onlySchema, removeHidden) {
   }
 
   return data;
+};
+
+ModelBaseClass.isProtectedProperty = function (propertyName) {
+  var model = this;
+  var settings = Model.definition && Model.definition.settings;
+  var protectedProperties = settings & (settings.protectedProperties || settings.protected);
+
+  if (Array.isArray(protectedProperties)) {
+    settings.protectedProperties = {};
+    for (var i = 0; i < protectedProperties.length; i++) {
+      settings.protectedProperties[protectedProperties[i]] = true;
+    }
+    protectedProperties = settings.protectedProperties;
+  }
+  if (protectedProperties) {
+    return protectedProperties[propertyName];
+  } else {
+    return false;
+  }
 };
 
 ModelBaseClass.isHiddenProperty = function (propertyName) {
@@ -423,10 +451,10 @@ ModelBaseClass.isHiddenProperty = function (propertyName) {
   } else {
     return false;
   }
-}
+};
 
 ModelBaseClass.prototype.toJSON = function () {
-  return this.toObject(false, true);
+  return this.toObject(false, true, false);
 };
 
 ModelBaseClass.prototype.fromObject = function (obj) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -7,6 +7,7 @@ module.exports = ModelBaseClass;
  * Module dependencies
  */
 
+var async = require('async');
 var util = require('util');
 var jutil = require('./jutil');
 var List = require('./list');
@@ -531,6 +532,53 @@ ModelBaseClass.getDataSource = function () {
 ModelBaseClass.prototype.setStrict = function (strict) {
   this.__strict = strict;
 };
+
+/**
+ * Register an asynchronous observer for the given operation (event).
+ * @param {String} operation The operation name.
+ * @callback {function} listener The listener function. It will be invoked with
+ * `this` set to the model constructor, e.g. `User`.
+ * @param {Object} context Operation-specific context.
+ * @param {function(Error=)} next The callback to call when the observer
+ *   has finished.
+ * @end
+ */
+ModelBaseClass.observe = function(operation, listener) {
+  if (!this._observers[operation]) {
+    this._observers[operation] = [];
+  }
+
+  this._observers[operation].push(listener);
+};
+
+/**
+ * Invoke all async observers for the given operation.
+ * @param {String} operation The operation name.
+ * @param {Object} context Operation-specific context.
+ * @param {function(Error=)} callback The callback to call when all observers
+ *   has finished.
+ */
+ModelBaseClass.notifyObserversOf = function(operation, context, callback) {
+  var observers = this._observers && this._observers[operation];
+
+  this._notifyBaseObservers(operation, context, function doNotify(err) {
+    if (err) return callback(err, context);
+    if (!observers || !observers.length) return callback(null, context);
+
+    async.eachSeries(
+      observers,
+      function(fn, next) { fn(context, next); },
+      function(err) { callback(err, context) }
+    );
+  });
+}
+
+ModelBaseClass._notifyBaseObservers = function(operation, context, callback) {
+  if (this.base && this.base.notifyObserversOf)
+    this.base.notifyObserversOf(operation, context, callback);
+  else
+    callback();
+}
 
 jutil.mixin(ModelBaseClass, Hookable);
 jutil.mixin(ModelBaseClass, validations.Validatable);

--- a/lib/model.js
+++ b/lib/model.js
@@ -321,6 +321,7 @@ ModelBaseClass.prototype.toObject = function (onlySchema, removeHidden, removePr
   var props = Model.definition.properties;
   var keys = Object.keys(props);
   var propertyName, val;
+
   for (var i = 0; i < keys.length; i++) {
     propertyName = keys[i];
     val = self[propertyName];
@@ -393,7 +394,7 @@ ModelBaseClass.prototype.toObject = function (onlySchema, removeHidden, removePr
         if (removeHidden && Model.isHiddenProperty(propertyName)) {
           continue;
         }
-        if (removeHidden && Model.isProtectedProperty(propertyName)) {
+        if (removeProtected && Model.isProtectedProperty(propertyName)) {
           continue;
         }
         var ownVal = self[propertyName];
@@ -416,11 +417,11 @@ ModelBaseClass.prototype.toObject = function (onlySchema, removeHidden, removePr
 };
 
 ModelBaseClass.isProtectedProperty = function (propertyName) {
-  var model = this;
+  var Model = this;
   var settings = Model.definition && Model.definition.settings;
-  var protectedProperties = settings & (settings.protectedProperties || settings.protected);
-
+  var protectedProperties = settings && (settings.protectedProperties || settings.protected);
   if (Array.isArray(protectedProperties)) {
+    // Cache the protected properties as an object for quick lookup
     settings.protectedProperties = {};
     for (var i = 0; i < protectedProperties.length; i++) {
       settings.protectedProperties[protectedProperties[i]] = true;

--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -213,7 +213,7 @@ RelationDefinition.prototype.applyProperties = function(modelInstance, obj) {
     target[this.keyTo] = source[this.keyTo];
   }
   if (typeof this.properties === 'function') {
-    var data = this.properties.call(this, source);
+    var data = this.properties.call(this, source, target);
     for(var k in data) {
       target[k] = data[k];
     }

--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -1490,12 +1490,26 @@ RelationDefinition.hasOne = function (modelFrom, modelTo, params) {
   // FIXME: [rfeng] Wrap the property into a function for remoting
   // so that it can be accessed as /api/<model>/<id>/<hasOneRelationName>
   // For example, /api/orders/1/customer
-  var fn = function() {
+  modelFrom.prototype['__get__' + relationName] = function() {
     var f = this[relationName];
     f.apply(this, arguments);
   };
-  modelFrom.prototype['__get__' + relationName] = fn;
-  
+
+  modelFrom.prototype['__create__' + relationName] = function() {
+    var f = this[relationName].create;
+    f.apply(this, arguments);
+  };
+
+  modelFrom.prototype['__update__' + relationName] = function() {
+    var f = this[relationName].update;
+    f.apply(this, arguments);
+  };
+
+  modelFrom.prototype['__destroy__' + relationName] = function() {
+    var f = this[relationName].destroy;
+    f.apply(this, arguments);
+  };
+
   return definition;
 };
 
@@ -1545,10 +1559,12 @@ HasOne.prototype.create = function (targetModelData, cb) {
   });
 };
 
-HasOne.prototype.update = function (targetModelData, cb) {
+HasOne.prototype.update = function(targetModelData, cb) {
   var definition = this.definition;
+  var fk = this.definition.keyTo;
   this.fetch(function(err, targetModel) {
     if (targetModel instanceof ModelBaseClass) {
+      delete targetModelData[fk];
       targetModel.updateAttributes(targetModelData, cb);
     } else {
       cb(new Error('HasOne relation ' + definition.name

--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -208,10 +208,19 @@ RelationDefinition.prototype.applyProperties = function(modelInstance, obj) {
   if (this.options.invertProperties) {
     source = obj, target = modelInstance;
   }
+  if (this.options.embedsProperties) {
+    target = target.__data[this.name] = {};
+    target[this.keyTo] = source[this.keyTo];
+  }
   if (typeof this.properties === 'function') {
     var data = this.properties.call(this, source);
     for(var k in data) {
       target[k] = data[k];
+    }
+  } else if (Array.isArray(this.properties)) {
+    for(var k = 0; k < this.properties.length; k++) {
+      var key = this.properties[k];
+      target[key] = source[key];
     }
   } else if (typeof this.properties === 'object') {
     for(var k in this.properties) {
@@ -1309,7 +1318,7 @@ BelongsTo.prototype.related = function (refresh, params) {
     }
     
     var cb = params;
-    if (cachedValue === undefined) {
+    if (cachedValue === undefined || !(cachedValue instanceof ModelBaseClass)) {
       var query = {where: {}};
       query.where[pk] = modelInstance[fk];
       

--- a/lib/validations.js
+++ b/lib/validations.js
@@ -589,8 +589,7 @@ var defaultMessages = {
 };
 
 function nullCheck(attr, conf, err) {
-  var isNull = this[attr] === null || !(attr in this);
-  if (isNull) {
+  if (this[attr] == null) {
     if (!conf.allowNull) {
       err('null');
     }

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "node >= 0.6"
   ],
   "devDependencies": {
-    "should": "~1.2.2",
-    "mocha": "~1.20.1"
+    "mocha": "~1.20.1",
+    "should": "^1.3.0"
   },
   "dependencies": {
     "async": "~0.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback-datasource-juggler",
-  "version": "2.14.1",
+  "version": "2.15.0",
   "description": "LoopBack DataSoure Juggler",
   "keywords": [
     "StrongLoop",

--- a/test/async-observer.test.js
+++ b/test/async-observer.test.js
@@ -1,0 +1,103 @@
+var ModelBuilder = require('../').ModelBuilder;
+var should = require('./init');
+
+describe('async observer', function() {
+  var TestModel;
+  beforeEach(function defineTestModel() {
+    var modelBuilder = new ModelBuilder();
+    TestModel = modelBuilder.define('TestModel', { name: String });
+  });
+
+  it('calls registered async observers', function(done) {
+    var notifications = [];
+    TestModel.observe('before', pushAndNext(notifications, 'before'));
+    TestModel.observe('after', pushAndNext(notifications, 'after'));
+
+    TestModel.notifyObserversOf('before', {}, function(err) {
+      if (err) return done(err);
+      notifications.push('call');
+      TestModel.notifyObserversOf('after', {}, function(err) {
+        if (err) return done(err);
+
+        notifications.should.eql(['before', 'call', 'after']);
+        done();
+      });
+    });
+  });
+
+  it('allows multiple observers for the same operation', function(done) {
+    var notifications = [];
+    TestModel.observe('event', pushAndNext(notifications, 'one'));
+    TestModel.observe('event', pushAndNext(notifications, 'two'));
+
+    TestModel.notifyObserversOf('event', {}, function(err) {
+      if (err) return done(err);
+      notifications.should.eql(['one', 'two']);
+      done();
+    });
+  });
+
+  it('inherits observers from base model', function(done) {
+    var notifications = [];
+    TestModel.observe('event', pushAndNext(notifications, 'base'));
+
+    var Child = TestModel.extend('Child');
+    Child.observe('event', pushAndNext(notifications, 'child'));
+
+    Child.notifyObserversOf('event', {}, function(err) {
+      if (err) return done(err);
+      notifications.should.eql(['base', 'child']);
+      done();
+    });
+  });
+
+  it('does not modify observers in the base model', function(done) {
+    var notifications = [];
+    TestModel.observe('event', pushAndNext(notifications, 'base'));
+
+    var Child = TestModel.extend('Child');
+    Child.observe('event', pushAndNext(notifications, 'child'));
+
+    TestModel.notifyObserversOf('event', {}, function(err) {
+      if (err) return done(err);
+      notifications.should.eql(['base']);
+      done();
+    });
+  });
+
+  it('always calls inherited observers', function(done) {
+    var notifications = [];
+    TestModel.observe('event', pushAndNext(notifications, 'base'));
+
+    var Child = TestModel.extend('Child');
+    // Important: there are no observers on the Child model
+
+    Child.notifyObserversOf('event', {}, function(err) {
+      if (err) return done(err);
+      notifications.should.eql(['base']);
+      done();
+    });
+  });
+
+  it('handles no observers', function(done) {
+    TestModel.notifyObserversOf('no-observers', {}, function(err) {
+      // the test passes when no error was raised
+      done(err);
+    });
+  });
+
+  it('passes context to final callback', function(done) {
+    var context = {};
+    TestModel.notifyObserversOf('event', context, function(err, ctx) {
+      (ctx || "null").should.equal(context);
+      done();
+    });
+  });
+});
+
+function pushAndNext(array, value) {
+  return function(ctx, next) {
+    array.push(value);
+    process.nextTick(next);
+  };
+}

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -445,7 +445,7 @@ function addHooks(name, done) {
   };
   User['after' + name] = function (next) {
     (new Boolean(called)).should.equal(true);
-    this.email.should.equal(random);
+    this.should.have.property('email', random);
     done();
   };
 }

--- a/test/loopback-dl.test.js
+++ b/test/loopback-dl.test.js
@@ -243,6 +243,19 @@ describe('ModelBuilder define model', function () {
     done(null, User);
   });
 
+  it('should define an id property for composite ids', function () {
+    var modelBuilder = new ModelBuilder();
+    var Follow = modelBuilder.define('Follow', {
+      followerId: { type: String, id: 1 },
+      followeeId: { type: String, id: 2 },
+      followAt: Date
+    });
+    var follow = new Follow({ followerId: 1, followeeId: 2 });
+
+    follow.should.have.property('id');
+    assert.deepEqual(follow.id, { followerId: 1, followeeId: 2 });
+  });
+
 });
 
 describe('DataSource ping', function() {

--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -153,6 +153,29 @@ describe('manipulation', function () {
         }).should.be.instanceOf(Array);
       }).should.have.lengthOf(3);
     });
+
+    it('should create batch of objects with beforeCreate', function(done) {
+      Person.beforeCreate = function(next, data) {
+        if (data && data.name === 'A') {
+          return next(null, {id: 'a', name: 'A'});
+        } else {
+          return next();
+        }
+      };
+      var batch = [
+        {name: 'A'},
+        {name: 'B'},
+        undefined
+      ];
+      Person.create(batch, function(e, ps) {
+        should.not.exist(e);
+        should.exist(ps);
+        ps.should.be.instanceOf(Array);
+        ps.should.have.lengthOf(batch.length);
+        ps[0].should.be.eql({id: 'a', name: 'A'});
+        done();
+      });
+    });
   });
 
   describe('save', function () {

--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -244,7 +244,7 @@ describe('manipulation', function () {
 
     before(function (done) {
       Person.destroyAll(function () {
-        person = Person.create(done);
+        person = Person.create({name: 'Mary', age: 15}, done);
       });
     });
 
@@ -259,6 +259,33 @@ describe('manipulation', function () {
         });
       });
     });
+
+    it('should ignore undefined values on updateAttributes', function(done) {
+      person.updateAttributes({'name': 'John', age: undefined},
+        function(err, p) {
+          should.not.exist(err);
+          Person.findById(p.id, function(e, p) {
+            should.not.exist(err);
+            p.name.should.equal('John');
+            p.age.should.equal(15);
+            done();
+          });
+        });
+    });
+
+    it('should allows model instance on updateAttributes', function(done) {
+      person.updateAttributes(new Person({'name': 'John', age: undefined}),
+        function(err, p) {
+          should.not.exist(err);
+          Person.findById(p.id, function(e, p) {
+            should.not.exist(err);
+            p.name.should.equal('John');
+            p.age.should.equal(15);
+            done();
+          });
+        });
+    });
+
   });
 
   describe('destroy', function () {

--- a/test/memory.test.js
+++ b/test/memory.test.js
@@ -5,6 +5,7 @@ var fs = require('fs');
 var assert = require('assert');
 var async = require('async');
 var should = require('./init.js');
+var Memory = require('../lib/connectors/memory').Memory;
 
 describe('Memory connector', function () {
   var file = path.join(__dirname, 'memory.json');
@@ -278,27 +279,27 @@ describe('Memory connector', function () {
     }
 
   });
-  
+
   it('should use collection setting', function (done) {
     var ds = new DataSource({
       connector: 'memory'
     });
-    
+
     var Product = ds.createModel('Product', {
       name: String
     });
-    
+
     var Tool = ds.createModel('Tool', {
       name: String
     }, {memory: {collection: 'Product'}});
-    
+
     var Widget = ds.createModel('Widget', {
       name: String
     }, {memory: {collection: 'Product'}});
-    
+
     ds.connector.getCollection('Tool').should.equal('Product');
     ds.connector.getCollection('Widget').should.equal('Product');
-    
+
     async.series([
       function(next) {
         Tool.create({ name: 'Tool A' }, next);
@@ -359,6 +360,17 @@ describe('Memory connector', function () {
     });
   });
 
+  require('./persistence-hooks.suite')(
+    new DataSource({ connector: Memory }),
+    should);
+});
+
+describe('Unoptimized connector', function() {
+  var ds = new DataSource({ connector: Memory });
+  // disable optimized methods
+  ds.connector.updateOrCreate = false;
+
+  require('./persistence-hooks.suite')(ds, should);
 });
 
 

--- a/test/memory.test.js
+++ b/test/memory.test.js
@@ -399,16 +399,29 @@ describe('Memory connector', function() {
       });
     });
   });
+});
 
-  require('./persistence-hooks.suite')(
-    new DataSource({ connector: Memory }),
-    should);
+describe('Optimized connector', function() {
+  var ds = new DataSource({ connector: Memory });
+
+  // optimized methods
+  ds.connector.findOrCreate = function (model, query, data, callback) {
+    this.all(model, query, function (err, list) {
+      if (err || (list && list[0])) return callback(err, list && list[0], false);
+      this.create(model, data, function (err) {
+        callback(err, data, true);
+      });
+    }.bind(this));
+  };
+
+  require('./persistence-hooks.suite')(ds, should);
 });
 
 describe('Unoptimized connector', function() {
   var ds = new DataSource({ connector: Memory });
   // disable optimized methods
   ds.connector.updateOrCreate = false;
+  ds.connector.findOrCreate = false;
 
   require('./persistence-hooks.suite')(ds, should);
 });

--- a/test/model-definition.test.js
+++ b/test/model-definition.test.js
@@ -271,7 +271,7 @@ describe('ModelDefinition class', function () {
   });
 
   it('should serialize protected properties into JSON', function() {
-    var memory = new DataSoruce({connector: Memory});
+    var memory = new DataSource({connector: Memory});
     var modelBuilder = memory.modelBuilder;
     var ProtectedModel = memory.createModel('protected', {}, {
       protected: ['protectedProperty']
@@ -285,7 +285,7 @@ describe('ModelDefinition class', function () {
     });
   });
 
-  it('should not serialized protected properties of nested models into JSON', function(done){
+  it('should not serialize protected properties of nested models into JSON', function(done){
     var memory = new DataSource({connector: Memory});
     var modelBuilder = memory.modelBuilder;
     var Parent = memory.createModel('parent');

--- a/test/model-definition.test.js
+++ b/test/model-definition.test.js
@@ -215,6 +215,28 @@ describe('ModelDefinition class', function () {
     done();
   });
 
+  it('should sort id properties by its index', function () {
+    var modelBuilder = new ModelBuilder();
+
+    var User = new ModelDefinition(modelBuilder, 'User', {
+      userId: {type: String, id: 2},
+      userType: {type: String, id: 1},
+      name: "string",
+      bio: ModelBuilder.Text,
+      approved: Boolean,
+      joinedAt: Date,
+      age: "number"
+    });
+
+    var ids = User.ids();
+    assert.ok(Array.isArray(ids));
+    assert.equal(ids.length, 2);
+    assert.equal(ids[0].id, 1);
+    assert.equal(ids[0].name, 'userType');
+    assert.equal(ids[1].id, 2);
+    assert.equal(ids[1].name, 'userId');
+  });
+
   it('should report correct table/column names', function (done) {
     var modelBuilder = new ModelBuilder();
 

--- a/test/model-definition.test.js
+++ b/test/model-definition.test.js
@@ -36,9 +36,9 @@ describe('ModelDefinition class', function () {
     assert.equal(json.properties.approved.type, "Boolean");
     assert.equal(json.properties.joinedAt.type, "Date");
     assert.equal(json.properties.age.type, "Number");
-    
+
     assert.deepEqual(User.toJSON(), json);
-    
+
     done();
 
   });
@@ -55,7 +55,7 @@ describe('ModelDefinition class', function () {
     });
 
     User.build();
-    
+
     var json = User.toJSON();
 
     User.defineProperty("id", {type: "number", id: true});
@@ -64,12 +64,12 @@ describe('ModelDefinition class', function () {
     assert.equal(User.properties.approved.type, Boolean);
     assert.equal(User.properties.joinedAt.type, Date);
     assert.equal(User.properties.age.type, Number);
-    
+
     assert.equal(User.properties.id.type, Number);
-    
+
     json = User.toJSON();
     assert.deepEqual(json.properties.id, {type: 'Number', id: true});
-    
+
     done();
 
   });
@@ -268,6 +268,45 @@ describe('ModelDefinition class', function () {
     var grandChild = child.extend('grand-child');
     assert.equal('child', grandChild.base.modelName);
     assert(grandChild.prototype instanceof child);
+  });
+
+  it('should serialize protected properties into JSON', function() {
+    var memory = new DataSoruce({connector: Memory});
+    var modelBuilder = memory.modelBuilder;
+    var ProtectedModel = memory.createModel('protected', {}, {
+      protected: ['protectedProperty']
+    });
+    var pm = new ProtectedModel({
+      id: 1, foo: 'bar', protectedProperty: 'protected'
+    });
+    var serialized = pm.toJSON();
+    assert.deepEqual(serialized, {
+      id: 1, foo: 'bar', protectedProperty: 'protected'
+    });
+  });
+
+  it('should not serialized protected properties of nested models into JSON', function(done){
+    var memory = new DataSource({connector: Memory});
+    var modelBuilder = memory.modelBuilder;
+    var Parent = memory.createModel('parent');
+    var Child = memory.createModel('child', {}, {protected: ['protectedProperty']});
+    Parent.hasMany(Child);
+    Parent.create({
+      name: 'parent'
+    }, function(err, parent) {
+      parent.children.create({
+        name: 'child',
+        protectedProperty: 'protectedValue'
+      }, function(err, child) {
+        Parent.find({include: 'children'}, function(err, parents) {
+          var serialized = parents[0].toJSON();
+          var child = serialized.children[0];
+          assert.equal(child.name, 'child');
+          assert.notEqual(child.protectedProperty, 'protectedValue');
+          done();
+        });
+      });
+    });
   });
 
   it('should not serialize hidden properties into JSON', function () {

--- a/test/persistence-hooks.suite.js
+++ b/test/persistence-hooks.suite.js
@@ -1,0 +1,1181 @@
+var ValidationError = require('../').ValidationError;
+var traverse = require('traverse');
+
+module.exports = function(dataSource, should) {
+  describe('Persistence hooks', function() {
+    var observedContexts, expectedError, observersCalled;
+    var TestModel, existingInstance;
+    var migrated = false, lastId;
+
+    beforeEach(function setupDatabase(done) {
+      observedContexts = "hook not called";
+      expectedError = new Error('test error');
+      observersCalled = [];
+
+      TestModel = dataSource.createModel('TestModel', {
+        id: { type: String, id: true, default: uid },
+        name: { type: String, required: true },
+        extra: { type: String, required: false }
+      });
+
+      lastId = 0;
+
+      if (migrated) {
+        TestModel.deleteAll(done);
+      } else {
+        dataSource.automigrate(TestModel.modelName, function(err) {
+          migrated = true;
+          done(err);
+        });
+      }
+    });
+
+    beforeEach(function createTestData(done) {
+      TestModel.create({ name: 'first' }, function(err, instance) {
+        if (err) return done(err);
+        existingInstance = instance;
+
+        TestModel.create({ name: 'second' }, function(err) {
+          if (err) return done(err);
+          done();
+        });
+      });
+    });
+
+    describe('PersistedModel.find', function() {
+      it('triggers `query` hook', function(done) {
+        TestModel.observe('query', pushContextAndNext());
+
+        TestModel.find({ where: { id: '1' } }, function(err, list) {
+          if (err) return done(err);
+          observedContexts.should.eql(aTestModelCtx({
+            query: { where: { id: '1' } }
+          }));
+          done();
+        });
+      });
+
+      it('aborts when `query` hook fails', function(done) {
+        TestModel.observe('query', nextWithError(expectedError));
+
+        TestModel.find(function(err, list) {
+          [err].should.eql([expectedError]);
+          done();
+        });
+      });
+
+      it('applies updates from `query` hook', function(done) {
+        TestModel.observe('query', function(ctx, next) {
+          ctx.query = { where: { id: existingInstance.id } };
+          next();
+        });
+
+        TestModel.find(function(err, list) {
+          if (err) return done(err);
+          list.map(get('name')).should.eql([existingInstance.name]);
+          done();
+        });
+      });
+
+      it('triggers `query` hook for geo queries', function(done) {
+        TestModel.observe('query', pushContextAndNext());
+
+        TestModel.find({ where: { geo: { near: '10,20' }}}, function(err, list) {
+          if (err) return done(err);
+          observedContexts.should.eql(aTestModelCtx({
+            query: { where: { geo: { near: '10,20' } } }
+          }));
+          done();
+        });
+      });
+
+      it('applies updates from `query` hook for geo queries', function(done) {
+        TestModel.observe('query', function(ctx, next) {
+          ctx.query = { where: { id: existingInstance.id } };
+          next();
+        });
+
+        TestModel.find({ where: { geo: { near: '10,20' } } }, function(err, list) {
+          if (err) return done(err);
+          list.map(get('name')).should.eql([existingInstance.name]);
+          done();
+        });
+      });
+    });
+
+    describe('PersistedModel.create', function() {
+      it('triggers `before save` hook', function(done) {
+        TestModel.observe('before save', pushContextAndNext());
+
+        TestModel.create({ name: 'created' }, function(err, instance) {
+          if (err) return done(err);
+          observedContexts.should.eql(aTestModelCtx({ instance: {
+            id: instance.id,
+            name: 'created',
+            extra: undefined
+          }}));
+          done();
+        });
+      });
+
+      it('aborts when `before save` hook fails', function(done) {
+        TestModel.observe('before save', nextWithError(expectedError));
+
+        TestModel.create({ name: 'created' }, function(err, instance) {
+          [err].should.eql([expectedError]);
+          done();
+        });
+      });
+
+      it('applies updates from `before save` hook', function(done) {
+        TestModel.observe('before save', function(ctx, next) {
+          ctx.instance.should.be.instanceOf(TestModel);
+          ctx.instance.extra = 'hook data';
+          next();
+        });
+
+        TestModel.create({ id: uid(), name: 'a-name' }, function(err, instance) {
+          if (err) return done(err);
+          instance.should.have.property('extra', 'hook data');
+          done();
+        });
+      });
+
+      it('sends `before save` for each model in an array', function(done) {
+        TestModel.observe('before save', pushContextAndNext());
+
+        TestModel.create(
+          [{ name: 'one' }, { name: 'two' }],
+          function(err, list) {
+            if (err) return done(err);
+            observedContexts.should.eql([
+              aTestModelCtx({
+                instance: { id: list[0].id, name: 'one', extra: undefined }
+              }),
+              aTestModelCtx({
+                instance: { id: list[1].id, name: 'two', extra: undefined  }
+               }),
+            ]);
+            done();
+          });
+      });
+
+      it('validates model after `before save` hook', function(done) {
+        TestModel.observe('before save', invalidateTestModel());
+
+        TestModel.create({ name: 'created' }, function(err) {
+          (err || {}).should.be.instanceOf(ValidationError);
+          (err.details.codes || {}).should.eql({ name: ['presence'] });
+          done();
+        });
+      });
+
+      it('triggers `after save` hook', function(done) {
+        TestModel.observe('after save', pushContextAndNext());
+
+        TestModel.create({ name: 'created' }, function(err, instance) {
+          if (err) return done(err);
+          observedContexts.should.eql(aTestModelCtx({ instance: {
+            id: instance.id,
+            name: 'created',
+            extra: undefined
+          }}));
+          done();
+        });
+      });
+
+      it('aborts when `after save` hook fails', function(done) {
+        TestModel.observe('after save', nextWithError(expectedError));
+
+        TestModel.create({ name: 'created' }, function(err, instance) {
+          [err].should.eql([expectedError]);
+          done();
+        });
+      });
+
+      it('applies updates from `after save` hook', function(done) {
+        TestModel.observe('after save', function(ctx, next) {
+          ctx.instance.should.be.instanceOf(TestModel);
+          ctx.instance.extra = 'hook data';
+          next();
+        });
+
+        TestModel.create({ name: 'a-name' }, function(err, instance) {
+          if (err) return done(err);
+          instance.should.have.property('extra', 'hook data');
+          done();
+        });
+      });
+
+      it('sends `after save` for each model in an array', function(done) {
+        TestModel.observe('after save', pushContextAndNext());
+
+        TestModel.create(
+          [{ name: 'one' }, { name: 'two' }],
+          function(err, list) {
+            if (err) return done(err);
+            observedContexts.should.eql([
+              aTestModelCtx({
+                instance: { id: list[0].id, name: 'one', extra: undefined }
+              }),
+              aTestModelCtx({
+                instance: { id: list[1].id, name: 'two', extra: undefined }
+              }),
+            ]);
+            done();
+          });
+      });
+
+      it('emits `after save` when some models were not saved', function(done) {
+        TestModel.observe('before save', function(ctx, next) {
+          if (ctx.instance.name === 'fail')
+            next(expectedError);
+          else
+            next();
+        });
+
+        TestModel.observe('after save', pushContextAndNext());
+
+        TestModel.create(
+          [{ name: 'ok' }, { name: 'fail' }],
+          function(err, list) {
+            (err || []).should.have.length(2);
+            err[1].should.eql(expectedError);
+
+            // NOTE(bajtos) The current implementation of `Model.create(array)`
+            // passes all models in the second callback argument, including
+            // the models that were not created due to an error.
+            list.map(get('name')).should.eql(['ok', 'fail']);
+
+            observedContexts.should.eql(aTestModelCtx({
+              instance: { id: list[0].id, name: 'ok', extra: undefined }
+            }));
+            done();
+          });
+      });
+    });
+
+    describe('PersistedModel.findOrCreate', function() {
+      it('triggers `query` hook', function(done) {
+        TestModel.observe('query', pushContextAndNext());
+
+        TestModel.findOrCreate(
+          { where: { name: 'new-record' } },
+          { name: 'new-record' },
+          function(err, record, created) {
+            if (err) return done(err);
+            observedContexts.should.eql(aTestModelCtx({ query: {
+              where: { name: 'new-record' },
+              limit: 1,
+              offset: 0,
+              skip: 0
+            }}));
+            done();
+          });
+      });
+
+      // TODO(bajtos) Enable this test for all connectors that
+      // provide optimized implementation of findOrCreate.
+      // The unoptimized implementation does not trigger the hook
+      // when an existing model was found.
+      it.skip('triggers `before save` hook when found', function(done) {
+        TestModel.observe('before save', pushContextAndNext());
+
+        TestModel.findOrCreate(
+          { where: { name: existingInstance.name } },
+          { name: existingInstance.name },
+          function(err, record, created) {
+            if (err) return done(err);
+            observedContexts.should.eql(aTestModelCtx({ instance: {
+              id: record.id,
+              name: existingInstance.name,
+              extra: undefined
+            }}));
+            done();
+          });
+      });
+
+      it('triggers `before save` hook when not found', function(done) {
+        TestModel.observe('before save', pushContextAndNext());
+
+        TestModel.findOrCreate(
+          { where: { name: 'new-record' } },
+          { name: 'new-record' },
+          function(err, record, created) {
+            if (err) return done(err);
+            observedContexts.should.eql(aTestModelCtx({ instance: {
+              id: record.id,
+              name: 'new-record',
+              extra: undefined
+            }}));
+            done();
+          });
+      });
+
+      it('validates model after `before save` hook', function(done) {
+        TestModel.observe('before save', invalidateTestModel());
+
+        TestModel.findOrCreate(
+          { where: { name: 'new-record' } },
+          { name: 'new-record' },
+          function(err) {
+            (err || {}).should.be.instanceOf(ValidationError);
+            (err.details.codes || {}).should.eql({ name: ['presence'] });
+            done();
+          });
+      });
+
+      it('triggers hooks in the correct order when not found', function(done) {
+        var triggered = [];
+        TestModel._notify = TestModel.notifyObserversOf;
+        TestModel.notifyObserversOf = function(operation, context, callback) {
+          triggered.push(operation);
+          this._notify.apply(this, arguments);
+        };
+
+        TestModel.findOrCreate(
+          { where: { name: 'new-record' } },
+          { name: 'new-record' },
+          function(err, record, created) {
+            if (err) return done(err);
+            triggered.should.eql([
+              'query',
+              'before save',
+              'after save'
+            ]);
+            done();
+          });
+      });
+
+      it('aborts when `query` hook fails', function(done) {
+        TestModel.observe('query', nextWithError(expectedError));
+
+        TestModel.findOrCreate(
+          { where: { id: 'does-not-exist' } },
+          { name: 'does-not-exist' },
+          function(err, instance) {
+            [err].should.eql([expectedError]);
+            done();
+          });
+      });
+
+      it('aborts when `before save` hook fails', function(done) {
+        TestModel.observe('before save', nextWithError(expectedError));
+
+        TestModel.findOrCreate(
+          { where: { id: 'does-not-exist' } },
+          { name: 'does-not-exist' },
+          function(err, instance) {
+            [err].should.eql([expectedError]);
+            done();
+          });
+      });
+
+      it('triggers `after save` hook when not found', function(done) {
+        TestModel.observe('after save', pushContextAndNext());
+
+        TestModel.findOrCreate(
+          { where: { name: 'new name' } },
+          { name: 'new name' },
+          function(err, instance) {
+            if (err) return done(err);
+            observedContexts.should.eql(aTestModelCtx({ instance: {
+              id: instance.id,
+              name: 'new name',
+              extra: undefined
+            }}));
+            done();
+          });
+      });
+
+      it('does not trigger `after save` hook when found', function(done) {
+        TestModel.observe('after save', pushContextAndNext());
+
+        TestModel.findOrCreate(
+          { where: { id: existingInstance.id } },
+          { name: existingInstance.name },
+          function(err, instance) {
+            if (err) return done(err);
+            observedContexts.should.eql("hook not called");
+            done();
+          });
+      });
+    });
+
+    describe('PersistedModel.count', function(done) {
+      it('triggers `query` hook', function(done) {
+        TestModel.observe('query', pushContextAndNext());
+
+        TestModel.count({ id: existingInstance.id }, function(err, count) {
+          if (err) return done(err);
+          observedContexts.should.eql(aTestModelCtx({ query: {
+            where: { id: existingInstance.id }
+          }}));
+          done();
+        });
+      });
+
+      it('applies updates from `query` hook', function(done) {
+        TestModel.observe('query', function(ctx, next) {
+          ctx.query.where = { id: existingInstance.id };
+          next();
+        });
+
+        TestModel.count(function(err, count) {
+          if (err) return done(err);
+          count.should.equal(1);
+          done();
+        });
+      });
+    });
+
+    describe('PersistedModel.prototype.save', function() {
+      it('triggers `before save` hook', function(done) {
+        TestModel.observe('before save', pushContextAndNext());
+
+        existingInstance.name = 'changed';
+        existingInstance.save(function(err, instance) {
+          if (err) return done(err);
+          observedContexts.should.eql(aTestModelCtx({ instance: {
+            id: existingInstance.id,
+            name: 'changed',
+            extra: undefined
+          }}));
+          done();
+        });
+      });
+
+      it('aborts when `before save` hook fails', function(done) {
+        TestModel.observe('before save', nextWithError(expectedError));
+
+        existingInstance.save(function(err, instance) {
+          [err].should.eql([expectedError]);
+          done();
+        });
+      });
+
+      it('applies updates from `before save` hook', function(done) {
+        TestModel.observe('before save', function(ctx, next) {
+          ctx.instance.should.be.instanceOf(TestModel);
+          ctx.instance.extra = 'hook data';
+          next();
+        });
+
+        existingInstance.save(function(err, instance) {
+          if (err) return done(err);
+          instance.should.have.property('extra', 'hook data');
+          done();
+        });
+      });
+
+      it('validates model after `before save` hook', function(done) {
+        TestModel.observe('before save', invalidateTestModel());
+
+        existingInstance.save(function(err) {
+          (err || {}).should.be.instanceOf(ValidationError);
+          (err.details.codes || {}).should.eql({ name: ['presence'] });
+          done();
+        });
+      });
+
+      it('triggers `after save` hook', function(done) {
+        TestModel.observe('after save', pushContextAndNext());
+
+        existingInstance.name = 'changed';
+        existingInstance.save(function(err, instance) {
+          if (err) return done(err);
+          observedContexts.should.eql(aTestModelCtx({ instance: {
+            id: existingInstance.id,
+            name: 'changed',
+            extra: undefined
+          }}));
+          done();
+        });
+      });
+
+      it('aborts when `after save` hook fails', function(done) {
+        TestModel.observe('after save', nextWithError(expectedError));
+
+        existingInstance.save(function(err, instance) {
+          [err].should.eql([expectedError]);
+          done();
+        });
+      });
+
+      it('applies updates from `after save` hook', function(done) {
+        TestModel.observe('after save', function(ctx, next) {
+          ctx.instance.should.be.instanceOf(TestModel);
+          ctx.instance.extra = 'hook data';
+          next();
+        });
+
+        existingInstance.save(function(err, instance) {
+          if (err) return done(err);
+          instance.should.have.property('extra', 'hook data');
+          done();
+        });
+      });
+    });
+
+    describe('PersistedModel.prototype.updateAttributes', function() {
+      it('triggers `before save` hook', function(done) {
+        TestModel.observe('before save', pushContextAndNext());
+
+        existingInstance.name = 'changed';
+        existingInstance.updateAttributes({ name: 'changed' }, function(err) {
+          if (err) return done(err);
+          observedContexts.should.eql(aTestModelCtx({
+            where: { id: existingInstance.id },
+            data: { name: 'changed' }
+          }));
+          done();
+        });
+      });
+
+      it('aborts when `before save` hook fails', function(done) {
+        TestModel.observe('before save', nextWithError(expectedError));
+
+        existingInstance.updateAttributes({ name: 'updated' }, function(err) {
+          [err].should.eql([expectedError]);
+          done();
+        });
+      });
+
+      it('applies updates from `before save` hook', function(done) {
+        TestModel.observe('before save', function(ctx, next) {
+          ctx.data.extra = 'extra data';
+          ctx.data.name = 'hooked name';
+          next();
+        });
+
+        existingInstance.updateAttributes({ name: 'updated' }, function(err) {
+          if (err) return done(err);
+          // We must query the database here because `updateAttributes`
+          // returns effectively `this`, not the data from the datasource
+          TestModel.findById(existingInstance.id, function(err, instance) {
+            if (err) return done(err);
+            instance.toObject(true).should.eql({
+              id: existingInstance.id,
+              name: 'hooked name',
+              extra: 'extra data'
+            });
+            done();
+          });
+        });
+      });
+
+      it('validates model after `before save` hook', function(done) {
+        TestModel.observe('before save', invalidateTestModel());
+
+        existingInstance.updateAttributes({ name: 'updated' }, function(err) {
+          (err || {}).should.be.instanceOf(ValidationError);
+          (err.details.codes || {}).should.eql({ name: ['presence'] });
+          done();
+        });
+      });
+
+      it('triggers `after save` hook', function(done) {
+        TestModel.observe('after save', pushContextAndNext());
+
+        existingInstance.name = 'changed';
+        existingInstance.updateAttributes({ name: 'changed' }, function(err) {
+          if (err) return done(err);
+          observedContexts.should.eql(aTestModelCtx({ instance: {
+            id: existingInstance.id,
+            name: 'changed',
+            extra: undefined
+          }}));
+          done();
+        });
+      });
+
+      it('aborts when `after save` hook fails', function(done) {
+        TestModel.observe('after save', nextWithError(expectedError));
+
+        existingInstance.updateAttributes({ name: 'updated' }, function(err) {
+          [err].should.eql([expectedError]);
+          done();
+        });
+      });
+
+      it('applies updates from `after save` hook', function(done) {
+        TestModel.observe('after save', function(ctx, next) {
+          ctx.instance.should.be.instanceOf(TestModel);
+          ctx.instance.extra = 'hook data';
+          next();
+        });
+
+        existingInstance.updateAttributes({ name: 'updated' }, function(err, instance) {
+          if (err) return done(err);
+          instance.should.have.property('extra', 'hook data');
+          done();
+        });
+      });
+    });
+
+    describe('PersistedModel.updateOrCreate', function() {
+      it('triggers `query` hook on create', function(done) {
+        TestModel.observe('query', pushContextAndNext());
+
+        TestModel.updateOrCreate(
+          { id: 'not-found', name: 'not found' },
+          function(err, instance) {
+            if (err) return done(err);
+            observedContexts.should.eql(aTestModelCtx({ query: {
+              where: { id: 'not-found' }
+            }}));
+            done();
+          });
+      });
+
+      it('triggers `query` hook on update', function(done) {
+        TestModel.observe('query', pushContextAndNext());
+
+        TestModel.updateOrCreate(
+          { id: existingInstance.id, name: 'new name' },
+          function(err, instance) {
+            if (err) return done(err);
+            observedContexts.should.eql(aTestModelCtx({ query: {
+              where: { id: existingInstance.id }
+            }}));
+            done();
+          });
+      });
+
+      it('does not trigger `query` on missing id', function(done) {
+        TestModel.observe('query', pushContextAndNext());
+
+        TestModel.updateOrCreate(
+          { name: 'new name' },
+          function(err, instance) {
+            if (err) return done(err);
+            observedContexts.should.equal('hook not called');
+            done();
+          });
+      });
+
+      it('applies updates from `query` hook when found', function(done) {
+        TestModel.observe('query', function(ctx, next) {
+          ctx.query = { where: { id: { neq: existingInstance.id } } };
+          next();
+        });
+
+        TestModel.updateOrCreate(
+          { id: existingInstance.id, name: 'new name' },
+          function(err, instance) {
+            if (err) return done(err);
+            findTestModels({ fields: ['id', 'name' ] }, function(err, list) {
+              if (err) return done(err);
+              (list||[]).map(toObject).should.eql([
+                { id: existingInstance.id, name: existingInstance.name, extra: undefined },
+                { id: instance.id, name: 'new name', extra: undefined }
+              ]);
+              done();
+            });
+        });
+      });
+
+      it('applies updates from `query` hook when not found', function(done) {
+        TestModel.observe('query', function(ctx, next) {
+          ctx.query = { where: { id: 'not-found' } };
+          next();
+        });
+
+        TestModel.updateOrCreate(
+          { id: existingInstance.id, name: 'new name' },
+          function(err, instance) {
+            if (err) return done(err);
+            findTestModels({ fields: ['id', 'name' ] }, function(err, list) {
+              if (err) return done(err);
+              (list||[]).map(toObject).should.eql([
+                { id: existingInstance.id, name: existingInstance.name, extra: undefined },
+                { id: list[1].id, name: 'second', extra: undefined },
+                { id: instance.id, name: 'new name', extra: undefined }
+              ]);
+              done();
+            });
+        });
+      });
+
+      it('triggers hooks only once', function(done) {
+        TestModel.observe('query', pushNameAndNext('query'));
+        TestModel.observe('before save', pushNameAndNext('before save'));
+
+        TestModel.observe('query', function(ctx, next) {
+          ctx.query = { where: { id: { neq: existingInstance.id } } };
+          next();
+        });
+
+        TestModel.updateOrCreate(
+          { id: 'ignored', name: 'new name' },
+          function(err, instance) {
+            if (err) return done(err);
+            observersCalled.should.eql(['query', 'before save']);
+            done();
+          });
+      });
+
+      it('triggers `before save` hook on update', function(done) {
+        TestModel.observe('before save', pushContextAndNext());
+
+        TestModel.updateOrCreate(
+          { id: existingInstance.id, name: 'updated name' },
+          function(err, instance) {
+            if (err) return done(err);
+            observedContexts.should.eql(aTestModelCtx({
+              where: { id: existingInstance.id },
+              data: { id: existingInstance.id, name: 'updated name' }
+            }));
+            done();
+          });
+      });
+
+      it('triggers `before save` hook on create', function(done) {
+        TestModel.observe('before save', pushContextAndNext());
+
+        TestModel.updateOrCreate(
+          { id: 'new-id', name: 'a name' },
+          function(err, instance) {
+            if (err) return done(err);
+
+            if (dataSource.connector.updateOrCreate) {
+              // Atomic implementations of `updateOrCreate` cannot
+              // provide full instance as that depends on whether
+              // UPDATE or CREATE will be triggered
+              observedContexts.should.eql(aTestModelCtx({
+                where: { id: 'new-id' },
+                data: { id: 'new-id', name: 'a name' }
+              }));
+            } else {
+              // The default unoptimized implementation runs
+              // `instance.save` and thus a full instance is availalbe
+              observedContexts.should.eql(aTestModelCtx({
+                instance: { id: 'new-id', name: 'a name', extra: undefined }
+              }));
+            }
+
+            done();
+          });
+      });
+
+      it('applies updates from `before save` hook on update', function(done) {
+        TestModel.observe('before save', function(ctx, next) {
+          ctx.data.name = 'hooked';
+          next();
+        });
+
+        TestModel.updateOrCreate(
+          { id: existingInstance.id, name: 'updated name' },
+          function(err, instance) {
+            if (err) return done(err);
+            instance.name.should.equal('hooked');
+            done();
+          });
+      });
+
+      it('applies updates from `before save` hook on create', function(done) {
+        TestModel.observe('before save', function(ctx, next) {
+          if (ctx.instance) {
+            ctx.instance.name = 'hooked';
+          } else {
+            ctx.data.name = 'hooked';
+          }
+          next();
+        });
+
+        TestModel.updateOrCreate(
+          { id: 'new-id', name: 'new name' },
+          function(err, instance) {
+            if (err) return done(err);
+            instance.name.should.equal('hooked');
+            done();
+          });
+      });
+
+      // FIXME(bajtos) this fails with connector-specific updateOrCreate
+      // implementations, see the comment inside lib/dao.js (updateOrCreate)
+      it.skip('validates model after `before save` hook on update', function(done) {
+        TestModel.observe('before save', invalidateTestModel());
+
+        TestModel.updateOrCreate(
+          { id: existingInstance.id, name: 'updated name' },
+          function(err, instance) {
+            (err || {}).should.be.instanceOf(ValidationError);
+            (err.details.codes || {}).should.eql({ name: ['presence'] });
+            done();
+          });
+      });
+
+      // FIXME(bajtos) this fails with connector-specific updateOrCreate
+      // implementations, see the comment inside lib/dao.js (updateOrCreate)
+      it.skip('validates model after `before save` hook on create', function(done) {
+        TestModel.observe('before save', invalidateTestModel());
+
+        TestModel.updateOrCreate(
+          { id: 'new-id', name: 'new name' },
+          function(err, instance) {
+            (err || {}).should.be.instanceOf(ValidationError);
+            (err.details.codes || {}).should.eql({ name: ['presence'] });
+            done();
+          });
+      });
+
+
+      it('triggers `after save` hook on update', function(done) {
+        TestModel.observe('after save', pushContextAndNext());
+
+        TestModel.updateOrCreate(
+          { id: existingInstance.id, name: 'updated name' },
+          function(err, instance) {
+            if (err) return done(err);
+            observedContexts.should.eql(aTestModelCtx({ instance: {
+              id: existingInstance.id,
+              name: 'updated name',
+              extra: undefined
+            }}));
+            done();
+          });
+      });
+
+      it('triggers `after save` hook on create', function(done) {
+        TestModel.observe('after save', pushContextAndNext());
+
+        TestModel.updateOrCreate(
+          { id: 'new-id', name: 'a name' },
+          function(err, instance) {
+            if (err) return done(err);
+            observedContexts.should.eql(aTestModelCtx({ instance: {
+              id: instance.id,
+              name: 'a name',
+              extra: undefined
+            }}));
+            done();
+          });
+      });
+    });
+
+    describe('PersistedModel.deleteAll', function() {
+      it('triggers `query` hook with query', function(done) {
+        TestModel.observe('query', pushContextAndNext());
+
+        TestModel.deleteAll({ name: existingInstance.name }, function(err) {
+          if (err) return done(err);
+          observedContexts.should.eql(aTestModelCtx({
+             query: { where: { name: existingInstance.name } }
+          }));
+          done();
+        });
+      });
+
+      it('triggers `query` hook without query', function(done) {
+        TestModel.observe('query', pushContextAndNext());
+
+        TestModel.deleteAll(function(err) {
+          if (err) return done(err);
+          observedContexts.should.eql(aTestModelCtx({ query: { where: {} } }));
+          done();
+        });
+      });
+
+      it('applies updates from `query` hook', function(done) {
+        TestModel.observe('query', function(ctx, next) {
+          ctx.query = { where: { id: { neq: existingInstance.id } } };
+          next();
+        });
+
+        TestModel.deleteAll(function(err) {
+          if (err) return done(err);
+          findTestModels(function(err, list) {
+            if (err) return done(err);
+            (list || []).map(get('id')).should.eql([existingInstance.id]);
+            done();
+          });
+        });
+      });
+
+      it('triggers `after delete` hook without query', function(done) {
+        TestModel.observe('after delete', pushContextAndNext());
+
+        TestModel.deleteAll(function(err) {
+          if (err) return done(err);
+          observedContexts.should.eql(aTestModelCtx({ where: {} }));
+          done();
+        });
+      });
+
+      it('triggers `after delete` hook without query', function(done) {
+        TestModel.observe('after delete', pushContextAndNext());
+
+        TestModel.deleteAll({ name: existingInstance.name }, function(err) {
+          if (err) return done(err);
+          observedContexts.should.eql(aTestModelCtx({
+            where: { name: existingInstance.name }
+          }));
+          done();
+        });
+      });
+
+      it('aborts when `after delete` hook fails', function(done) {
+        TestModel.observe('after delete', nextWithError(expectedError));
+
+        TestModel.deleteAll(function(err) {
+          [err].should.eql([expectedError]);
+          done();
+        });
+      });
+    });
+
+    describe('PersistedModel.prototype.delete', function() {
+      it('triggers `query` hook', function(done) {
+        TestModel.observe('query', pushContextAndNext());
+
+        existingInstance.delete(function(err) {
+          if (err) return done(err);
+          observedContexts.should.eql(aTestModelCtx({
+             query: { where: { id: existingInstance.id } }
+          }));
+          done();
+        });
+      });
+
+      it('applies updated from `query` hook', function(done) {
+        TestModel.observe('query', function(ctx, next) {
+          ctx.query = { where: { id: { neq: existingInstance.id } } };
+          next();
+        });
+
+        existingInstance.delete(function(err) {
+          if (err) return done(err);
+          findTestModels(function(err, list) {
+            if (err) return done(err);
+            (list || []).map(get('id')).should.eql([existingInstance.id]);
+            done();
+          });
+        });
+      });
+
+      it('triggers `after delete` hook', function(done) {
+        TestModel.observe('after delete', pushContextAndNext());
+
+        existingInstance.delete(function(err) {
+          if (err) return done(err);
+          observedContexts.should.eql(aTestModelCtx({
+            where: { id: existingInstance.id }
+          }));
+          done();
+        });
+      });
+
+      it('triggers `after delete` hook without query', function(done) {
+        TestModel.observe('after delete', pushContextAndNext());
+
+        TestModel.deleteAll({ name: existingInstance.name }, function(err) {
+          if (err) return done(err);
+          observedContexts.should.eql(aTestModelCtx({
+            where: { name: existingInstance.name }
+          }));
+          done();
+        });
+      });
+
+      it('aborts when `after delete` hook fails', function(done) {
+        TestModel.observe('after delete', nextWithError(expectedError));
+
+        TestModel.deleteAll(function(err) {
+          [err].should.eql([expectedError]);
+          done();
+        });
+      });
+
+      it('triggers hooks only once', function(done) {
+        TestModel.observe('query', pushNameAndNext('query'));
+        TestModel.observe('after delete', pushNameAndNext('after delete'));
+        TestModel.observe('query', function(ctx, next) {
+          ctx.query = { where: { id: { neq: existingInstance.id } } };
+          next();
+        });
+
+        existingInstance.delete(function(err) {
+          if (err) return done(err);
+          observersCalled.should.eql(['query', 'after delete']);
+          done();
+        });
+      });
+    });
+
+    describe('PersistedModel.updateAll', function() {
+      it('triggers `query` hook', function(done) {
+        TestModel.observe('query', pushContextAndNext());
+
+        TestModel.updateAll(
+          { name: 'searched' },
+          { name: 'updated' },
+          function(err, instance) {
+            if (err) return done(err);
+            observedContexts.should.eql(aTestModelCtx({ query: {
+              where: { name: 'searched' }
+            }}));
+            done();
+          });
+      });
+
+      it('applies updates from `query` hook', function(done) {
+        TestModel.observe('query', function(ctx, next) {
+          ctx.query = { where: { id: { neq: existingInstance.id } } };
+          next();
+        });
+
+        TestModel.updateAll(
+          { id: existingInstance.id },
+          { name: 'new name' },
+          function(err) {
+            if (err) return done(err);
+            findTestModels({ fields: ['id', 'name' ] }, function(err, list) {
+              if (err) return done(err);
+              (list||[]).map(toObject).should.eql([
+                { id: existingInstance.id, name: existingInstance.name, extra: undefined },
+                { id: '2', name: 'new name', extra: undefined }
+              ]);
+              done();
+            });
+        });
+      });
+
+      it('triggers `before save` hook', function(done) {
+        TestModel.observe('before save', pushContextAndNext());
+
+        TestModel.updateAll(
+          { name: 'searched' },
+          { name: 'updated' },
+          function(err, instance) {
+            if (err) return done(err);
+            observedContexts.should.eql(aTestModelCtx({
+              where: { name: 'searched' },
+              data: { name: 'updated' },
+            }));
+            done();
+          });
+      });
+
+      it('applies updates from `before save` hook', function(done) {
+        TestModel.observe('before save', function(ctx, next) {
+          ctx.data = { name: 'hooked', extra: 'added' };
+          next();
+        });
+
+        TestModel.updateAll(
+          { id: existingInstance.id },
+          { name: 'updated name' },
+          function(err) {
+            if (err) return done(err);
+            loadTestModel(existingInstance.id, function(err, instance) {
+              if (err) return done(err);
+              instance.should.have.property('name', 'hooked');
+              instance.should.have.property('extra', 'added');
+              done();
+            });
+          });
+      });
+
+      it('triggers `after save` hook', function(done) {
+        TestModel.observe('after save', pushContextAndNext());
+
+        TestModel.updateAll(
+          { id: existingInstance.id },
+          { name: 'updated name' },
+          function(err) {
+            if (err) return done(err);
+            observedContexts.should.eql(aTestModelCtx({
+              where: { id: existingInstance.id },
+              data: { name: 'updated name' }
+            }));
+            done();
+          });
+      });
+    });
+
+    function pushContextAndNext() {
+      return function(context, next) {
+        context = deepCloneToObject(context);
+
+        if (typeof observedContexts === 'string') {
+          observedContexts = context;
+          return next();
+        }
+
+        if (!Array.isArray(observedContexts)) {
+          observedContexts = [observedContexts];
+        }
+
+        observedContexts.push(context);
+        next();
+      };
+    }
+
+    function pushNameAndNext(name) {
+      return function(context, next) {
+        observersCalled.push(name);
+        next();
+      };
+    }
+
+    function nextWithError(err) {
+      return function(context, next) {
+        next(err);
+      };
+    }
+
+    function invalidateTestModel() {
+      return function(context, next) {
+        if (context.instance) {
+          context.instance.name = '';
+        } else {
+          context.data.name = '';
+        }
+        next();
+      };
+    }
+
+    function aTestModelCtx(ctx) {
+      ctx.Model = TestModel;
+      return deepCloneToObject(ctx);
+    }
+
+    function findTestModels(query, cb) {
+      if (cb === undefined && typeof query === 'function') {
+        cb = query;
+        query = null;
+      }
+
+      TestModel.find(query, { notify: false }, cb);
+    }
+
+    function loadTestModel(id, cb) {
+      TestModel.findOne({ where: { id: id } }, { notify: false }, cb);
+    }
+
+    function uid() {
+      lastId += 1;
+      return '' + lastId;
+    }
+  });
+
+  function deepCloneToObject(obj) {
+    return traverse(obj).map(function(x) {
+      if (x && x.toObject)
+        return x.toObject(true);
+      if (x && typeof x === 'function' && x.modelName)
+        return '[ModelCtor ' + x.modelName + ']';
+    });
+  }
+
+  function get(propertyName) {
+    return function(obj) {
+      return obj[propertyName];
+    };
+  }
+
+  function toObject(obj) {
+    return obj.toObject ? obj.toObject() : obj;
+  }
+};

--- a/test/persistence-hooks.suite.js
+++ b/test/persistence-hooks.suite.js
@@ -43,8 +43,8 @@ module.exports = function(dataSource, should) {
     });
 
     describe('PersistedModel.find', function() {
-      it('triggers `query` hook', function(done) {
-        TestModel.observe('query', pushContextAndNext());
+      it('triggers `access` hook', function(done) {
+        TestModel.observe('access', pushContextAndNext());
 
         TestModel.find({ where: { id: '1' } }, function(err, list) {
           if (err) return done(err);
@@ -55,8 +55,8 @@ module.exports = function(dataSource, should) {
         });
       });
 
-      it('aborts when `query` hook fails', function(done) {
-        TestModel.observe('query', nextWithError(expectedError));
+      it('aborts when `access` hook fails', function(done) {
+        TestModel.observe('access', nextWithError(expectedError));
 
         TestModel.find(function(err, list) {
           [err].should.eql([expectedError]);
@@ -64,8 +64,8 @@ module.exports = function(dataSource, should) {
         });
       });
 
-      it('applies updates from `query` hook', function(done) {
-        TestModel.observe('query', function(ctx, next) {
+      it('applies updates from `access` hook', function(done) {
+        TestModel.observe('access', function(ctx, next) {
           ctx.query = { where: { id: existingInstance.id } };
           next();
         });
@@ -77,8 +77,8 @@ module.exports = function(dataSource, should) {
         });
       });
 
-      it('triggers `query` hook for geo queries', function(done) {
-        TestModel.observe('query', pushContextAndNext());
+      it('triggers `access` hook for geo queries', function(done) {
+        TestModel.observe('access', pushContextAndNext());
 
         TestModel.find({ where: { geo: { near: '10,20' }}}, function(err, list) {
           if (err) return done(err);
@@ -89,8 +89,8 @@ module.exports = function(dataSource, should) {
         });
       });
 
-      it('applies updates from `query` hook for geo queries', function(done) {
-        TestModel.observe('query', function(ctx, next) {
+      it('applies updates from `access` hook for geo queries', function(done) {
+        TestModel.observe('access', function(ctx, next) {
           ctx.query = { where: { id: existingInstance.id } };
           next();
         });
@@ -256,8 +256,8 @@ module.exports = function(dataSource, should) {
     });
 
     describe('PersistedModel.findOrCreate', function() {
-      it('triggers `query` hook', function(done) {
-        TestModel.observe('query', pushContextAndNext());
+      it('triggers `access` hook', function(done) {
+        TestModel.observe('access', pushContextAndNext());
 
         TestModel.findOrCreate(
           { where: { name: 'new-record' } },
@@ -339,7 +339,7 @@ module.exports = function(dataSource, should) {
           function(err, record, created) {
             if (err) return done(err);
             triggered.should.eql([
-              'query',
+              'access',
               'before save',
               'after save'
             ]);
@@ -347,8 +347,8 @@ module.exports = function(dataSource, should) {
           });
       });
 
-      it('aborts when `query` hook fails', function(done) {
-        TestModel.observe('query', nextWithError(expectedError));
+      it('aborts when `access` hook fails', function(done) {
+        TestModel.observe('access', nextWithError(expectedError));
 
         TestModel.findOrCreate(
           { where: { id: 'does-not-exist' } },
@@ -403,8 +403,8 @@ module.exports = function(dataSource, should) {
     });
 
     describe('PersistedModel.count', function(done) {
-      it('triggers `query` hook', function(done) {
-        TestModel.observe('query', pushContextAndNext());
+      it('triggers `access` hook', function(done) {
+        TestModel.observe('access', pushContextAndNext());
 
         TestModel.count({ id: existingInstance.id }, function(err, count) {
           if (err) return done(err);
@@ -415,8 +415,8 @@ module.exports = function(dataSource, should) {
         });
       });
 
-      it('applies updates from `query` hook', function(done) {
-        TestModel.observe('query', function(ctx, next) {
+      it('applies updates from `access` hook', function(done) {
+        TestModel.observe('access', function(ctx, next) {
           ctx.query.where = { id: existingInstance.id };
           next();
         });
@@ -614,8 +614,8 @@ module.exports = function(dataSource, should) {
     });
 
     describe('PersistedModel.updateOrCreate', function() {
-      it('triggers `query` hook on create', function(done) {
-        TestModel.observe('query', pushContextAndNext());
+      it('triggers `access` hook on create', function(done) {
+        TestModel.observe('access', pushContextAndNext());
 
         TestModel.updateOrCreate(
           { id: 'not-found', name: 'not found' },
@@ -628,8 +628,8 @@ module.exports = function(dataSource, should) {
           });
       });
 
-      it('triggers `query` hook on update', function(done) {
-        TestModel.observe('query', pushContextAndNext());
+      it('triggers `access` hook on update', function(done) {
+        TestModel.observe('access', pushContextAndNext());
 
         TestModel.updateOrCreate(
           { id: existingInstance.id, name: 'new name' },
@@ -642,8 +642,8 @@ module.exports = function(dataSource, should) {
           });
       });
 
-      it('does not trigger `query` on missing id', function(done) {
-        TestModel.observe('query', pushContextAndNext());
+      it('does not trigger `access` on missing id', function(done) {
+        TestModel.observe('access', pushContextAndNext());
 
         TestModel.updateOrCreate(
           { name: 'new name' },
@@ -654,8 +654,8 @@ module.exports = function(dataSource, should) {
           });
       });
 
-      it('applies updates from `query` hook when found', function(done) {
-        TestModel.observe('query', function(ctx, next) {
+      it('applies updates from `access` hook when found', function(done) {
+        TestModel.observe('access', function(ctx, next) {
           ctx.query = { where: { id: { neq: existingInstance.id } } };
           next();
         });
@@ -675,8 +675,8 @@ module.exports = function(dataSource, should) {
         });
       });
 
-      it('applies updates from `query` hook when not found', function(done) {
-        TestModel.observe('query', function(ctx, next) {
+      it('applies updates from `access` hook when not found', function(done) {
+        TestModel.observe('access', function(ctx, next) {
           ctx.query = { where: { id: 'not-found' } };
           next();
         });
@@ -698,10 +698,10 @@ module.exports = function(dataSource, should) {
       });
 
       it('triggers hooks only once', function(done) {
-        TestModel.observe('query', pushNameAndNext('query'));
+        TestModel.observe('access', pushNameAndNext('access'));
         TestModel.observe('before save', pushNameAndNext('before save'));
 
-        TestModel.observe('query', function(ctx, next) {
+        TestModel.observe('access', function(ctx, next) {
           ctx.query = { where: { id: { neq: existingInstance.id } } };
           next();
         });
@@ -710,7 +710,7 @@ module.exports = function(dataSource, should) {
           { id: 'ignored', name: 'new name' },
           function(err, instance) {
             if (err) return done(err);
-            observersCalled.should.eql(['query', 'before save']);
+            observersCalled.should.eql(['access', 'before save']);
             done();
           });
       });
@@ -855,8 +855,8 @@ module.exports = function(dataSource, should) {
     });
 
     describe('PersistedModel.deleteAll', function() {
-      it('triggers `query` hook with query', function(done) {
-        TestModel.observe('query', pushContextAndNext());
+      it('triggers `access` hook with query', function(done) {
+        TestModel.observe('access', pushContextAndNext());
 
         TestModel.deleteAll({ name: existingInstance.name }, function(err) {
           if (err) return done(err);
@@ -867,8 +867,8 @@ module.exports = function(dataSource, should) {
         });
       });
 
-      it('triggers `query` hook without query', function(done) {
-        TestModel.observe('query', pushContextAndNext());
+      it('triggers `access` hook without query', function(done) {
+        TestModel.observe('access', pushContextAndNext());
 
         TestModel.deleteAll(function(err) {
           if (err) return done(err);
@@ -877,8 +877,8 @@ module.exports = function(dataSource, should) {
         });
       });
 
-      it('applies updates from `query` hook', function(done) {
-        TestModel.observe('query', function(ctx, next) {
+      it('applies updates from `access` hook', function(done) {
+        TestModel.observe('access', function(ctx, next) {
           ctx.query = { where: { id: { neq: existingInstance.id } } };
           next();
         });
@@ -977,8 +977,8 @@ module.exports = function(dataSource, should) {
     });
 
     describe('PersistedModel.prototype.delete', function() {
-      it('triggers `query` hook', function(done) {
-        TestModel.observe('query', pushContextAndNext());
+      it('triggers `access` hook', function(done) {
+        TestModel.observe('access', pushContextAndNext());
 
         existingInstance.delete(function(err) {
           if (err) return done(err);
@@ -989,8 +989,8 @@ module.exports = function(dataSource, should) {
         });
       });
 
-      it('applies updated from `query` hook', function(done) {
-        TestModel.observe('query', function(ctx, next) {
+      it('applies updated from `access` hook', function(done) {
+        TestModel.observe('access', function(ctx, next) {
           ctx.query = { where: { id: { neq: existingInstance.id } } };
           next();
         });
@@ -1080,24 +1080,24 @@ module.exports = function(dataSource, should) {
       });
 
       it('triggers hooks only once', function(done) {
-        TestModel.observe('query', pushNameAndNext('query'));
+        TestModel.observe('access', pushNameAndNext('access'));
         TestModel.observe('after delete', pushNameAndNext('after delete'));
-        TestModel.observe('query', function(ctx, next) {
+        TestModel.observe('access', function(ctx, next) {
           ctx.query = { where: { id: { neq: existingInstance.id } } };
           next();
         });
 
         existingInstance.delete(function(err) {
           if (err) return done(err);
-          observersCalled.should.eql(['query', 'after delete']);
+          observersCalled.should.eql(['access', 'after delete']);
           done();
         });
       });
     });
 
     describe('PersistedModel.updateAll', function() {
-      it('triggers `query` hook', function(done) {
-        TestModel.observe('query', pushContextAndNext());
+      it('triggers `access` hook', function(done) {
+        TestModel.observe('access', pushContextAndNext());
 
         TestModel.updateAll(
           { name: 'searched' },
@@ -1111,8 +1111,8 @@ module.exports = function(dataSource, should) {
           });
       });
 
-      it('applies updates from `query` hook', function(done) {
-        TestModel.observe('query', function(ctx, next) {
+      it('applies updates from `access` hook', function(done) {
+        TestModel.observe('access', function(ctx, next) {
           ctx.query = { where: { id: { neq: existingInstance.id } } };
           next();
         });

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -1718,6 +1718,45 @@ describe('relations', function () {
   
   });
 
+  describe('belongsTo with embed', function () {
+    var Person, Passport;
+
+    it('can be declared with embed and properties', function (done) {
+      Person = db.define('Person', {name: String, age: Number});
+      Passport = db.define('Passport', {name: String, notes: String});
+      Passport.belongsTo(Person, {
+        properties: ['name'],
+        options: { embedsProperties: true, invertProperties: true }
+      });
+      db.automigrate(done);
+    });
+
+    it('should create record with embedded data', function (done) {
+      Person.create({name: 'Fred', age: 36 }, function(err, person) {
+        var p = new Passport({ name: 'Passport', notes: 'Some notes...' });
+        p.person(person);
+        p.personId.should.equal(person.id);
+        var data = p.toObject(true);
+        data.person.id.should.equal(person.id);
+        data.person.name.should.equal('Fred');
+        p.save(function (err) {
+          should.not.exists(err);
+          done();
+        });
+      });
+    });
+
+    it('should find record with embedded data', function (done) {
+      Passport.findOne(function (err, p) {
+        should.not.exists(err);
+        var data = p.toObject(true);
+        data.person.id.should.equal(p.personId);
+        data.person.name.should.equal('Fred');
+        done();
+      });
+    });
+  });
+
   describe('hasOne', function () {
     var Supplier, Account;
     var supplierId, accountId;

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -1809,6 +1809,24 @@ describe('relations', function () {
         });
       });
     });
+
+    it('should ignore the foreign key in the update', function(done) {
+      Supplier.create({name: 'Supplier 2'}, function (e, supplier) {
+        var sid = supplier.id;
+        Supplier.findById(supplierId, function(e, supplier) {
+          should.not.exist(e);
+          should.exist(supplier);
+          supplier.account.update({supplierName: 'Supplier A',
+              supplierId: sid},
+            function(err, act) {
+              should.not.exist(e);
+              act.supplierName.should.equal('Supplier A');
+              act.supplierId.should.equal(supplierId);
+              done();
+            });
+        });
+      });
+    });
     
     it('should get the related item on scope', function(done) {
       Supplier.findById(supplierId, function(e, supplier) {

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -1821,7 +1821,7 @@ describe('relations', function () {
             function(err, act) {
               should.not.exist(e);
               act.supplierName.should.equal('Supplier A');
-              act.supplierId.should.equal(supplierId);
+              act.supplierId.should.eql(supplierId);
               done();
             });
         });

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -727,7 +727,7 @@ describe('relations', function () {
       Job = db.define('Job', {name: String, type: String});
 
       Category.hasMany(Job, {
-        properties: function(inst) {
+        properties: function(inst, target) {
           if (!inst.jobType) return; // skip
           return { type: inst.jobType };
         },

--- a/test/validations.test.js
+++ b/test/validations.test.js
@@ -387,6 +387,30 @@ describe('validations', function () {
   describe('format', function () {
     it('should validate format');
     it('should overwrite default blank message with custom format message');
+
+    it('should skip missing values when allowing null', function () {
+      User.validatesFormatOf('email', { with: /^\S+@\S+\.\S+$/, allowNull: true });
+      var u = new User({});
+      u.isValid().should.be.true;
+    });
+
+    it('should skip null values when allowing null', function () {
+      User.validatesFormatOf('email', { with: /^\S+@\S+\.\S+$/, allowNull: true });
+      var u = new User({ email: null });
+      u.isValid().should.be.true;
+    });
+
+    it('should not skip missing values', function () {
+      User.validatesFormatOf('email', { with: /^\S+@\S+\.\S+$/ });
+      var u = new User({});
+      u.isValid().should.be.false;
+    });
+
+    it('should not skip null values', function () {
+      User.validatesFormatOf('email', { with: /^\S+@\S+\.\S+$/ });
+      var u = new User({ email: null });
+      u.isValid().should.be.false;
+    });
   });
 
   describe('numericality', function () {


### PR DESCRIPTION
When using mongodb as database, I often use the native `findAndModify()` to perform a `find or create` (using `$setOnInsert` and `upsert` option). Since `findAndModify()` is an atomic operation, it won't cause conflict in some cases.

This PR tests that if the `connector` support `findOrCreate`, and if so then use it, otherwise `find()` or `create()`.

**Note**:
Since this is an atomic operation now, should the `create` hooks be triggered?

Signed-off-by: Clark Wang <clark.wangs@gmail.com>