### PR TITLE
Promises for operation hooks

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -567,7 +567,15 @@ ModelBaseClass.notifyObserversOf = function(operation, context, callback) {
 
     async.eachSeries(
       observers,
-      function(fn, next) { fn(context, next); },
+      function notifySingleObserver(fn, next) {
+        var retval = fn(context, next);
+        if (retval && typeof retval.then === 'function') {
+          retval.then(
+            function() { next(); },
+            next // error handler
+          );
+        }
+      },
       function(err) { callback(err, context) }
     );
   });

--- a/lib/model.js
+++ b/lib/model.js
@@ -561,6 +561,8 @@ ModelBaseClass.observe = function(operation, listener) {
 ModelBaseClass.notifyObserversOf = function(operation, context, callback) {
   var observers = this._observers && this._observers[operation];
 
+  if (!callback) callback = utils.createPromiseCallback();
+
   this._notifyBaseObservers(operation, context, function doNotify(err) {
     if (err) return callback(err, context);
     if (!observers || !observers.length) return callback(null, context);
@@ -579,6 +581,7 @@ ModelBaseClass.notifyObserversOf = function(operation, context, callback) {
       function(err) { callback(err, context) }
     );
   });
+  return callback.promise;
 }
 
 ModelBaseClass._notifyBaseObservers = function(operation, context, callback) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,6 +9,7 @@ exports.defineCachedRelations = defineCachedRelations;
 exports.sortObjectsByIds = sortObjectsByIds;
 exports.setScopeValuesFromWhere = setScopeValuesFromWhere;
 exports.mergeQuery = mergeQuery;
+exports.createPromiseCallback = createPromiseCallback
 
 var traverse = require('traverse');
 
@@ -340,3 +341,30 @@ function sortObjectsByIds(idName, ids, objects, strict) {
   
   return heading.concat(tailing);
 };
+
+function createPromiseCallback() {
+  var cb;
+
+  if (!global.Promise) {
+    cb = function(){};
+    cb.promise = {};
+    Object.defineProperty(cb.promise, 'then', { get: throwPromiseNotDefined });
+    Object.defineProperty(cb.promise, 'catch', { get: throwPromiseNotDefined });
+    return cb;
+  }
+
+  var promise = new Promise(function (resolve, reject) {
+    cb = function (err, data) {
+      if (err) return reject(err);
+      return resolve(data);
+    };
+  });
+  cb.promise = promise;
+  return cb;
+}
+
+function throwPromiseNotDefined() {
+  throw new Error(
+    'Your Node runtime does support ES6 Promises. ' +
+    'Set "global.Promise" to your preferred implementation of promises.');
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "node >= 0.6"
   ],
   "devDependencies": {
+    "bluebird": "^2.9.9",
     "mocha": "^2.1.0",
     "should": "^5.0.0"
   },

--- a/test/async-observer.test.js
+++ b/test/async-observer.test.js
@@ -1,6 +1,5 @@
 var ModelBuilder = require('../').ModelBuilder;
 var should = require('./init');
-var Promise = global.Promise || require('bluebird');
 
 describe('async observer', function() {
   var TestModel;
@@ -114,6 +113,28 @@ describe('async observer', function() {
       err.should.eql(testError);
       done();
     });
+  });
+
+  it('returns a promise when no callback is provided', function() {
+    var context = { value: 'a-test-context' };
+    var p = TestModel.notifyObserversOf('event', context);
+    (p !== undefined).should.be.true;
+    return p.then(function(result) {
+      result.should.eql(context);
+    });
+  });
+
+  it('returns a rejected promise when no callback is provided', function() {
+    var testError = new Error('expected test error');
+    TestModel.observe('event', function(ctx, next) { next(testError); });
+    var p = TestModel.notifyObserversOf('event', context);
+    return p.then(
+      function(result) {
+        throw new Error('The promise should have been rejected.');
+      },
+      function(err) {
+        err.should.eql(testError);
+      });
   });
 });
 

--- a/test/async-observer.test.js
+++ b/test/async-observer.test.js
@@ -1,5 +1,6 @@
 var ModelBuilder = require('../').ModelBuilder;
 var should = require('./init');
+var Promise = global.Promise || require('bluebird');
 
 describe('async observer', function() {
   var TestModel;
@@ -90,6 +91,27 @@ describe('async observer', function() {
     var context = {};
     TestModel.notifyObserversOf('event', context, function(err, ctx) {
       (ctx || "null").should.equal(context);
+      done();
+    });
+  });
+
+  it('resolves promises returned by observers', function(done) {
+    TestModel.observe('event', function(ctx) {
+      return Promise.resolve('value-to-ignore');
+    });
+    TestModel.notifyObserversOf('event', {}, function(err, ctx) {
+      // the test times out when the promises are not supported
+      done();
+    });
+  });
+
+  it('handles rejected promise returned by an observer', function(done) {
+    var testError = new Error('expected test error');
+    TestModel.observe('event', function(ctx) {
+      return Promise.reject(testError);
+    });
+    TestModel.notifyObserversOf('event', {}, function(err, ctx) {
+      err.should.eql(testError);
       done();
     });
   });

--- a/test/init.js
+++ b/test/init.js
@@ -26,3 +26,7 @@ if (!('getModelBuilder' in global)) {
     return new ModelBuilder();
   };
 }
+
+if (!('Promise' in global)) {
+  global.Promise = require('bluebird');
+}


### PR DESCRIPTION
- Allow the observer functions passed to `ModelBaseClass.observe` to return a promise instead of calling the callback.

- Support both promise and callback styles in `ModelBaseClass.notifyObserversOf`.

Related: https://github.com/strongloop/strong-remoting/pull/179 and https://github.com/strongloop/loopback-datasource-juggler/pull/447
Connect strongloop/loopback#418

/to @raymondfeng Please review.
/cc @partap This patch provides the infrastructure needed for promise support, it's based on my comments in your PR. My plan is to land this PR first, so that you can use this infrastructure in your PR.