### PR TITLE
failing test for HasManyThrough relations

### DIFF
--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -1330,7 +1330,24 @@ describe('relations', function () {
         should.exist(f);
         f.followeeId.should.eql(user2.id);
         f.followerId.should.eql(user.id);
-        done();
+        user.following(function (err, following) {
+          // following [ { id: 2 } ]
+          console.log('following', following);
+        });
+        user2.followers(function (err, followers) {
+          // followers [ null ]
+          console.log('followers', followers);
+        });
+        user.following.findById(user2.id, function (err, u2) {
+          // errors here
+          should.not.exist(err);
+          should.exist(u2);
+          user2.followers.findById(user.id, function (err, u1) {
+            should.not.exist(err);
+            should.exist(u1);
+            done();
+          });
+        });
       });
     });
 


### PR DESCRIPTION
I haven’t found the root cause of this yet, but the test illustrates the issue.  As far as I can tell this seems to be a scope / query problem.

`user.following` functions correctly, returning a list containing only other user
however `user2.followers` should be returning another list containing only the first user

I originally found this by trying to use a type of `user.following.findById` which returned an error, not finding the relation.