### PR TITLE
relation-definition: remove trailing whitespace

### DIFF
--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -124,12 +124,12 @@ function RelationDefinition(definition) {
 
 RelationDefinition.prototype.toJSON = function () {
   var polymorphic = typeof this.polymorphic === 'object';
-    
+
   var modelToName = this.modelTo && this.modelTo.modelName;
   if (!modelToName && polymorphic && this.type === 'belongsTo') {
     modelToName = '<polymorphic>';
-  } 
-    
+  }
+
   var json = {
     name: this.name,
     type: this.type,
@@ -280,7 +280,7 @@ Relation.prototype.callScopeMethod = function(methodName) {
   } else {
     throw new Error('Unknown scope method: ' + methodName);
   }
-} 
+}
 
 /**
  * Fetch the related model(s) - this is a helper method to unify access.
@@ -535,12 +535,12 @@ function polymorphicParams(params, as) {
 
 /**
  * Define a "one to many" relationship by specifying the model name
- * 
+ *
  * Examples:
  * ```
  * User.hasMany(Post, {as: 'posts', foreignKey: 'authorId'});
  * ```
- * 
+ *
  * ```
  * Book.hasMany(Chapter);
  * ```
@@ -559,14 +559,14 @@ RelationDefinition.hasMany = function hasMany(modelFrom, modelTo, params) {
   var thisClassName = modelFrom.modelName;
   params = params || {};
   modelTo = lookupModelTo(modelFrom, modelTo, params, true);
-  
+
   var relationName = params.as || i8n.camelize(modelTo.pluralModelName, true);
   var fk = params.foreignKey || i8n.camelize(thisClassName + '_id', true);
   var keyThrough = params.keyThrough || i8n.camelize(modelTo.modelName + '_id', true);
 
   var idName = modelFrom.dataSource.idName(modelFrom.modelName) || 'id';
   var discriminator, polymorphic;
-  
+
   if (params.polymorphic) {
     polymorphic = polymorphicParams(params.polymorphic);
     if (params.invert) {
@@ -581,7 +581,7 @@ RelationDefinition.hasMany = function hasMany(modelFrom, modelTo, params) {
       modelTo.dataSource.defineProperty(modelTo.modelName, discriminator, { type: 'string', index: true });
     }
   }
-  
+
   var definition = new RelationDefinition({
     name: relationName,
     type: RelationTypes.hasMany,
@@ -596,9 +596,9 @@ RelationDefinition.hasMany = function hasMany(modelFrom, modelTo, params) {
     keyThrough: keyThrough,
     polymorphic: polymorphic
   });
-  
+
   definition.modelThrough = params.through;
-  
+
   modelFrom.relations[relationName] = definition;
 
   if (!params.through) {
@@ -641,9 +641,9 @@ RelationDefinition.hasMany = function hasMany(modelFrom, modelTo, params) {
     scopeMethods.create = scopeMethod(definition, 'create');
     scopeMethods.build = scopeMethod(definition, 'build');
   }
-  
+
   var customMethods = extendScopeMethods(definition, scopeMethods, params.scopeMethods);
-  
+
   for (var i = 0; i < customMethods.length; i++) {
     var methodName = customMethods[i];
     var method = scopeMethods[methodName];
@@ -651,13 +651,13 @@ RelationDefinition.hasMany = function hasMany(modelFrom, modelTo, params) {
       modelFrom.prototype['__' + methodName + '__' + relationName] = method;
     }
   };
-  
+
   // Mix the property and scoped methods into the prototype class
   defineScope(modelFrom.prototype, params.through || modelTo, relationName, function () {
     var filter = {};
     filter.where = {};
     filter.where[fk] = this[idName];
-    
+
     definition.applyScope(this, filter);
 
     if (definition.modelThrough) {
@@ -689,7 +689,7 @@ RelationDefinition.hasMany = function hasMany(modelFrom, modelTo, params) {
 
     return filter;
   }, scopeMethods, definition.options);
-  
+
   return definition;
 };
 
@@ -735,13 +735,13 @@ HasMany.prototype.findById = function (fkId, cb) {
   filter.where = {};
   filter.where[idName] = fkId;
   filter.where[fk] = modelInstance[pk];
-  
+
   if (filter.where[fk] === undefined) {
     // Foreign key is undefined
     return process.nextTick(cb);
   }
   this.definition.applyScope(modelInstance, filter);
-  
+
   modelTo.findOne(filter, function (err, inst) {
     if (err) {
       return cb(err);
@@ -823,7 +823,7 @@ HasMany.prototype.destroyById = function (fkId, cb) {
 var throughKeys = function(definition) {
   var modelThrough = definition.modelThrough;
   var pk2 = definition.modelTo.definition.idName();
-  
+
   if (typeof definition.polymorphic === 'object') { // polymorphic
     var fk1 = definition.keyTo;
     if (definition.polymorphic.invert) {
@@ -915,7 +915,7 @@ HasManyThrough.prototype.create = function create(data, done) {
   var definition = this.definition;
   var modelTo = definition.modelTo;
   var modelThrough = definition.modelThrough;
-  
+
   if (typeof data === 'function' && !done) {
     done = data;
     data = {};
@@ -934,13 +934,13 @@ HasManyThrough.prototype.create = function create(data, done) {
     var keys = throughKeys(definition);
     var fk1 = keys[0];
     var fk2 = keys[1];
-    
+
     function createRelation(to, next) {
       var d = {};
       d[fk1] = modelInstance[definition.keyFrom];
       d[fk2] = to[pk2];
       definition.applyProperties(modelInstance, d);
-      
+
       // Then create the through model
       modelThrough.create(d, function (e, through) {
         if (e) {
@@ -981,24 +981,24 @@ HasManyThrough.prototype.add = function (acInst, data, done) {
     data = {};
   }
   var query = {};
-  
+
   // The primary key for the target model
   var pk2 = definition.modelTo.definition.idName();
 
   var keys = throughKeys(definition);
   var fk1 = keys[0];
   var fk2 = keys[1];
-  
+
   query[fk1] = this.modelInstance[pk1];
   query[fk2] = (acInst instanceof definition.modelTo) ? acInst[pk2] : acInst;
-  
+
   var filter = { where: query };
-  
+
   definition.applyScope(this.modelInstance, filter);
 
   data[fk1] = this.modelInstance[pk1];
   data[fk2] = (acInst instanceof definition.modelTo) ? acInst[pk2] : acInst;
-  
+
   definition.applyProperties(this.modelInstance, data);
 
   // Create an instance of the through model
@@ -1025,18 +1025,18 @@ HasManyThrough.prototype.exists = function (acInst, done) {
 
   // The primary key for the target model
   var pk2 = definition.modelTo.definition.idName();
-  
+
   var keys = throughKeys(definition);
   var fk1 = keys[0];
   var fk2 = keys[1];
-  
+
   query[fk1] = this.modelInstance[pk1];
   query[fk2] = (acInst instanceof definition.modelTo) ? acInst[pk2] : acInst;
-  
+
   var filter = { where: query };
-  
+
   definition.applyScope(this.modelInstance, filter);
-  
+
   modelThrough.count(filter.where, function(err, ac) {
     done(err, ac > 0);
   });
@@ -1056,18 +1056,18 @@ HasManyThrough.prototype.remove = function (acInst, done) {
 
   // The primary key for the target model
   var pk2 = definition.modelTo.definition.idName();
-  
+
   var keys = throughKeys(definition);
   var fk1 = keys[0];
   var fk2 = keys[1];
 
   query[fk1] = this.modelInstance[pk1];
   query[fk2] = (acInst instanceof definition.modelTo) ? acInst[pk2] : acInst;
-  
+
   var filter = { where: query };
-  
+
   definition.applyScope(this.modelInstance, filter);
-  
+
   modelThrough.deleteAll(filter.where, function (err) {
     if (!err) {
       self.removeFromCache(query[fk2]);
@@ -1092,14 +1092,14 @@ HasManyThrough.prototype.remove = function (acInst, done) {
  *
  * This optional parameter default value is false, so the related object will
  * be loaded from cache if available.
- * 
+ *
  * @param {Class|String} modelTo Model object (or String name of model) to
  * which you are creating the relationship.
  * @options {Object} params Configuration parameters; see below.
  * @property {String} as Name of the property in the referring model that
  * corresponds to the foreign key field in the related model.
  * @property {String} foreignKey Name of foreign key property.
- * 
+ *
  */
 RelationDefinition.belongsTo = function (modelFrom, modelTo, params) {
   var discriminator, polymorphic;
@@ -1111,36 +1111,36 @@ RelationDefinition.belongsTo = function (modelFrom, modelTo, params) {
   var idName, relationName, fk;
   if (params.polymorphic) {
     relationName = params.as || (typeof modelTo === 'string' ? modelTo : null); // initially
-    
+
     if (params.polymorphic === true) {
       // modelTo arg will be the name of the polymorphic relation (string)
       polymorphic = polymorphicParams(modelTo, relationName);
     } else {
       polymorphic = polymorphicParams(params.polymorphic, relationName);
     }
-    
+
     modelTo = null; // will lookup dynamically
-    
+
     idName = params.idName || 'id';
     relationName = params.as || polymorphic.as; // finally
     fk = polymorphic.foreignKey;
     discriminator = polymorphic.discriminator;
-    
+
     if (polymorphic.idType) { // explicit key type
       modelFrom.dataSource.defineProperty(modelFrom.modelName, fk, { type: polymorphic.idType, index: true });
     } else { // try to use the same foreign key type as modelFrom
       modelFrom.dataSource.defineForeignKey(modelFrom.modelName, fk, modelFrom.modelName);
     }
-    
+
     modelFrom.dataSource.defineProperty(modelFrom.modelName, discriminator, { type: 'string', index: true });
   } else {
     idName = modelTo.dataSource.idName(modelTo.modelName) || 'id';
     relationName = params.as || i8n.camelize(modelTo.modelName, true);
     fk = params.foreignKey || relationName + 'Id';
-    
+
     modelFrom.dataSource.defineForeignKey(modelFrom.modelName, fk, modelTo.modelName);
   }
-  
+
   var definition = modelFrom.relations[relationName] = new RelationDefinition({
     name: relationName,
     type: RelationTypes.belongsTo,
@@ -1154,7 +1154,7 @@ RelationDefinition.belongsTo = function (modelFrom, modelTo, params) {
     options: params.options,
     polymorphic: polymorphic
   });
-  
+
   // Define a property for the scope so that we have 'this' for the scoped methods
   Object.defineProperty(modelFrom.prototype, relationName, {
     enumerable: true,
@@ -1164,7 +1164,7 @@ RelationDefinition.belongsTo = function (modelFrom, modelTo, params) {
       var relationMethod = relation.related.bind(relation);
       relationMethod.update = relation.update.bind(relation);
       relationMethod.destroy = relation.destroy.bind(relation);
-      if (!polymorphic) { 
+      if (!polymorphic) {
         relationMethod.create = relation.create.bind(relation);
         relationMethod.build = relation.build.bind(relation);
         relationMethod._targetClass = definition.modelTo.modelName;
@@ -1181,7 +1181,7 @@ RelationDefinition.belongsTo = function (modelFrom, modelTo, params) {
     f.apply(this, arguments);
   };
   modelFrom.prototype['__get__' + relationName] = fn;
-  
+
   return definition;
 };
 
@@ -1196,9 +1196,9 @@ BelongsTo.prototype.create = function(targetModelData, cb) {
     cb = targetModelData;
     targetModelData = {};
   }
-  
+
   this.definition.applyProperties(modelInstance, targetModelData || {});
-  
+
   modelTo.create(targetModelData, function(err, targetModel) {
     if(!err) {
       modelInstance[fk] = targetModel[pk];
@@ -1274,7 +1274,7 @@ BelongsTo.prototype.related = function (refresh, params) {
   var modelInstance = this.modelInstance;
   var discriminator;
   var scopeQuery = null;
-  
+
   if (arguments.length === 1) {
     params = refresh;
     refresh = false;
@@ -1284,27 +1284,27 @@ BelongsTo.prototype.related = function (refresh, params) {
   } else if (arguments.length > 2) {
     throw new Error('Method can\'t be called with more than two arguments');
   }
-  
+
   if (typeof this.definition.polymorphic === 'object') {
     discriminator = this.definition.polymorphic.discriminator;
   }
-  
+
   var cachedValue;
   if (!refresh) {
     cachedValue = self.getCache();
   }
   if (params instanceof ModelBaseClass) { // acts as setter
     modelInstance[fk] = params[pk];
-    
+
     if (discriminator) {
       modelInstance[discriminator] = params.constructor.modelName;
     }
-    
+
     this.definition.applyProperties(modelInstance, params);
-    
+
     self.resetCache(params);
   } else if (typeof params === 'function') { // acts as async getter
-    
+
     if (discriminator) {
       var modelToName = modelInstance[discriminator];
       if (typeof modelToName !== 'string') {
@@ -1316,26 +1316,26 @@ BelongsTo.prototype.related = function (refresh, params) {
         throw new Error('Polymorphic model not found: `' + modelToName + '`');
       }
     }
-    
+
     var cb = params;
     if (cachedValue === undefined || !(cachedValue instanceof ModelBaseClass)) {
       var query = {where: {}};
       query.where[pk] = modelInstance[fk];
-      
-      if (query.where[pk] === undefined 
+
+      if (query.where[pk] === undefined
         || query.where[pk] === null) {
         // Foreign key is undefined
         return process.nextTick(cb);
       }
-    
+
       this.definition.applyScope(modelInstance, query);
-      
+
       if (scopeQuery) mergeQuery(query, scopeQuery);
-      
+
       if (Array.isArray(query.fields) && query.fields.indexOf(pk) === -1) {
           query.fields.push(pk); // always include the pk
       }
-      
+
       modelTo.findOne(query, function (err, inst) {
         if (err) {
           return cb(err);
@@ -1344,7 +1344,7 @@ BelongsTo.prototype.related = function (refresh, params) {
           return cb(null, null);
         }
         // Check if the foreign key matches the primary key
-        if (inst[pk] && modelInstance[fk] 
+        if (inst[pk] && modelInstance[fk]
           && inst[pk].toString() === modelInstance[fk].toString()) {
           self.resetCache(inst);
           cb(null, inst);
@@ -1377,7 +1377,7 @@ BelongsTo.prototype.related = function (refresh, params) {
  * ```
  *  User.hasAndBelongsToMany('groups', {model: Group, foreignKey: 'groupId'});
  * ```
- * 
+ *
  * @param {String|Object} modelTo Model object (or String name of model) to
  * which you are creating the relationship.
  * @options {Object} params Configuration parameters; see below.
@@ -1389,9 +1389,9 @@ BelongsTo.prototype.related = function (refresh, params) {
 RelationDefinition.hasAndBelongsToMany = function hasAndBelongsToMany(modelFrom, modelTo, params) {
   params = params || {};
   modelTo = lookupModelTo(modelFrom, modelTo, params, true);
-  
+
   var models = modelFrom.dataSource.modelBuilder.models;
-  
+
   if (!params.through) {
     if (params.polymorphic) throw new Error('Polymorphic relations need a through model');
     var name1 = modelFrom.modelName + modelTo.modelName;
@@ -1399,11 +1399,11 @@ RelationDefinition.hasAndBelongsToMany = function hasAndBelongsToMany(modelFrom,
     params.through = lookupModel(models, name1) || lookupModel(models, name2) ||
       modelFrom.dataSource.define(name1);
   }
-  
+
   var options = {as: params.as, through: params.through};
   options.properties = params.properties;
   options.scope = params.scope;
-  
+
   if (params.polymorphic) {
     var polymorphic = polymorphicParams(params.polymorphic);
     options.polymorphic = polymorphic; // pass through
@@ -1415,9 +1415,9 @@ RelationDefinition.hasAndBelongsToMany = function hasAndBelongsToMany(modelFrom,
   } else {
     params.through.belongsTo(modelFrom);
   }
-  
+
   params.through.belongsTo(modelTo);
-  
+
   return this.hasMany(modelFrom, modelTo, options);
 };
 
@@ -1445,7 +1445,7 @@ RelationDefinition.hasOne = function (modelFrom, modelTo, params) {
 
   var fk = params.foreignKey || i8n.camelize(modelFrom.modelName + '_id', true);
   var discriminator, polymorphic;
-  
+
   if (params.polymorphic) {
     polymorphic = polymorphicParams(params.polymorphic);
     fk = polymorphic.foreignKey;
@@ -1454,7 +1454,7 @@ RelationDefinition.hasOne = function (modelFrom, modelTo, params) {
       modelTo.dataSource.defineProperty(modelTo.modelName, discriminator, { type: 'string', index: true });
     }
   }
-  
+
   var definition = modelFrom.relations[relationName] = new RelationDefinition({
     name: relationName,
     type: RelationTypes.hasOne,
@@ -1486,7 +1486,7 @@ RelationDefinition.hasOne = function (modelFrom, modelTo, params) {
       return relationMethod;
     }
   });
-  
+
   // FIXME: [rfeng] Wrap the property into a function for remoting
   // so that it can be accessed as /api/<model>/<id>/<hasOneRelationName>
   // For example, /api/orders/1/customer
@@ -1535,7 +1535,7 @@ HasOne.prototype.create = function (targetModelData, cb) {
   targetModelData[fk] = modelInstance[pk];
   var query = {where: {}};
   query.where[fk] = targetModelData[fk];
-  
+
   this.definition.applyScope(modelInstance, query);
   this.definition.applyProperties(modelInstance, targetModelData);
 
@@ -1633,12 +1633,12 @@ HasMany.prototype.build = HasOne.prototype.build = function(targetModelData) {
   var modelTo = this.definition.modelTo;
   var pk = this.definition.keyFrom;
   var fk = this.definition.keyTo;
-  
+
   targetModelData = targetModelData || {};
   targetModelData[fk] = this.modelInstance[pk];
-  
+
   this.definition.applyProperties(this.modelInstance, targetModelData);
-  
+
   return new modelTo(targetModelData);
 };
 
@@ -1722,13 +1722,13 @@ RelationDefinition.embedsOne = function (modelFrom, modelTo, params) {
   var relationName = params.as || (i8n.camelize(modelTo.modelName, true) + 'Item');
   var propertyName = params.property || i8n.camelize(modelTo.modelName, true);
   var idName = modelTo.dataSource.idName(modelTo.modelName) || 'id';
-  
+
   if (relationName === propertyName) {
     propertyName = '_' + propertyName;
     debug('EmbedsOne property cannot be equal to relation name: ' +
       'forcing property %s for relation %s', propertyName, relationName);
   }
-  
+
   var definition = modelFrom.relations[relationName] = new RelationDefinition({
     name: relationName,
     type: RelationTypes.embedsOne,
@@ -1742,9 +1742,9 @@ RelationDefinition.embedsOne = function (modelFrom, modelTo, params) {
     options: params.options,
     embed: true
   });
-  
+
   var opts = { type: modelTo };
-  
+
   if (params.default === true) {
     opts.default = function() { return new modelTo(); };
   } else if (typeof params.default === 'object') {
@@ -1754,9 +1754,9 @@ RelationDefinition.embedsOne = function (modelFrom, modelTo, params) {
       };
     }(params.default));
   }
-  
+
   modelFrom.dataSource.defineProperty(modelFrom.modelName, propertyName, opts);
-  
+
   // validate the embedded instance
   if (definition.options.validate !== false) {
     modelFrom.validate(relationName, function(err) {
@@ -1771,7 +1771,7 @@ RelationDefinition.embedsOne = function (modelFrom, modelTo, params) {
       }
     });
   }
-  
+
   // Define a property for the scope so that we have 'this' for the scoped methods
   Object.defineProperty(modelFrom.prototype, relationName, {
     enumerable: true,
@@ -1788,7 +1788,7 @@ RelationDefinition.embedsOne = function (modelFrom, modelTo, params) {
       return relationMethod;
     }
   });
-  
+
   // FIXME: [rfeng] Wrap the property into a function for remoting
   // so that it can be accessed as /api/<model>/<id>/<embedsOneRelationName>
   // For example, /api/orders/1/customer
@@ -1797,7 +1797,7 @@ RelationDefinition.embedsOne = function (modelFrom, modelTo, params) {
     f.apply(this, arguments);
   };
   modelFrom.prototype['__get__' + relationName] = fn;
-  
+
   return definition;
 };
 
@@ -1805,14 +1805,14 @@ EmbedsOne.prototype.related = function (refresh, params) {
   var modelTo = this.definition.modelTo;
   var modelInstance = this.modelInstance;
   var propertyName = this.definition.keyFrom;
-  
+
   if (arguments.length === 1) {
     params = refresh;
     refresh = false;
   } else if (arguments.length > 2) {
     throw new Error('Method can\'t be called with more than two arguments');
   }
-  
+
   if (params instanceof ModelBaseClass) { // acts as setter
     if (params instanceof modelTo) {
       this.definition.applyProperties(modelInstance, params);
@@ -1820,16 +1820,16 @@ EmbedsOne.prototype.related = function (refresh, params) {
     }
     return;
   }
-  
+
   var embeddedInstance = modelInstance[propertyName];
 
   if (embeddedInstance) {
     embeddedInstance.__persisted = true;
   }
-  
+
   if (typeof params === 'function') { // acts as async getter
     var cb = params;
-    process.nextTick(function() { 
+    process.nextTick(function() {
       cb(null, embeddedInstance);
     });
   } else if (params === undefined) { // acts as sync getter
@@ -1846,23 +1846,23 @@ EmbedsOne.prototype.create = function (targetModelData, cb) {
   var modelTo = this.definition.modelTo;
   var propertyName = this.definition.keyFrom;
   var modelInstance = this.modelInstance;
-  
+
   if (typeof targetModelData === 'function' && !cb) {
     cb = targetModelData;
     targetModelData = {};
   }
-  
+
   targetModelData = targetModelData || {};
-  
+
   var inst = this.callScopeMethod('build', targetModelData);
-  
+
   var updateEmbedded = function() {
-    modelInstance.updateAttribute(propertyName, 
+    modelInstance.updateAttribute(propertyName,
       inst, function(err) {
       cb(err, err ? null : inst);
     });
   };
-  
+
   if (this.definition.options.persistent) {
     inst.save(function(err) { // will validate
       if (err) return cb(err, inst);
@@ -1872,7 +1872,7 @@ EmbedsOne.prototype.create = function (targetModelData, cb) {
     var err = inst.isValid() ? null : new ValidationError(inst);
     if (err) {
       process.nextTick(function() {
-        cb(err); 
+        cb(err);
       });
     } else {
       updateEmbedded();
@@ -1887,25 +1887,25 @@ EmbedsOne.prototype.build = function (targetModelData) {
   var forceId = this.definition.options.forceId;
   var persistent = this.definition.options.persistent;
   var connector = modelTo.dataSource.connector;
-  
+
   targetModelData = targetModelData || {};
-  
+
   this.definition.applyProperties(modelInstance, targetModelData);
-  
+
   var pk = this.definition.keyTo;
   var pkProp = modelTo.definition.properties[pk];
-  
+
   var assignId = (forceId || targetModelData[pk] === undefined);
   assignId = assignId && !persistent && (pkProp && pkProp.generated);
-  
+
   if (assignId && typeof connector.generateId === 'function') {
       var id = connector.generateId(modelTo.modelName, targetModelData, pk);
       targetModelData[pk] = id;
   }
-  
+
   var embeddedInstance = new modelTo(targetModelData);
   modelInstance[propertyName] = embeddedInstance;
-  
+
   return embeddedInstance;
 };
 
@@ -1913,10 +1913,10 @@ EmbedsOne.prototype.update = function (targetModelData, cb) {
   var modelTo = this.definition.modelTo;
   var modelInstance = this.modelInstance;
   var propertyName = this.definition.keyFrom;
-  
+
   var isInst = targetModelData instanceof ModelBaseClass;
   var data = isInst ? targetModelData.toObject() : targetModelData;
-  
+
   var embeddedInstance = modelInstance[propertyName];
   if (embeddedInstance instanceof modelTo) {
     embeddedInstance.setAttributes(data);
@@ -1944,18 +1944,18 @@ EmbedsOne.prototype.destroy = function (cb) {
 RelationDefinition.embedsMany = function embedsMany(modelFrom, modelTo, params) {
   params = params || {};
   modelTo = lookupModelTo(modelFrom, modelTo, params, true);
-  
+
   var thisClassName = modelFrom.modelName;
   var relationName = params.as || (i8n.camelize(modelTo.modelName, true) + 'List');
   var propertyName = params.property || i8n.camelize(modelTo.pluralModelName, true);
   var idName = modelTo.dataSource.idName(modelTo.modelName) || 'id';
-  
+
   if (relationName === propertyName) {
     propertyName = '_' + propertyName;
     debug('EmbedsMany property cannot be equal to relation name: ' +
       'forcing property %s for relation %s', propertyName, relationName);
   }
-  
+
   var definition = modelFrom.relations[relationName] = new RelationDefinition({
     name: relationName,
     type: RelationTypes.embedsMany,
@@ -1969,11 +1969,11 @@ RelationDefinition.embedsMany = function embedsMany(modelFrom, modelTo, params) 
     options: params.options,
     embed: true
   });
-  
+
   modelFrom.dataSource.defineProperty(modelFrom.modelName, propertyName, {
-    type: [modelTo], default: function() { return []; } 
+    type: [modelTo], default: function() { return []; }
   });
-  
+
   if (typeof modelTo.dataSource.connector.generateId !== 'function') {
     modelFrom.validate(propertyName, function(err) {
       var self = this;
@@ -1990,7 +1990,7 @@ RelationDefinition.embedsMany = function embedsMany(modelFrom, modelTo, params) 
       if (hasErrors) err(false);
     });
   }
-  
+
   if (!params.polymorphic) {
     modelFrom.validate(propertyName, function(err) {
       var embeddedList = this[propertyName] || [];
@@ -2004,7 +2004,7 @@ RelationDefinition.embedsMany = function embedsMany(modelFrom, modelTo, params) 
       }
     }, { code: 'uniqueness' })
   }
-  
+
   // validate all embedded items
   if (definition.options.validate !== false) {
     modelFrom.validate(propertyName, function(err) {
@@ -2033,7 +2033,7 @@ RelationDefinition.embedsMany = function embedsMany(modelFrom, modelTo, params) 
       if (hasErrors) err(false);
     });
   }
-  
+
   var scopeMethods = {
     findById: scopeMethod(definition, 'findById'),
     destroy: scopeMethod(definition, 'destroyById'),
@@ -2047,16 +2047,16 @@ RelationDefinition.embedsMany = function embedsMany(modelFrom, modelTo, params) 
     at: scopeMethod(definition, 'at'),
     value: scopeMethod(definition, 'embeddedValue')
   };
-  
+
   var findByIdFunc = scopeMethods.findById;
   modelFrom.prototype['__findById__' + relationName] = findByIdFunc;
-  
+
   var destroyByIdFunc = scopeMethods.destroy;
   modelFrom.prototype['__destroyById__' + relationName] = destroyByIdFunc;
-  
+
   var updateByIdFunc = scopeMethods.updateById;
   modelFrom.prototype['__updateById__' + relationName] = updateByIdFunc;
-  
+
   var addFunc = scopeMethods.add;
   modelFrom.prototype['__link__' + relationName] = addFunc;
 
@@ -2065,11 +2065,11 @@ RelationDefinition.embedsMany = function embedsMany(modelFrom, modelTo, params) 
 
   scopeMethods.create = scopeMethod(definition, 'create');
   scopeMethods.build = scopeMethod(definition, 'build');
-  
+
   scopeMethods.related = scopeMethod(definition, 'related'); // bound to definition
-  
+
   var customMethods = extendScopeMethods(definition, scopeMethods, params.scopeMethods);
-  
+
   for (var i = 0; i < customMethods.length; i++) {
     var methodName = customMethods[i];
     var method = scopeMethods[methodName];
@@ -2077,14 +2077,14 @@ RelationDefinition.embedsMany = function embedsMany(modelFrom, modelTo, params) 
       modelFrom.prototype['__' + methodName + '__' + relationName] = method;
     }
   };
-  
+
   // Mix the property and scoped methods into the prototype class
   var scopeDefinition = defineScope(modelFrom.prototype, modelTo, relationName, function () {
     return {};
   }, scopeMethods, definition.options);
 
   scopeDefinition.related = scopeMethods.related;
-  
+
   return definition;
 };
 
@@ -2131,7 +2131,7 @@ EmbedsMany.prototype.prepareEmbeddedInstance = function(inst) {
   }
 };
 
-EmbedsMany.prototype.embeddedList = 
+EmbedsMany.prototype.embeddedList =
   EmbedsMany.prototype.embeddedValue = function(modelInstance) {
   modelInstance = modelInstance || this.modelInstance;
   var embeddedList = modelInstance[this.definition.keyFrom] || [];
@@ -2142,7 +2142,7 @@ EmbedsMany.prototype.embeddedList =
 EmbedsMany.prototype.related = function(receiver, scopeParams, condOrRefresh, cb) {
   var modelTo = this.definition.modelTo;
   var modelInstance = this.modelInstance;
-  
+
   var actualCond = {};
   if (arguments.length === 3) {
     cb = condOrRefresh;
@@ -2153,17 +2153,17 @@ EmbedsMany.prototype.related = function(receiver, scopeParams, condOrRefresh, cb
   } else {
     throw new Error('Method can be only called with one or two arguments');
   }
-  
+
   var embeddedList = this.embeddedList(receiver);
-  
+
   this.definition.applyScope(receiver, actualCond);
-  
+
   var params = mergeQuery(actualCond, scopeParams);
-  
+
   if (params.where && Object.keys(params.where).length > 0) { // TODO [fabien] Support order/sorting
     embeddedList = embeddedList ? embeddedList.filter(applyFilter(params)) : embeddedList;
   }
-  
+
   var returnRelated = function(list) {
     if (params.include) {
       modelTo.include(list, params.include, cb);
@@ -2171,7 +2171,7 @@ EmbedsMany.prototype.related = function(receiver, scopeParams, condOrRefresh, cb
       process.nextTick(function() { cb(null, list); });
     }
   };
-  
+
   returnRelated(embeddedList);
 };
 
@@ -2179,9 +2179,9 @@ EmbedsMany.prototype.findById = function (fkId, cb) {
   var pk = this.definition.keyTo;
   var modelTo = this.definition.modelTo;
   var modelInstance = this.modelInstance;
-  
+
   var embeddedList = this.embeddedList();
-  
+
   var find = function(id) {
     for (var i = 0; i < embeddedList.length; i++) {
       var item = embeddedList[i];
@@ -2189,17 +2189,17 @@ EmbedsMany.prototype.findById = function (fkId, cb) {
     }
     return null;
   };
-  
+
   var item = find(fkId.toString()); // in case of explicit id
   item = (item instanceof modelTo) ? item : null;
-  
+
   if (typeof cb === 'function') {
     process.nextTick(function() {
       cb(null, item);
     });
   };
-  
-  return item; // sync 
+
+  return item; // sync
 };
 
 EmbedsMany.prototype.exists = function (fkId, cb) {
@@ -2207,7 +2207,7 @@ EmbedsMany.prototype.exists = function (fkId, cb) {
   var inst = this.findById(fkId, function (err, inst) {
     if (cb) cb(err, inst instanceof modelTo);
   });
-  return inst instanceof modelTo; // sync 
+  return inst instanceof modelTo; // sync
 };
 
 EmbedsMany.prototype.updateById = function (fkId, data, cb) {
@@ -2215,54 +2215,54 @@ EmbedsMany.prototype.updateById = function (fkId, data, cb) {
     cb = data;
     data = {};
   }
-  
+
   var modelTo = this.definition.modelTo;
   var propertyName = this.definition.keyFrom;
   var modelInstance = this.modelInstance;
-  
+
   var embeddedList = this.embeddedList();
-  
+
   var inst = this.findById(fkId);
-  
+
   if (inst instanceof modelTo) {
     if (typeof data === 'object') {
         inst.setAttributes(data);
     }
     var err = inst.isValid() ? null : new ValidationError(inst);
     if (err && typeof cb === 'function') {
-      return process.nextTick(function() { 
-        cb(err, inst); 
+      return process.nextTick(function() {
+        cb(err, inst);
       });
     }
-    
+
     if (typeof cb === 'function') {
-      modelInstance.updateAttribute(propertyName, 
+      modelInstance.updateAttribute(propertyName,
         embeddedList, function(err) {
         cb(err, inst);
       });
     }
   } else if (typeof cb === 'function') {
-    process.nextTick(function() { 
+    process.nextTick(function() {
       cb(null, null); // not found
     });
   }
-  return inst; // sync 
+  return inst; // sync
 };
 
 EmbedsMany.prototype.destroyById = function (fkId, cb) {
   var modelTo = this.definition.modelTo;
   var propertyName = this.definition.keyFrom;
   var modelInstance = this.modelInstance;
-  
+
   var embeddedList = this.embeddedList();
-  
+
   var inst = (fkId instanceof modelTo) ? fkId : this.findById(fkId);
-  
+
   if (inst instanceof modelTo) {
     var index = embeddedList.indexOf(inst);
     if (index > -1) embeddedList.splice(index, 1);
     if (typeof cb === 'function') {
-      modelInstance.updateAttribute(propertyName, 
+      modelInstance.updateAttribute(propertyName,
         embeddedList, function(err) {
         cb(err);
         modelTo.emit('deleted', inst.id, inst.toJSON());
@@ -2281,19 +2281,19 @@ EmbedsMany.prototype.unset = EmbedsMany.prototype.destroyById;
 EmbedsMany.prototype.at = function (index, cb) {
   var modelTo = this.definition.modelTo;
   var modelInstance = this.modelInstance;
-  
+
   var embeddedList = this.embeddedList();
-  
+
   var item = embeddedList[parseInt(index)];
   item = (item instanceof modelTo) ? item : null;
-  
+
   if (typeof cb === 'function') {
     process.nextTick(function() {
       cb(null, item);
     });
   };
-  
-  return item; // sync 
+
+  return item; // sync
 };
 
 EmbedsMany.prototype.create = function (targetModelData, cb) {
@@ -2301,24 +2301,24 @@ EmbedsMany.prototype.create = function (targetModelData, cb) {
   var modelTo = this.definition.modelTo;
   var propertyName = this.definition.keyFrom;
   var modelInstance = this.modelInstance;
-  
+
   if (typeof targetModelData === 'function' && !cb) {
     cb = targetModelData;
     targetModelData = {};
   }
   targetModelData = targetModelData || {};
-  
+
   var embeddedList = this.embeddedList();
-  
+
   var inst = this.callScopeMethod('build', targetModelData);
-  
+
   var updateEmbedded = function() {
     modelInstance.updateAttribute(propertyName,
       embeddedList, function(err, modelInst) {
       cb(err, err ? null : inst);
     });
   };
-  
+
   if (this.definition.options.persistent) {
     inst.save(function(err) { // will validate
       if (err) return cb(err, inst);
@@ -2328,7 +2328,7 @@ EmbedsMany.prototype.create = function (targetModelData, cb) {
     var err = inst.isValid() ? null : new ValidationError(inst);
     if (err) {
       process.nextTick(function() {
-        cb(err); 
+        cb(err);
       });
     } else {
       updateEmbedded();
@@ -2342,20 +2342,20 @@ EmbedsMany.prototype.build = function(targetModelData) {
   var forceId = this.definition.options.forceId;
   var persistent = this.definition.options.persistent;
   var connector = modelTo.dataSource.connector;
-  
+
   var pk = this.definition.keyTo;
   var pkProp = modelTo.definition.properties[pk];
   var pkType = pkProp && pkProp.type;
-  
+
   var embeddedList = this.embeddedList();
-  
+
   targetModelData = targetModelData || {};
-  
+
   var assignId = (forceId || targetModelData[pk] === undefined);
   assignId = assignId && !persistent;
-  
+
   if (assignId && pkType === Number) {
-    var ids = embeddedList.map(function(m) { 
+    var ids = embeddedList.map(function(m) {
       return (typeof m[pk] === 'number' ? m[pk] : 0);
     });
     if (ids.length > 0) {
@@ -2367,19 +2367,19 @@ EmbedsMany.prototype.build = function(targetModelData) {
       var id = connector.generateId(modelTo.modelName, targetModelData, pk);
       targetModelData[pk] = id;
   }
-  
+
   this.definition.applyProperties(modelInstance, targetModelData);
-  
+
   var inst = new modelTo(targetModelData);
-  
+
   if (this.definition.options.prepend) {
     embeddedList.unshift(inst);
   } else {
     embeddedList.push(inst);
   }
-  
+
   this.prepareEmbeddedInstance(inst);
-  
+
   return inst;
 };
 
@@ -2392,30 +2392,30 @@ EmbedsMany.prototype.add = function (acInst, data, cb) {
     cb = data;
     data = {};
   }
-  
+
   var self = this;
   var definition = this.definition;
   var modelTo = this.definition.modelTo;
   var modelInstance = this.modelInstance;
-  
+
   var options = definition.options;
   var belongsTo = options.belongsTo && modelTo.relations[options.belongsTo];
-  
+
   if (!belongsTo) {
     throw new Error('Invalid reference: ' + options.belongsTo || '(none)');
   }
-  
+
   var fk2 = belongsTo.keyTo;
   var pk2 = belongsTo.modelTo.definition.idName() || 'id';
-  
+
   var query = {};
-  
+
   query[fk2] = (acInst instanceof belongsTo.modelTo) ? acInst[pk2] : acInst;
-  
+
   var filter = { where: query };
-  
+
   belongsTo.applyScope(modelInstance, filter);
-  
+
   belongsTo.modelTo.findOne(filter, function(err, ref) {
     if (ref instanceof belongsTo.modelTo) {
       var inst = self.build(data || {});
@@ -2438,32 +2438,32 @@ EmbedsMany.prototype.remove = function (acInst, cb) {
   var definition = this.definition;
   var modelTo = this.definition.modelTo;
   var modelInstance = this.modelInstance;
-  
+
   var options = definition.options;
   var belongsTo = options.belongsTo && modelTo.relations[options.belongsTo];
-  
+
   if (!belongsTo) {
     throw new Error('Invalid reference: ' + options.belongsTo || '(none)');
   }
-  
+
   var fk2 = belongsTo.keyTo;
   var pk2 = belongsTo.modelTo.definition.idName() || 'id';
-  
+
   var query = {};
-  
+
   query[fk2] = (acInst instanceof belongsTo.modelTo) ? acInst[pk2] : acInst;
-  
+
   var filter = { where: query };
-  
+
   belongsTo.applyScope(modelInstance, filter);
-  
+
   modelInstance[definition.name](filter, function(err, items) {
     if (err) return cb(err);
-    
+
     items.forEach(function(item) {
       self.unset(item);
     });
-    
+
     modelInstance.save(function(err) {
       cb(err);
     });
@@ -2473,13 +2473,13 @@ EmbedsMany.prototype.remove = function (acInst, cb) {
 RelationDefinition.referencesMany = function referencesMany(modelFrom, modelTo, params) {
   params = params || {};
   modelTo = lookupModelTo(modelFrom, modelTo, params, true);
-  
+
   var thisClassName = modelFrom.modelName;
   var relationName = params.as || i8n.camelize(modelTo.pluralModelName, true);
   var fk = params.foreignKey || i8n.camelize(modelTo.modelName + '_ids', true);
   var idName = modelTo.dataSource.idName(modelTo.modelName) || 'id';
   var idType = modelTo.definition.properties[idName].type;
-  
+
   var definition = modelFrom.relations[relationName] = new RelationDefinition({
     name: relationName,
     type: RelationTypes.referencesMany,
@@ -2492,11 +2492,11 @@ RelationDefinition.referencesMany = function referencesMany(modelFrom, modelTo, 
     scope: params.scope,
     options: params.options
   });
-  
-  modelFrom.dataSource.defineProperty(modelFrom.modelName, fk, { 
-    type: [idType], default: function() { return []; } 
+
+  modelFrom.dataSource.defineProperty(modelFrom.modelName, fk, {
+    type: [idType], default: function() { return []; }
   });
-  
+
   modelFrom.validate(relationName, function(err) {
     var ids = this[fk] || [];
     var uniqueIds = ids.filter(function(id, pos) {
@@ -2508,7 +2508,7 @@ RelationDefinition.referencesMany = function referencesMany(modelFrom, modelTo, 
       err(false);
     }
   }, { code: 'uniqueness' })
-  
+
   var scopeMethods = {
     findById: scopeMethod(definition, 'findById'),
     destroy: scopeMethod(definition, 'destroyById'),
@@ -2518,29 +2518,29 @@ RelationDefinition.referencesMany = function referencesMany(modelFrom, modelTo, 
     remove: scopeMethod(definition, 'remove'),
     at: scopeMethod(definition, 'at')
   };
-  
+
   var findByIdFunc = scopeMethods.findById;
   modelFrom.prototype['__findById__' + relationName] = findByIdFunc;
-  
+
   var destroyByIdFunc = scopeMethods.destroy;
   modelFrom.prototype['__destroyById__' + relationName] = destroyByIdFunc;
-  
+
   var updateByIdFunc = scopeMethods.updateById;
   modelFrom.prototype['__updateById__' + relationName] = updateByIdFunc;
-  
+
   var addFunc = scopeMethods.add;
   modelFrom.prototype['__link__' + relationName] = addFunc;
 
   var removeFunc = scopeMethods.remove;
   modelFrom.prototype['__unlink__' + relationName] = removeFunc;
-  
+
   scopeMethods.create = scopeMethod(definition, 'create');
   scopeMethods.build = scopeMethod(definition, 'build');
-  
+
   scopeMethods.related = scopeMethod(definition, 'related');
-  
+
   var customMethods = extendScopeMethods(definition, scopeMethods, params.scopeMethods);
-  
+
   for (var i = 0; i < customMethods.length; i++) {
     var methodName = customMethods[i];
     var method = scopeMethods[methodName];
@@ -2548,14 +2548,14 @@ RelationDefinition.referencesMany = function referencesMany(modelFrom, modelTo, 
       modelFrom.prototype['__' + methodName + '__' + relationName] = method;
     }
   };
-  
+
   // Mix the property and scoped methods into the prototype class
   var scopeDefinition = defineScope(modelFrom.prototype, modelTo, relationName, function () {
     return {};
   }, scopeMethods, definition.options);
-  
+
   scopeDefinition.related = scopeMethods.related; // bound to definition
-  
+
   return definition;
 };
 
@@ -2565,7 +2565,7 @@ ReferencesMany.prototype.related = function(receiver, scopeParams, condOrRefresh
   var relationName = this.definition.name;
   var modelInstance = this.modelInstance;
   var self = receiver;
-  
+
   var actualCond = {};
   var actualRefresh = false;
   if (arguments.length === 3) {
@@ -2580,13 +2580,13 @@ ReferencesMany.prototype.related = function(receiver, scopeParams, condOrRefresh
   } else {
     throw new Error('Method can be only called with one or two arguments');
   }
-  
+
   var ids = self[fk] || [];
-  
+
   this.definition.applyScope(modelInstance, actualCond);
-  
+
   var params = mergeQuery(actualCond, scopeParams);
-  
+
   modelTo.findByIds(ids, params, cb);
 };
 
@@ -2595,36 +2595,36 @@ ReferencesMany.prototype.findById = function (fkId, cb) {
   var modelFrom = this.definition.modelFrom;
   var relationName = this.definition.name;
   var modelInstance = this.modelInstance;
-  
+
   var modelTo = this.definition.modelTo;
   var pk = this.definition.keyTo;
   var fk = this.definition.keyFrom;
-  
+
   if (typeof fkId === 'object') {
     fkId = fkId.toString(); // mongodb
   }
-  
+
   var ids = [fkId];
-  
+
   var filter = {};
-  
+
   this.definition.applyScope(modelInstance, filter);
-  
+
   modelTo.findByIds(ids, filter, function (err, instances) {
     if (err) {
       return cb(err);
     }
-    
+
     var inst = instances[0];
     if (!inst) {
       err = new Error('No instance with id ' + fkId + ' found for ' + modelTo.modelName);
       err.statusCode = 404;
       return cb(err);
     }
-    
+
     var currentIds = ids.map(function(id) { return id.toString(); });
     var id = (inst[pk] || '').toString(); // mongodb
-    
+
     // Check if the foreign key is amongst the ids
     if (currentIds.indexOf(id) > -1) {
       cb(null, inst);
@@ -2651,7 +2651,7 @@ ReferencesMany.prototype.updateById = function (fkId, data, cb) {
     cb = data;
     data = {};
   }
-  
+
   this.findById(fkId, function(err, inst) {
     if (err) return cb(err);
     inst.updateAttributes(data, cb);
@@ -2679,35 +2679,35 @@ ReferencesMany.prototype.create = function (targetModelData, cb) {
   var modelTo = this.definition.modelTo;
   var relationName = this.definition.name;
   var modelInstance = this.modelInstance;
-  
+
   var pk = this.definition.keyTo;
   var fk = this.definition.keyFrom;
-  
+
   if (typeof targetModelData === 'function' && !cb) {
     cb = targetModelData;
     targetModelData = {};
   }
   targetModelData = targetModelData || {};
-  
+
   var ids = modelInstance[fk] || [];
-  
+
   var inst = this.callScopeMethod('build', targetModelData);
-  
+
   inst.save(function(err, inst) {
     if (err) return cb(err, inst);
-    
+
     var id = inst[pk];
-    
+
     if (typeof id === 'object') {
       id = id.toString(); // mongodb
     }
-    
+
     if (definition.options.prepend) {
       ids.unshift(id);
     } else {
       ids.push(id);
     }
-    
+
     modelInstance.updateAttribute(fk,
       ids, function(err, modelInst) {
       cb(err, inst);
@@ -2718,9 +2718,9 @@ ReferencesMany.prototype.create = function (targetModelData, cb) {
 ReferencesMany.prototype.build = function(targetModelData) {
   var modelTo = this.definition.modelTo;
   targetModelData = targetModelData || {};
-  
+
   this.definition.applyProperties(this.modelInstance, targetModelData);
-  
+
   return new modelTo(targetModelData);
 };
 
@@ -2733,38 +2733,38 @@ ReferencesMany.prototype.add = function (acInst, cb) {
   var definition = this.definition;
   var modelTo = this.definition.modelTo;
   var modelInstance = this.modelInstance;
-  
+
   var pk = this.definition.keyTo;
   var fk = this.definition.keyFrom;
-  
+
   var insert = function(inst, done) {
     var id = inst[pk];
-    
+
     if (typeof id === 'object') {
       id = id.toString(); // mongodb
     }
-    
+
     var ids = modelInstance[fk] || [];
-    
+
     if (definition.options.prepend) {
       ids.unshift(id);
     } else {
       ids.push(id);
     }
-    
+
     modelInstance.updateAttribute(fk, ids, function(err) {
       done(err, err ? null : inst);
     });
   };
-  
+
   if (acInst instanceof modelTo) {
     insert(acInst, cb);
   } else {
     var filter = { where: {} };
     filter.where[pk] = acInst;
-    
+
     definition.applyScope(modelInstance, filter);
-    
+
     modelTo.findOne(filter, function (err, inst) {
       if (err || !inst) return cb(err, null);
       insert(inst, cb);
@@ -2779,17 +2779,17 @@ ReferencesMany.prototype.add = function (acInst, cb) {
 ReferencesMany.prototype.remove = function (acInst, cb) {
   var definition = this.definition;
   var modelInstance = this.modelInstance;
-  
+
   var pk = this.definition.keyTo;
   var fk = this.definition.keyFrom;
-  
+
   var ids = modelInstance[fk] || [];
-  
+
   var currentIds = ids.map(function(id) { return id.toString(); });
-  
+
   var id = (acInst instanceof definition.modelTo) ? acInst[pk] : acInst;
   id = id.toString();
-  
+
   var index = currentIds.indexOf(id);
   if (index > -1) {
     ids.splice(index, 1);


### PR DESCRIPTION
Remove all trailing whitespace to make @partap's work in #452 easier.

> There is a ton of trailing whitespace in relation-definition.js. I've been dancing around it with my commits... Could you take care of it in the master branch?

/cc @raymondfeng @ritch 

We should consider adding a `pretest` script running `jscs && jshint` as we do in loopback.