### PR TITLE
Implement intent hook `before delete`

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -995,7 +995,11 @@ DataAccessObject.remove = DataAccessObject.deleteAll = DataAccessObject.destroyA
       { Model: Model, query: query },
       function(err, ctx) {
         if (err) return cb(err);
-        doDelete(ctx.query.where);
+        var context = { Model: Model, where: ctx.query.where };
+        Model.notifyObserversOf('before delete', context, function(err, ctx) {
+          if (err) return cb(err);
+          doDelete(ctx.where);
+        });
       });
   }
 
@@ -1311,7 +1315,13 @@ DataAccessObject.prototype.remove =
         { Model: Model, query: byIdQuery(Model, id) },
         function(err, ctx) {
           if (err) return cb(err);
-          doDeleteInstance(ctx.query.where);
+          Model.notifyObserversOf(
+            'before delete',
+            { Model: Model, where: ctx.query.where },
+            function(err, ctx) {
+              if (err) return cb(err);
+              doDeleteInstance(ctx.where);
+            });
         });
 
       function doDeleteInstance(where) {


### PR DESCRIPTION
Methods `DAO.deleteAll` and `DAO.prototype.delete` now invoke `before delete` hook too. The hook receives `ctx.where` describing models to be deleted.

Connect #367

/to @raymondfeng please review
/cc @ritch FYI