### PR TITLE
Supply target to applyProperties function

### DIFF
--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -213,7 +213,7 @@ RelationDefinition.prototype.applyProperties = function(modelInstance, obj) {
     target[this.keyTo] = source[this.keyTo];
   }
   if (typeof this.properties === 'function') {
-    var data = this.properties.call(this, source);
+    var data = this.properties.call(this, source, target);
     for(var k in data) {
       target[k] = data[k];
     }

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -727,7 +727,7 @@ describe('relations', function () {
       Job = db.define('Job', {name: String, type: String});
 
       Category.hasMany(Job, {
-        properties: function(inst) {
+        properties: function(inst, target) {
           if (!inst.jobType) return; // skip
           return { type: inst.jobType };
         },


### PR DESCRIPTION
This is a tiny fix for relations with a function to transfer properties during creation. In order to preserve given target values specifically, provide the target to the properties function (if present, one can decide to override or keep as specified).