### PR TITLE
Fix the like and nlike not works with array/object field type problem

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -974,7 +974,9 @@ DataAccessObject._coerce = function (where) {
       }
     }
     // Coerce the array items
-    if (Array.isArray(val)) {
+    if (['like', 'nlike'].indexOf(operator) >= 0) {
+      // Do not force convert type for like/nlike query, it has to keep the string/regex type anyway.
+    } else if (Array.isArray(val)) {
       for (var i = 0; i < val.length; i++) {
         if (val[i] !== null && val[i] !== undefined) {
           val[i] = DataType(val[i]);


### PR DESCRIPTION
When I do with some object/array type of field, it's stored in db in json, I want to do like query on it, but found the code converted the like value into an object, finally I found it's caused by the DataType conversion.

This PR will force keep the string/regex type for the like/nlike value (which was verified in previous code). then we can query the JSON string by the like query.
