### PR TITLE
Fix the perf around should.not.equal for complex objects

### DIFF
--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -13,16 +13,16 @@ describe('dataSource', function () {
   });
 
   it('should clone existing model', function () {
-    // Workaround for a possible bug in `should`
-    // where it takes ages to evaluate `should.equal` for complex objects
-    this.timeout(20000);
-
     SlaveModel = slave.copyModel(Model);
     SlaveModel.dataSource.should.equal(slave);
-    slave.should.not.equal(db);
+    // Workaround for an performance issue in `should` by customizing the msg
+    // where it takes ages to evaluate `should.not.equal` for complex objects
+    // https://github.com/shouldjs/should.js/blob/master/lib/assertion.js#L159-L162
+    slave.should.not.equal(db, 'The two data sources should be different');
     var sm = new SlaveModel;
     sm.should.be.instanceOf(Model);
-    sm.getDataSource().should.not.equal(db);
+    sm.getDataSource().should.not.equal(db, 'The data source of an instance ' +
+      'of the slave model should be different from the original one');
     sm.getDataSource().should.equal(slave);
   });
 


### PR DESCRIPTION
/to @bajtos 

The PR fixes the performance issue by providing a custom message to `should.not.equal` calls. The `should` module always asserts the `equal` first, creates an `AssertionError`, and then tests the `not` condition. See See https://github.com/shouldjs/should.js/blob/master/lib/assertion.js#L47-L68. For complex objects, the [getMessage](https://github.com/shouldjs/should.js/blob/master/lib/assertion.js#L202-L208) is very expensive. It takes more than 4 seconds for a `DataSource` object that has references to many models.

I'll create an issue to should.js too.