### PR TITLE
Always use findOrCreate when creating a through model

### DIFF
--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -954,13 +954,14 @@ HasManyThrough.prototype.create = function create(data, done) {
     var fk2 = keys[1];
 
     function createRelation(to, next) {
-      var d = {};
-      d[fk1] = modelInstance[definition.keyFrom];
-      d[fk2] = to[pk2];
+      var d = {}, q = {}, filter = {where:q};
+      d[fk1] = q[fk1] = modelInstance[definition.keyFrom];
+      d[fk2] = q[fk2] = to[pk2];
       definition.applyProperties(modelInstance, d);
+      definition.applyScope(modelInstance, filter);
 
       // Then create the through model
-      modelThrough.create(d, function (e, through) {
+      modelThrough.findOrCreate(filter, d, function (e, through) {
         if (e) {
           // Undo creation of the target model
           to.destroy(function () {


### PR DESCRIPTION
fix a problem that mentioned in strongloop/loopback-connector-mongodb#92

Notes:
1. The earlier commits add `.editorconfig`, I have separated the changes to a standalone commit beside the real patch 
2. I don't see the necessary to add new tests since they have already covered, and pass tests of strongloop/loopback-connector-mongodb#92
3. to @raymondfeng , although this PR fix the id problem, but for a `HasManyThrough#create`, it does **create** a **new** model every time, hence the through model will always been **created**, it would never been **found**. So the query is unnecessary if the connector doesn't support optimized `findOrCreate`. Is that ok?