### PR TITLE
Implement 'Guid' type + fix loading of the GeoPoint type

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ exports.ModelBuilder = exports.LDL = require('./lib/model-builder.js').ModelBuil
 exports.DataSource = exports.Schema = require('./lib/datasource.js').DataSource;
 exports.ModelBaseClass = require('./lib/model.js');
 exports.GeoPoint = require('./lib/geo.js').GeoPoint;
+exports.Guid = require('./lib/guid');
 exports.ValidationError = require('./lib/validations.js').ValidationError;
 
 Object.defineProperty(exports, 'version', {

--- a/lib/connectors/memory.js
+++ b/lib/connectors/memory.js
@@ -2,6 +2,7 @@ var util = require('util');
 var Connector = require('loopback-connector').Connector;
 var geo = require('../geo');
 var GeoPoint = geo.GeoPoint;
+var Guid = require('../guid');
 var utils = require('../utils');
 var fs = require('fs');
 var async = require('async');
@@ -280,6 +281,9 @@ Memory.prototype.fromDb = function (model, data) {
           break;
         case 'GeoPoint':
           val = GeoPoint(val);
+          break;
+        case 'Guid':
+          val = Guid(val);
           break;
       }
     }

--- a/lib/connectors/memory.js
+++ b/lib/connectors/memory.js
@@ -1,6 +1,7 @@
 var util = require('util');
 var Connector = require('loopback-connector').Connector;
 var geo = require('../geo');
+var GeoPoint = geo.GeoPoint;
 var utils = require('../utils');
 var fs = require('fs');
 var async = require('async');
@@ -276,6 +277,9 @@ Memory.prototype.fromDb = function (model, data) {
           break;
         case 'Number':
           val = Number(val);
+          break;
+        case 'GeoPoint':
+          val = GeoPoint(val);
           break;
       }
     }

--- a/lib/guid.js
+++ b/lib/guid.js
@@ -10,7 +10,8 @@ function Guid(data) {
   }
 
   if (data === undefined || data === 'new') {
-    data = uuid.v4();
+    // Generate a v1 (time-based) id
+    data = uuid.v1();
   } else if (data instanceof Guid) {
     data = data.value;
   }

--- a/lib/guid.js
+++ b/lib/guid.js
@@ -1,0 +1,33 @@
+var assert = require('assert');
+var uuid = require('node-uuid');
+module.exports = Guid;
+
+var UUID_REGEXP = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function Guid(data) {
+  if (!(this instanceof Guid)) {
+    return new Guid(data);
+  }
+
+  if (data === undefined || data === 'new') {
+    data = uuid.v4();
+  } else if (data instanceof Guid) {
+    data = data.value;
+  }
+
+  assert(typeof data === 'string',
+    'Guid value must be a string, was "' + (typeof data) + '" instead');
+  assert(UUID_REGEXP.test(data),
+    'Guid value must be a valid UUID as specified by RFC4122,' +
+    ' was "' + data + '" instead');
+
+  this.value = data;
+}
+
+Guid.prototype.toObject =
+Guid.prototype.toJSON =
+Guid.prototype.toString = function() {
+  return this.value;
+};
+
+

--- a/lib/types.js
+++ b/lib/types.js
@@ -61,6 +61,7 @@ module.exports = function (modelTypes) {
   modelTypes.registerType(Buffer, ['Binary']);
   modelTypes.registerType(Array);
   modelTypes.registerType(GeoPoint);
+  modelTypes.registerType(require('./guid'));
   modelTypes.registerType(Object);
 };
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "inflection": "^1.6.0",
     "lodash": "~3.0.1",
     "loopback-connector": "1.x",
+    "node-uuid": "^1.4.2",
     "qs": "^2.3.3",
     "traverse": "^0.6.6"
   },

--- a/test/basic-querying.test.js
+++ b/test/basic-querying.test.js
@@ -2,6 +2,7 @@
 var should = require('./init.js');
 var async = require('async');
 var db, User;
