### PR TITLE
Enhance updateAll to coerce the data per property definitions

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1530,6 +1530,8 @@ DataAccessObject.updateAll = function (where, data, options, cb) {
     try {
       where = removeUndefined(where);
       where = Model._coerce(where);
+      data = removeUndefined(data);
+      data = Model._coerce(data);
     } catch (err) {
       return process.nextTick(function () {
         cb(err);

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -768,17 +768,28 @@ DataAccessObject._normalize = function (filter) {
 };
 
 function DateType(arg) {
-  return new Date(arg);
+  var d = new Date(arg);
+  if (isNaN(d.getTime())) {
+    throw new Error('Invalid date: ' + arg);
+  }
+  return d;
 }
 
-function BooleanType(val) {
-  if (val === 'true') {
-    return true;
-  } else if (val === 'false') {
-    return false;
-  } else {
-    return Boolean(val);
+function BooleanType(arg) {
+  if (typeof arg === 'string') {
+    switch (arg) {
+      case 'true':
+      case '1':
+        return true;
+      case 'false':
+      case '0':
+        return false;
+    }
   }
+  if (arg == null) {
+    return null;
+  }
+  return Boolean(arg);
 }
 
 function NumberType(val) {

--- a/test/basic-querying.test.js
+++ b/test/basic-querying.test.js
@@ -654,6 +654,24 @@ describe('basic-querying', function () {
       });
     });
 
+    it('should ignore undefined values of data', function (done) {
+      User.update({name: 'John Lennon'}, {name: undefined}, function (err) {
+        should.not.exist(err);
+        User.find({where: {name: 'John Lennon'}}, function (err, data) {
+          should.not.exist(err);
+          data.length.should.equal(1);
+          done();
+        });
+      });
+    });
+
+    it('should coerce data', function (done) {
+      User.update({name: 'John Lennon'}, {birthday: 'invalidate'}, function (err) {
+        should.exist(err);
+        done();
+      });
+    });
+
   });
 
 });


### PR DESCRIPTION
Coerce ```data``` before updating models.
Relates to https://github.com/strongloop/loopback-connector-mysql/pull/74 .