### PR TITLE
Corrects improper MySQL column updates resulting in a value of [object Object] for PUT updates

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -359,7 +359,7 @@ DataAccessObject.updateOrCreate = DataAccessObject.upsert = function upsert(data
 
         update = removeUndefined(update);
         self.getDataSource().connector
-          .updateOrCreate(Model.modelName, update, done);
+          .updateOrCreate(Model.modelName, self._forDB(update), done);
 
         function done(err, data) {
           var obj;
@@ -1284,6 +1284,10 @@ DataAccessObject.removeById = DataAccessObject.destroyById = DataAccessObject.de
       options = {};
     }
   }
+
+  options = options || {};
+  cb = cb || noCallback;
+
   assert(typeof options === 'object', 'The options argument must be an object');
   assert(typeof cb === 'function', 'The cb argument must be a function');
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -208,6 +208,7 @@ ModelBaseClass.prototype._initProperties = function (data, options) {
   for (k = 0; k < size; k++) {
     p = keys[k];
     propVal = self.__data[p];
+    var type = properties[p].type;
 
     // Set default values
     if (propVal === undefined) {
@@ -222,6 +223,8 @@ ModelBaseClass.prototype._initProperties = function (data, options) {
           } else {
             def = def();
           }
+        } else if (type.name === 'Date' && def === '$now') {
+          def = new Date();
         }
         // FIXME: We should coerce the value
         // will implement it after we refactor the PropertyDefinition
@@ -230,7 +233,6 @@ ModelBaseClass.prototype._initProperties = function (data, options) {
     }
 
     // Handle complex types (JSON/Object)
-    var type = properties[p].type;
     if (!BASE_TYPES[type.name]) {
 
       if (typeof self.__data[p] !== 'object' && self.__data[p]) {
@@ -561,16 +563,27 @@ ModelBaseClass.observe = function(operation, listener) {
 ModelBaseClass.notifyObserversOf = function(operation, context, callback) {
   var observers = this._observers && this._observers[operation];
 
+  if (!callback) callback = utils.createPromiseCallback();
+
   this._notifyBaseObservers(operation, context, function doNotify(err) {
     if (err) return callback(err, context);
     if (!observers || !observers.length) return callback(null, context);
 
     async.eachSeries(
       observers,
-      function(fn, next) { fn(context, next); },
+      function notifySingleObserver(fn, next) {
+        var retval = fn(context, next);
+        if (retval && typeof retval.then === 'function') {
+          retval.then(
+            function() { next(); },
+            next // error handler
+          );
+        }
+      },
       function(err) { callback(err, context) }
     );
   });
+  return callback.promise;
 }
 
 ModelBaseClass._notifyBaseObservers = function(operation, context, callback) {

--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -6,6 +6,7 @@ var util = require('util');
 var async = require('async');
 var utils = require('./utils');
 var i8n = require('inflection');
+var _ = require('lodash');
 var defineScope = require('./scope.js').defineScope;
 var mergeQuery = utils.mergeQuery;
 var ModelBaseClass = require('./model.js');
@@ -468,20 +469,14 @@ util.inherits(ReferencesMany, Relation);
 /*!
  * Find the relation by foreign key
  * @param {*} foreignKey The foreign key
- * @returns {Object} The relation object
+ * @returns {Array} The array of matching relation objects
  */
 function findBelongsTo(modelFrom, modelTo, keyTo) {
-  var relations = modelFrom.relations;
-  var keys = Object.keys(relations);
-  for (var k = 0; k < keys.length; k++) {
-    var rel = relations[keys[k]];
-    if (rel.type === RelationTypes.belongsTo &&
-      rel.modelTo === modelTo &&
-      (keyTo === undefined || rel.keyTo === keyTo)) {
-      return rel.keyFrom;
-    }
-  }
-  return null;
+  return _.pluck(_.filter(modelFrom.relations, function (rel) {
+    return (rel.type === RelationTypes.belongsTo &&
+            rel.modelTo === modelTo &&
+            (keyTo === undefined || rel.keyTo === keyTo));
+  }), 'keyFrom');
 }
 
 /*!
@@ -833,10 +828,12 @@ var throughKeys = function(definition) {
     } else {
       var fk2 = definition.keyThrough;
     }
+  } else if (definition.modelFrom === definition.modelTo) {
+    return findBelongsTo(modelThrough, definition.modelTo, pk2);
   } else {
     var fk1 = findBelongsTo(modelThrough, definition.modelFrom,
-      definition.keyFrom);
-    var fk2 = findBelongsTo(modelThrough, definition.modelTo, pk2);
+                            definition.keyFrom)[0];
+    var fk2 = findBelongsTo(modelThrough, definition.modelTo, pk2)[0];
   }
   return [fk1, fk2];
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,6 +9,7 @@ exports.defineCachedRelations = defineCachedRelations;
 exports.sortObjectsByIds = sortObjectsByIds;
 exports.setScopeValuesFromWhere = setScopeValuesFromWhere;
 exports.mergeQuery = mergeQuery;
+exports.createPromiseCallback = createPromiseCallback
 
 var traverse = require('traverse');
 
@@ -340,3 +341,30 @@ function sortObjectsByIds(idName, ids, objects, strict) {
   
   return heading.concat(tailing);
 };
+
+function createPromiseCallback() {
+  var cb;
+
+  if (!global.Promise) {
+    cb = function(){};
+    cb.promise = {};
+    Object.defineProperty(cb.promise, 'then', { get: throwPromiseNotDefined });
+    Object.defineProperty(cb.promise, 'catch', { get: throwPromiseNotDefined });
+    return cb;
+  }
+
+  var promise = new Promise(function (resolve, reject) {
+    cb = function (err, data) {
+      if (err) return reject(err);
+      return resolve(data);
+    };
+  });
+  cb.promise = promise;
+  return cb;
+}
+
+function throwPromiseNotDefined() {
+  throw new Error(
+    'Your Node runtime does support ES6 Promises. ' +
+    'Set "global.Promise" to your preferred implementation of promises.');
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "node >= 0.6"
   ],
   "devDependencies": {
+    "bluebird": "^2.9.9",
     "mocha": "^2.1.0",
     "should": "^5.0.0"
   },
@@ -30,6 +31,7 @@
     "async": "^0.9.0",
     "debug": "^2.1.1",
     "inflection": "^1.6.0",
+    "lodash": "~3.0.1",
     "loopback-connector": "1.x",
     "qs": "^2.3.3",
     "traverse": "^0.6.6"

--- a/test/crud-with-options.test.js
+++ b/test/crud-with-options.test.js
@@ -77,7 +77,7 @@ describe('crud-with-options', function () {
       });
 
   });
-  
+
   describe('findByIds', function () {
 
     before(function(done) {
@@ -351,6 +351,12 @@ describe('crud-with-options', function () {
       });
     });
 
+  });
+
+  describe('deleteById', function() {
+    it('should allow deleteById(id)', function () {
+      User.deleteById(1);
+    });
   });
 
   describe('updateAll ', function () {

--- a/test/events.js
+++ b/test/events.js
@@ -14,17 +14,13 @@ describe('events', function() {
       });
     });
     this.shouldEmitEvent = function(eventName, listener, done) {
-      var timeout = setTimeout(function() {
-        done(new Error('did not emit ' + eventName));
-      }, 100);
       this.TestModel.on(eventName, function() {
-        clearTimeout(timeout);
         listener.apply(this, arguments);
         done();
       });
     }
   });
-  
+
   describe('changed', function() {
     it('should be emitted after save', function(done) {
       var model = new this.TestModel({name: 'foobar'});
@@ -50,7 +46,7 @@ describe('events', function() {
       });
     });
   });
-  
+
   describe('deleted', function() {
     it('should be emitted after destroy', function(done) {
       this.shouldEmitEvent('deleted', assertValidDeletedArgs, done);
@@ -61,7 +57,7 @@ describe('events', function() {
       this.TestModel.deleteById(this.inst.id);
     });
   });
-  
+
   describe('deletedAll', function() {
     it('should be emitted after destroyAll', function(done) {
       this.shouldEmitEvent('deletedAll', function(where) {

--- a/test/init.js
+++ b/test/init.js
@@ -26,3 +26,7 @@ if (!('getModelBuilder' in global)) {
     return new ModelBuilder();
   };
 }
+
+if (!('Promise' in global)) {
+  global.Promise = require('bluebird');
+}

--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -442,6 +442,35 @@ describe('manipulation', function () {
       person.isNewRecord().should.be.true;
     });
 
+    it('should report current date when using $now as default value for date property',
+      function (done) {
+        var CustomModel = db.define('CustomModel', {
+          createdAt: { type: Date, default: '$now' }
+        });
+
+        var now = Date.now();
+
+        var myCustomModel = CustomModel.create(function (err, m) {
+           m.createdAt.should.be.instanceOf(Date);
+           (m.createdAt >= now).should.be.true;
+        });
+
+        done();
+    });
+
+    it('should report \'$now\' when using $now as default value for string property',
+      function (done) {
+        var CustomModel = db.define('CustomModel', {
+          now: { type: String, default: '$now' }
+        });
+
+        var myCustomModel = CustomModel.create(function (err, m) {
+          m.now.should.be.instanceOf(String);
+          m.now.should.equal('$now');
+        });
+
+        done();
+    });
     // it('should work when constructor called as function', function() {
     //     var p = Person({name: 'John Resig'});
     //     p.should.be.an.instanceOf(Person);

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -690,6 +690,18 @@ describe('relations', function () {
       });
     });
 
+    it('should set the keyThrough and the foreignKey', function (done) {
+      var user = new User({id: 1});
+      var user2 = new User({id: 2});
+      user.following.add(user2, function (err, f) {
+        should.not.exist(err);
+        should.exist(f);
+        f.followeeId.should.equal(user2.id);
+        f.followerId.should.equal(user.id);
+        done();
+      });
+    });
+
     it('can determine the collect via keyThrough for each side', function () {
       var user = new User({id: 1});
       var scope1 = user.followers._scope;


### PR DESCRIPTION
Original Issue: https://github.com/strongloop/loopback/issues/1101

Corrects property values which are arrays of objects (and possibly nested), being updated in MySQL as `[object Object]`, instead of the actual stringified value, when using `PUT /Model` and providing the `id` of the existing model instance in the request payload.
