### PR TITLE
Relax "id" checks in test/manipulation.test.js

### DIFF
--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -50,7 +50,7 @@ describe('manipulation', function () {
         should.not.exist(err);
         should.exist(p);
         Person.findById(p.id, function (err, person) {
-          person.id.should.equal(p.id);
+          person.id.should.eql(p.id);
           person.name.should.equal('Anatoliy');
           done();
         });
@@ -122,7 +122,7 @@ describe('manipulation', function () {
         should.exist(p);
         should.not.exists(p.name);
         Person.findById(p.id, function (err, person) {
-          person.id.should.equal(p.id);
+          person.id.should.eql(p.id);
           should.not.exists(person.name);
           done();
         });


### PR DESCRIPTION
Use `eql` instead of `equal` to support non-scalar id values used by MongoDB connector.

/cc @raymondfeng FYI