### PR TITLE
use optimized findOrCreate if possible

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -373,9 +373,11 @@ DataAccessObject.updateOrCreate = DataAccessObject.upsert = function upsert(data
  * @param {Object} query Search conditions. See [find](#dataaccessobjectfindquery-callback) for query format.
  * For example: `{where: {test: 'me'}}`.
  * @param {Object} data Object to create.
- * @param {Function} cb Callback called with (err, instance, created)
+ * @param {Function} callback Callback called with (err, instance, created)
  */
 DataAccessObject.findOrCreate = function findOrCreate(query, data, callback) {
+  if (stillConnecting(this.getDataSource(), this, arguments)) return;
+
   if (query === undefined) {
     query = {where: {}};
   }
@@ -388,14 +390,81 @@ DataAccessObject.findOrCreate = function findOrCreate(query, data, callback) {
     };
   }
 
+  var self = this;
   var Model = this;
-  Model.findOne(query, function (err, record) {
-    if (err) return callback(err);
-    if (record) return callback(null, record, false);
-    Model.create(data, function (err, record) {
-      callback(err, record, record != null);
+
+  if (this.getDataSource().connector.findOrCreate) {
+    query.limit = 1;
+
+    try {
+      this._normalize(query);
+    } catch (err) {
+      return process.nextTick(function () {
+        callback && callback(err);
+      });
+    }
+
+    this.applyScope(query);
+
+    Model.notifyObserversOf('access', { Model: Model, query: query }, function (err, ctx) {
+      if (err) return callback(err);
+
+      var query = ctx.query;
+
+      var enforced = {};
+      var Model = self.lookupModel(data);
+      var obj = data instanceof Model ? data : new Model(data);
+
+      Model.applyProperties(enforced, obj);
+      obj.setAttributes(enforced);
+
+      Model.notifyObserversOf('before save', { Model: Model, instance: obj }, function(err, ctx) {
+        if (err) return callback(err);
+
+        var obj = ctx.instance;
+        var data = obj.toObject(true);
+
+        // validation required
+        obj.isValid(function (valid) {
+          if (valid) {
+            findOrCreate(query, data);
+          } else {
+            callback(new ValidationError(obj), obj);
+          }
+        }, data);
+      });
+
     });
-  });
+
+    function findOrCreate(query, data) {
+      var modelName = Model.modelName;
+      data = removeUndefined(data);
+      self.getDataSource().connector.findOrCreate(modelName, query, self._forDB(data), function (err, data, created) {
+        var obj, Model = self.lookupModel(data);
+
+        if (data) {
+          obj = new Model(data, {fields: query.fields, applySetters: false, persisted: true});
+        }
+
+        if (created) {
+          Model.notifyObserversOf('after save', { Model: Model, instance: obj }, function(err) {
+            callback(err, obj, created);
+            if(!err) Model.emit('changed', obj);
+          });
+        } else {
+          callback(err, obj, created);
+        }
+      });
+    }
+  } else {
+    Model.findOne(query, function (err, record) {
+      if (err) return callback(err);
+      if (record) return callback(null, record, false);
+      Model.create(data, function (err, record) {
+        callback(err, record, record != null);
+      });
+    });
+  }
 };
 
 /**

--- a/test/memory.test.js
+++ b/test/memory.test.js
@@ -399,16 +399,29 @@ describe('Memory connector', function() {
       });
     });
   });
+});
 
-  require('./persistence-hooks.suite')(
-    new DataSource({ connector: Memory }),
-    should);
+describe('Optimized connector', function() {
+  var ds = new DataSource({ connector: Memory });
+
+  // optimized methods
+  ds.connector.findOrCreate = function (model, query, data, callback) {
+    this.all(model, query, function (err, list) {
+      if (err || (list && list[0])) return callback(err, list && list[0], false);
+      this.create(model, data, function (err) {
+        callback(err, data, true);
+      });
+    }.bind(this));
+  };
+
+  require('./persistence-hooks.suite')(ds, should);
 });
 
 describe('Unoptimized connector', function() {
   var ds = new DataSource({ connector: Memory });
   // disable optimized methods
   ds.connector.updateOrCreate = false;
+  ds.connector.findOrCreate = false;
 
   require('./persistence-hooks.suite')(ds, should);
 });


### PR DESCRIPTION
When using mongodb as database, I often use the native `findAndModify()` to perform a `find or create` (using `$setOnInsert` and `upsert` option). Since `findAndModify()` is an atomic operation, it won't cause conflict in some cases.

This PR tests that if the `connector` support `findOrCreate`, and if so then use it, otherwise `find()` or `create()`.

This PR use the new hook system introduced in https://github.com/strongloop/loopback-datasource-juggler/pull/403

Signed-off-by: Clark Wang <clark.wangs@gmail.com>