+var aGuidValue = require('../').Guid();
 
 describe('basic-querying', function () {
 
@@ -14,6 +15,7 @@ describe('basic-querying', function () {
       birthday: {type: Date, index: true},
       role: {type: String, index: true},
       order: {type: Number, index: true, sort: true},
+      guid: {type: 'Guid' },
       vip: {type: Boolean}
     });
 
@@ -58,7 +60,7 @@ describe('basic-querying', function () {
     });
 
   });
-  
+
   describe('findByIds', function () {
 
     before(function(done) {
@@ -88,9 +90,9 @@ describe('basic-querying', function () {
         done();
       });
     });
-    
+
     it('should query by ids and condition', function (done) {
-      User.findByIds([4, 3, 2, 1], 
+      User.findByIds([4, 3, 2, 1],
         { where: { vip: true } }, function (err, users) {
         should.exist(users);
         should.not.exist(err);
@@ -424,6 +426,27 @@ describe('basic-querying', function () {
       });
     });
 
+    it('should support string guid equality that is satisfied', function(done) {
+      User.find(
+        { where: { guid: aGuidValue.toString() } },
+        function(err, users) {
+          should.not.exist(err);
+          users.should.have.length(1);
+          users[0].should.have.property('guid', aGuidValue);
+          done();
+        });
+    });
+
+    it('should support object guid equality that is satisfied', function(done) {
+      User.find(
+        { where: { guid: aGuidValue } },
+        function(err, users) {
+          should.not.exist(err);
+          users.should.have.length(1);
+          users[0].should.have.property('guid', aGuidValue);
+          done();
+        });
+    });
 
     it('should only include fields as specified', function (done) {
       var remaining = 0;
@@ -464,7 +487,7 @@ describe('basic-querying', function () {
       }
 
       sample({name: true}).expect(['name']);
-      sample({name: false}).expect(['id', 'seq', 'email', 'role', 'order', 'birthday', 'vip']);
+      sample({name: false}).expect(['id', 'seq', 'email', 'role', 'order', 'birthday', 'vip', 'guid']);
       sample({name: false, id: true}).expect(['id']);
       sample({id: true}).expect(['id']);
       sample('id').expect(['id']);
@@ -649,6 +672,7 @@ function seed(done) {
       role: 'lead',
       birthday: new Date('1980-12-08'),
       order: 2,
+      guid: aGuidValue,
       vip: true
     },
     {

--- a/test/datatype.test.js
+++ b/test/datatype.test.js
@@ -1,5 +1,7 @@
 // This test written in mocha+should.js
 var should = require('./init.js');
+var Guid = require('../').Guid;
+var GeoPoint = require('../').GeoPoint;
 
 var db, Model;
 
@@ -14,6 +16,8 @@ describe('datatypes', function () {
       date: Date,
       num: Number,
       bool: Boolean,
+      loc: 'GeoPoint',
+      guid: 'Guid',
       list: {type: [String]},
       arr: Array,
       nested: Nested
@@ -53,6 +57,7 @@ describe('datatypes', function () {
     var d = new Date, id;
 
     Model.create({
+      guid: new Guid().toString(), loc: '10,20',
       str: 'hello', date: d, num: '3', bool: 1, list: ['test'], arr: [1, 'str']
     }, function (err, m) {
       should.not.exists(err);
@@ -60,6 +65,8 @@ describe('datatypes', function () {
       m.str.should.be.type('string');
       m.num.should.be.type('number');
       m.bool.should.be.type('boolean');
+      m.loc.should.be.instanceOf(GeoPoint);
+      m.guid.should.be.instanceOf(Guid);
       m.list[0].should.be.equal('test');
       m.arr[0].should.be.equal(1);
       m.arr[1].should.be.equal('str');
@@ -74,6 +81,8 @@ describe('datatypes', function () {
         m.str.should.be.type('string');
         m.num.should.be.type('number');
         m.bool.should.be.type('boolean');
+        m.loc.should.be.instanceOf(GeoPoint);
+        m.guid.should.be.instanceOf(Guid);
         m.list[0].should.be.equal('test');
         m.arr[0].should.be.equal(1);
         m.arr[1].should.be.equal('str');
@@ -90,6 +99,7 @@ describe('datatypes', function () {
         m.str.should.be.type('string');
         m.num.should.be.type('number');
         m.bool.should.be.type('boolean');
+        m.guid.should.be.instanceOf(Guid);
         m.date.should.be.an.instanceOf(Date);
         m.date.toString().should.equal(d.toString(), 'Time must match');
         done();
@@ -100,9 +110,10 @@ describe('datatypes', function () {
 
   it('should respect data types when updating attributes', function (done) {
     var d = new Date, id;
+    var guid = new Guid();
 
     Model.create({
-      str: 'hello', date: d, num: '3', bool: 1}, function(err, m) {
+      guid: guid, str: 'hello', date: d, num: '3', bool: 1}, function(err, m) {
       should.not.exist(err);
       should.exist(m && m.id);
 
@@ -110,6 +121,7 @@ describe('datatypes', function () {
       m.str.should.be.type('string');
       m.num.should.be.type('number');
       m.bool.should.be.type('boolean');
+      m.guid.should.eql(guid);
       id = m.id;
       testDataInDB(function () {
         testUpdate(function() {
@@ -121,24 +133,26 @@ describe('datatypes', function () {
     function testUpdate(done) {
       Model.findById(id, function(err, m) {
         should.not.exist(err);
+        guid = new Guid();
 
         // update using updateAttributes
         m.updateAttributes({
-          id: id, num: '10'
+          id: id, num: '10', guid: guid.toString(),
         }, function (err, m) {
           should.not.exist(err);
-          m.num.should.be.type('number');
+          m.num.should.eql(10);
+          m.guid.should.eql(guid);
           done();
         });
       });
     }
 
     function testDataInDB(done) {
-
       // verify that the value stored in the db is still an object
       db.connector.find(Model.modelName, id, function (err, data) {
         should.exist(data);
         data.num.should.be.type('number');
+        data.guid.should.eql(guid);
         done();
       });
     }

--- a/test/guid.test.js
+++ b/test/guid.test.js
@@ -1,0 +1,42 @@
+var should = require('should');
+
+var Guid = require('..').Guid;
+
+describe('Guid', function() {
+  it('accepts string value in the UUID format', function() {
+    var val = new Guid('88157b51-84c4-4fe4-89e6-7c9acbf23688');
+    val.toString().should.equal('88157b51-84c4-4fe4-89e6-7c9acbf23688');
+  });
+
+  it('rejects malformed string values', function() {
+    should.throws(function() { new Guid('not-a-guid'); });
+  });
+
+  it('generates a unique id when the data is empty', function() {
+    var val1 = new Guid();
+    var val2 = new Guid();
+    val1.toString().should.not.equal(val2.toString());
+    should.doesNotThrow(function() { return new Guid(val1); });
+  });
+
+  it('accepts guid value', function() {
+    var val = new Guid();
+    var copy = new Guid(val);
+    copy.toString().should.equal(val.toString());
+  });
+
+  it('generates a unique id when data is "new"', function() {
+    var val = new Guid('new');
+    should.doesNotThrow(function() { return new Guid(val); });
+  });
+
+  it('returns string as the JSON value', function() {
+    var val = new Guid();
+    JSON.stringify(val).should.equal(JSON.stringify(val.toString()));
+  });
+
+  it('returns string as the Object value', function() {
+    var val = new Guid();
+    val.toObject().should.equal(val.toString());
+  });
+});


### PR DESCRIPTION
The new type represents a UUID (GUID) string value.

The constructor interprets the value "new" as a request to generate
a new unique id, which allows developers to define auto-generated guid
properties in LDL:

    id: { type: 'guid', id: true, default: 'new' }

Connect #388

/to @raymondfeng @ritch @fabien @kraman  please review

