### PR TITLE
support: add install-test-deps.js

### DIFF
--- a/support/install-test-deps.js
+++ b/support/install-test-deps.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+if (process.env.npm_config_production) return;
+
+var path = require('path');
+var juggler = path.resolve(path.dirname(__filename), '..');
+var cp = require('child_process');
+
+console.log('Installing dev dependencies in', juggler);
+process.chdir(juggler);
+
+cp.exec('npm install', function(err, stdout, stderr) {
+  if (err) throw err;
+  if (stderr) console.log(stderr);
+});


### PR DESCRIPTION
This script should be used by connectors to install dependencies needed to run the shared test suite.

Usage: Add an npm "install" scripts with the following contents:

    node -e "require('loopback-datasource-juggler/support/install-test-deps')"

/to @raymondfeng please review