### PR TITLE
Deprecate model hooks and events

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ OPTS = --growl
 TESTS = test/*.test.js
 
 test:
-	$(TESTER) $(OPTS) $(TESTS)
+	NO_DEPRECATION=loopback-datasource-juggler $(TESTER) $(OPTS) $(TESTS)
 test-verbose:
 	$(TESTER) $(OPTS) --reporter spec $(TESTS)
 testing:

--- a/lib/browser.depd.js
+++ b/lib/browser.depd.js
@@ -1,0 +1,16 @@
+// A lightweight alternative to "depd" that works in the browser
+module.exports = function depd(namespace) {
+  var warned = {};
+  return function deprecate(message) {
+    if (warned[message]) return;
+    warned[message] = true;
+
+    if (process.noDeprecation) {
+      return;
+    } else if (process.traceDeprecation) {
+      console.trace(namespace, 'deprecated', message);
+    } else {
+      console.warn(namespace, 'deprecated', message);
+    }
+  };
+};

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -1,3 +1,5 @@
+var deprecated = require('depd')('loopback-datasource-juggler');
+
 /*!
  * Module exports
  */
@@ -39,6 +41,13 @@ Hookable.prototype.trigger = function trigger(actionName, work, data, callback) 
   }
   var inst = this;
 
+  if (actionName !== 'initialize') {
+    if (beforeHook)
+      deprecateHook(inst.constructor, ['before', 'pre'], capitalizedName);
+    if (afterHook)
+      deprecateHook(inst.constructor, ['after', 'post'], capitalizedName);
+  }
+
   // we only call "before" hook when we have actual action (work) to perform
   if (work) {
     if (beforeHook) {
@@ -70,4 +79,17 @@ Hookable.prototype.trigger = function trigger(actionName, work, data, callback) 
 
 function capitalize(string) {
   return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
+function deprecateHook(ctor, prefixes, capitalizedName) {
+  var candidateNames = prefixes.map(function(p) { return p + capitalizedName; });
+  if (capitalizedName === 'Validate')
+    candidateNames.push(prefixes[0] + 'Validation');
+
+  var hookName = candidateNames.filter(function(hook) { return !!ctor[hook]; })[0];
+  if (!hookName) return; // just to be sure, this should never happen
+  if (ctor.modelName) hookName  = ctor.modelName + '.' + hookName;
+  deprecated('Model hook "' + hookName + '" is deprecated, ' +
+    'use Operation hooks instead. ' +
+    'http://docs.strongloop.com/display/LB/Operation+hooks');
 }

--- a/lib/model-builder.js
+++ b/lib/model-builder.js
@@ -6,6 +6,7 @@ var inflection = require('inflection');
 var EventEmitter = require('events').EventEmitter;
 var util = require('util');
 var assert = require('assert');
+var deprecated = require('depd')('loopback-datasource-juggler');
 var DefaultModelBaseClass = require('./model.js');
 var List = require('./list.js');
 var ModelDefinition = require('./model-definition.js');
@@ -182,7 +183,20 @@ ModelBuilder.prototype.define = function defineClass(className, properties, sett
     events.setMaxListeners(32);
     for (var f in EventEmitter.prototype) {
       if (typeof EventEmitter.prototype[f] === 'function') {
-        ModelClass[f] = EventEmitter.prototype[f].bind(events);
+        if (f !== 'on') {
+          ModelClass[f] = EventEmitter.prototype[f].bind(events);
+          continue;
+        }
+
+        // report deprecation warnings at the time Model.on() is called
+        ModelClass.on = function(event) {
+          if (['changed', 'deleted', 'deletedAll'].indexOf(event) !== -1) {
+            deprecated(this.modelName + '\'s event "' + event + '" ' +
+              'is deprecated, use Operation hooks instead. ' +
+              'http://docs.strongloop.com/display/LB/Operation+hooks');
+          }
+          EventEmitter.prototype.on.apply(events, arguments);
+        };
       }
     }
     hiddenProperty(ModelClass, 'modelName', className);

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "url": "https://github.com/strongloop/loopback-datasource-juggler"
   },
   "main": "index.js",
+  "browser": {
+    "depd": "./lib/browser.depd.js"
+  },
   "scripts": {
     "test": "make test"
   },
@@ -30,6 +33,7 @@
   "dependencies": {
     "async": "^0.9.0",
     "debug": "^2.1.1",
+    "depd": "^1.0.0",
     "inflection": "^1.6.0",
     "lodash": "~3.0.1",
     "loopback-connector": "1.x",


### PR DESCRIPTION
Deprecate the following [Model hooks](http://docs.strongloop.com/display/LB/Model+hooks):

 - beforeValidate
 - afterValidate
 - beforeCreate
 - afterCreate
 - beforeSave
 - afterSave
 - beforeUpdate
 - afterUpdate
 - beforeDestroy
 - afterDestroy

Deprecate the following Model events:

 - changed
 - deletedAll
 - deleted

Closes strongloop/loopback#617.

/to @raymondfeng @ritch please review