### PR TITLE
Fixed nullCheck in validations for undefined attributes

### DIFF
--- a/lib/validations.js
+++ b/lib/validations.js
@@ -589,8 +589,7 @@ var defaultMessages = {
 };
 
 function nullCheck(attr, conf, err) {
-  var isNull = this[attr] === null || !(attr in this);
-  if (isNull) {
+  if (this[attr] == null) {
     if (!conf.allowNull) {
       err('null');
     }

--- a/test/validations.test.js
+++ b/test/validations.test.js
@@ -387,6 +387,30 @@ describe('validations', function () {
   describe('format', function () {
     it('should validate format');
     it('should overwrite default blank message with custom format message');
+
+    it('should skip missing values when allowing null', function () {
+      User.validatesFormatOf('email', { with: /^\S+@\S+\.\S+$/, allowNull: true });
+      var u = new User({});
+      u.isValid().should.be.true;
+    });
+
+    it('should skip null values when allowing null', function () {
+      User.validatesFormatOf('email', { with: /^\S+@\S+\.\S+$/, allowNull: true });
+      var u = new User({ email: null });
+      u.isValid().should.be.true;
+    });
+
+    it('should not skip missing values', function () {
+      User.validatesFormatOf('email', { with: /^\S+@\S+\.\S+$/ });
+      var u = new User({});
+      u.isValid().should.be.false;
+    });
+
+    it('should not skip null values', function () {
+      User.validatesFormatOf('email', { with: /^\S+@\S+\.\S+$/ });
+      var u = new User({ email: null });
+      u.isValid().should.be.false;
+    });
   });
 
   describe('numericality', function () {


### PR DESCRIPTION
The current code `!(attr in this)` was not working (and I have written a unit test showing this). I have replaced it with a typeof undefined check. This then passes the unit test.

I have also written a couple of other unit tests to check other possible cases to ensure my change does not impact those.