### PR TITLE
Operation hooks improvements

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1732,7 +1732,7 @@ DataAccessObject.prototype.remove =
       assert(typeof options === 'object', 'The options argument should be an object');
       assert(typeof cb === 'function', 'The cb argument should be a function');
 
-      var self = this;
+      var inst = this;
       var Model = this.constructor;
       var id = getIdValue(this.constructor, this);
       var hookState = {};
@@ -1743,7 +1743,9 @@ DataAccessObject.prototype.remove =
 
       Model.notifyObserversOf('access', context, function(err, ctx) {
           if (err) return cb(err);
-          var context = { Model: Model, where: ctx.query.where, hookState: hookState };
+          var context = { 
+            Model: Model, where: ctx.query.where, instance: inst, hookState: hookState
+          };
           Model.notifyObserversOf('before delete', context, function(err, ctx) {
               if (err) return cb(err);
               doDeleteInstance(ctx.where);
@@ -1757,7 +1759,9 @@ DataAccessObject.prototype.remove =
           // We must switch to full query-based delete.
           Model.deleteAll(where, { notify: false }, function(err) {
             if (err) return cb(err);
-            var context = { Model: Model, where: where, hookState: hookState };
+            var context = { 
+              Model: Model, where: where, instance: inst, hookState: hookState
+            };
             Model.notifyObserversOf('after delete', context, function(err) {
               cb(err);
               if (!err) Model.emit('deleted', id);
@@ -1766,14 +1770,16 @@ DataAccessObject.prototype.remove =
           return;
         }
 
-        self.trigger('destroy', function (destroyed) {
-          self._adapter().destroy(self.constructor.modelName, id, function (err) {
+        inst.trigger('destroy', function (destroyed) {
+          inst._adapter().destroy(inst.constructor.modelName, id, function (err) {
             if (err) {
               return cb(err);
             }
 
             destroyed(function () {
-              var context = { Model: Model, where: where, hookState: hookState };
+              var context = { 
+                Model: Model, where: where, instance: inst, hookState: hookState
+              };
               Model.notifyObserversOf('after delete', context, function(err) {
                 cb(err);
                 if (!err) Model.emit('deleted', id);
@@ -1893,6 +1899,7 @@ DataAccessObject.prototype.updateAttributes = function updateAttributes(data, op
     Model: Model,
     where: byIdQuery(Model, getIdValue(Model, inst)).where,
     data: data,
+    currentInstance: inst,
     hookState: hookState
   };
 

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -231,9 +231,8 @@ DataAccessObject.create = function (data, options, cb) {
   Model = this.lookupModel(data); // data-specific
   if (Model !== obj.constructor) obj = new Model(data);
 
-  Model.notifyObserversOf('before save', {
-    Model: Model, instance: obj, hookState: hookState
-  }, function(err) {
+  var context = { Model: Model, instance: obj, hookState: hookState };
+  Model.notifyObserversOf('before save', context, function(err) {
     if (err) return cb(err);
 
     data = obj.toObject(true);
@@ -271,9 +270,8 @@ DataAccessObject.create = function (data, options, cb) {
               if (err) {
                 return cb(err, obj);
               }
-              Model.notifyObserversOf('after save', {
-                Model: Model, instance: obj, hookState: hookState
-              }, function(err) {
+              var context = { Model: Model, instance: obj, hookState: hookState };
+              Model.notifyObserversOf('after save', context, function(err) {
                 cb(err, obj);
                 if(!err) Model.emit('changed', obj);
               });
@@ -357,9 +355,8 @@ DataAccessObject.updateOrCreate = DataAccessObject.upsert = function upsert(data
     return this.create(data, options, cb);
   }
 
-  Model.notifyObserversOf('access', { 
-    Model: Model, query: byIdQuery(Model, id), hookState: hookState
-  }, doUpdateOrCreate);
+  var context = { Model: Model, query: byIdQuery(Model, id), hookState: hookState };
+  Model.notifyObserversOf('access', context, doUpdateOrCreate);
 
   function doUpdateOrCreate(err, ctx) {
     if (err) return cb(err);
@@ -367,7 +364,10 @@ DataAccessObject.updateOrCreate = DataAccessObject.upsert = function upsert(data
     var isOriginalQuery = isWhereByGivenId(Model, ctx.query.where, id)
     if (Model.getDataSource().connector.updateOrCreate && isOriginalQuery) {
       var context = { 
-        Model: Model, where: ctx.query.where, data: data, hookState: hookState
+        Model: Model,
+        where: ctx.query.where,
+        data: data,
+        hookState: hookState
       };
       Model.notifyObserversOf('before save', context, function(err, ctx) {
         if (err) return cb(err);
@@ -404,9 +404,8 @@ DataAccessObject.updateOrCreate = DataAccessObject.upsert = function upsert(data
               Model.emit('changed', inst);
             }
           } else {
-            Model.notifyObserversOf('after save', { 
-              Model: Model, instance: obj, hookState: hookState 
-            }, function(err) {
+            var context = { Model: Model, instance: obj, hookState: hookState };
+            Model.notifyObserversOf('after save', context, function(err) {
               cb(err, obj);
               if(!err) {
                 Model.emit('changed', inst);
@@ -506,9 +505,8 @@ DataAccessObject.findOrCreate = function findOrCreate(query, data, options, cb) 
         }
 
         if (created) {
-          Model.notifyObserversOf('after save', { 
-            Model: Model, instance: obj, hookState: hookState
-          }, function(err) {
+          var context = { Model: Model, instance: obj, hookState: hookState };
+          Model.notifyObserversOf('after save', context, function(err) {
               if (cb.promise) {
                 cb(err, [obj, created]);
               } else {
@@ -540,9 +538,8 @@ DataAccessObject.findOrCreate = function findOrCreate(query, data, options, cb) 
 
     this.applyScope(query);
 
-    Model.notifyObserversOf('access', { 
-      Model: Model, query: query, hookState: hookState 
-    }, function (err, ctx) {
+    var context = { Model: Model, query: query, hookState: hookState };
+    Model.notifyObserversOf('access', context, function (err, ctx) {
       if (err) return cb(err);
 
       var query = ctx.query;
@@ -554,9 +551,8 @@ DataAccessObject.findOrCreate = function findOrCreate(query, data, options, cb) 
       Model.applyProperties(enforced, obj);
       obj.setAttributes(enforced);
 
-      Model.notifyObserversOf('before save', { 
-        Model: Model, instance: obj, hookState: hookState
-      }, function(err, ctx) {
+      var context = { Model: Model, instance: obj, hookState: hookState };
+      Model.notifyObserversOf('before save', context, function(err, ctx) {
         if (err) return cb(err);
 
         var obj = ctx.instance;
@@ -1122,9 +1118,8 @@ DataAccessObject.find = function find(query, options, cb) {
       // using all documents
       // TODO [fabien] use default scope here?
 
-      self.notifyObserversOf('access', {
-        Model: self, query: query, hookState: hookState
-      }, function(err, ctx) {
+      var context = { Model: self, query: query, hookState: hookState };
+      self.notifyObserversOf('access', context, function(err, ctx) {
         if (err) return cb(err);
 
         self.getDataSource().connector.all(self.modelName, {}, function (err, data) {
@@ -1218,9 +1213,8 @@ DataAccessObject.find = function find(query, options, cb) {
   if (options.notify === false) {
     self.getDataSource().connector.all(self.modelName, query, allCb);
   } else {
-    this.notifyObserversOf('access', {
-      Model: this, query: query, hookState: hookState
-    }, function(err, ctx) {
+    var context =  { Model: this, query: query, hookState: hookState };
+    this.notifyObserversOf('access', context, function(err, ctx) {
       if (err) return cb(err);
       var query = ctx.query;
       self.getDataSource().connector.all(self.modelName, query, allCb);
@@ -1318,6 +1312,7 @@ DataAccessObject.remove = DataAccessObject.deleteAll = DataAccessObject.destroyA
   where = query.where;
 
   var hookState = {};
+
   var context = {
     Model: Model, where: whereIsEmpty(where) ? {} : where, hookState: hookState
   };
@@ -1326,13 +1321,10 @@ DataAccessObject.remove = DataAccessObject.deleteAll = DataAccessObject.destroyA
     doDelete(where);
   } else {
     query = { where: whereIsEmpty(where) ? {} : where };
-    Model.notifyObserversOf('access', { 
-      Model: Model, query: query, hookState: hookState
-    }, function(err, ctx) {
+    var context = { Model: Model, query: query, hookState: hookState };
+    Model.notifyObserversOf('access', context, function(err, ctx) {
         if (err) return cb(err);
-        var context = {
-          Model: Model, where: ctx.query.where, hookState: hookState
-        };
+        var context = { Model: Model, where: ctx.query.where, hookState: hookState };
         Model.notifyObserversOf('before delete', context, function(err, ctx) {
           if (err) return cb(err);
           doDelete(ctx.where);
@@ -1365,9 +1357,8 @@ DataAccessObject.remove = DataAccessObject.deleteAll = DataAccessObject.destroyA
         return cb(err, data);
       }
 
-      Model.notifyObserversOf('after delete', {
-        Model: Model, where: where, hookState: hookState
-      }, function(err) {
+      var context = { Model: Model, where: where, hookState: hookState };
+      Model.notifyObserversOf('after delete', context, function(err) {
         cb(err, data);
         if (!err)
           Model.emit('deletedAll', whereIsEmpty(where) ? undefined : where);
@@ -1490,9 +1481,8 @@ DataAccessObject.count = function (where, options, cb) {
   var Model = this;
   var hookState = {};
 
-  this.notifyObserversOf('access', {
-    Model: Model, query: { where: where }, hookState: hookState
-  }, function(err, ctx) {
+  var context = { Model: Model, query: { where: where }, hookState: hookState };
+  this.notifyObserversOf('access', context, function(err, ctx) {
       if (err) return cb(err);
       where = ctx.query.where;
       Model.getDataSource().connector.count(Model.modelName, cb, where);
@@ -1540,10 +1530,9 @@ DataAccessObject.prototype.save = function (options, cb) {
   var inst = this;
   var modelName = Model.modelName;
   var hookState = {};
-
-  Model.notifyObserversOf('before save', {
-    Model: Model, instance: inst, hookState: hookState
-  }, function(err) {
+  
+  var context = { Model: Model, instance: inst, hookState: hookState };
+  Model.notifyObserversOf('before save', context, function(err) {
     if (err) return cb(err);
 
     var data = inst.toObject(true);
@@ -1578,9 +1567,8 @@ DataAccessObject.prototype.save = function (options, cb) {
               return cb(err, inst);
             }
             inst._initProperties(data, { persisted: true });
-            Model.notifyObserversOf('after save', {
-              Model: Model, instance: inst, hookState: hookState
-            }, function(err) {
+            var context = { Model: Model, instance: inst, hookState: hookState };
+            Model.notifyObserversOf('after save', context, function(err) {
               if (err) return cb(err, inst);
               updateDone.call(inst, function () {
                 saveDone.call(inst, function () {
@@ -1665,18 +1653,13 @@ DataAccessObject.updateAll = function (where, data, options, cb) {
   var Model = this;
   var hookState = {};
 
-  Model.notifyObserversOf('access', {
-    Model: Model, query: { where: where }, hookState: hookState
-  }, function(err, ctx) {
+  var context = { Model: Model, query: { where: where }, hookState: hookState };
+  Model.notifyObserversOf('access', context, function(err, ctx) {
     if (err) return cb(err);
-    Model.notifyObserversOf(
-      'before save',
-      {
-        Model: Model,
-        where: ctx.query.where,
-        data: data,
-        hookState: hookState
-      },
+    var context = {
+      Model: Model, where: ctx.query.where, data: data, hookState: hookState
+    };
+    Model.notifyObserversOf('before save', context,
       function(err, ctx) {
         if (err) return cb(err);
         doUpdate(ctx.where, ctx.data);
@@ -1699,15 +1682,10 @@ DataAccessObject.updateAll = function (where, data, options, cb) {
     var connector = Model.getDataSource().connector;
     connector.update(Model.modelName, where, data, function(err, count) {
       if (err) return cb (err);
-      Model.notifyObserversOf(
-        'after save',
-        {
-          Model: Model,
-          where: where,
-          data: data,
-          hookState: hookState
-        },
-        function(err, ctx) {
+      var context = {
+        Model: Model, where: where, data: data, hookState: hookState
+      };
+      Model.notifyObserversOf('after save', context, function(err, ctx) {
           return cb(err, count);
         });
     });
@@ -1759,13 +1737,14 @@ DataAccessObject.prototype.remove =
       var id = getIdValue(this.constructor, this);
       var hookState = {};
 
-      Model.notifyObserversOf('access', { 
+      var context = { 
         Model: Model, query: byIdQuery(Model, id), hookState: hookState 
-      }, function(err, ctx) {
+      };
+
+      Model.notifyObserversOf('access', context, function(err, ctx) {
           if (err) return cb(err);
-          Model.notifyObserversOf('before delete',{ 
-            Model: Model, where: ctx.query.where, hookState: hookState
-          }, function(err, ctx) {
+          var context = { Model: Model, where: ctx.query.where, hookState: hookState };
+          Model.notifyObserversOf('before delete', context, function(err, ctx) {
               if (err) return cb(err);
               doDeleteInstance(ctx.where);
             });
@@ -1778,9 +1757,8 @@ DataAccessObject.prototype.remove =
           // We must switch to full query-based delete.
           Model.deleteAll(where, { notify: false }, function(err) {
             if (err) return cb(err);
-            Model.notifyObserversOf('after delete', {
-              Model: Model, where: where, hookState: hookState
-            }, function(err) {
+            var context = { Model: Model, where: where, hookState: hookState };
+            Model.notifyObserversOf('after delete', context, function(err) {
               cb(err);
               if (!err) Model.emit('deleted', id);
             });
@@ -1795,9 +1773,8 @@ DataAccessObject.prototype.remove =
             }
 
             destroyed(function () {
-              Model.notifyObserversOf('after delete', {
-                Model: Model, where: where, hookState: hookState
-              }, function(err) {
+              var context = { Model: Model, where: where, hookState: hookState };
+              Model.notifyObserversOf('after delete', context, function(err) {
                 cb(err);
                 if (!err) Model.emit('deleted', id);
               });
@@ -1953,9 +1930,8 @@ DataAccessObject.prototype.updateAttributes = function updateAttributes(data, op
             done.call(inst, function () {
               saveDone.call(inst, function () {
                 if (err) return cb(err, inst);
-                Model.notifyObserversOf('after save', {
-                  Model: Model, instance: inst, hookState: hookState
-                }, function(err) {
+                var context = { Model: Model, instance: inst, hookState: hookState };
+                Model.notifyObserversOf('after save', context, function(err) {
                   if(!err) Model.emit('changed', inst);
                   cb(err, inst);
                 });

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -216,6 +216,7 @@ DataAccessObject.create = function (data, options, cb) {
   var enforced = {};
   var obj;
   var idValue = getIdValue(this, data);
+  var hookState = {};
 
   // if we come from save
   if (data instanceof Model && !idValue) {
@@ -230,7 +231,9 @@ DataAccessObject.create = function (data, options, cb) {
   Model = this.lookupModel(data); // data-specific
   if (Model !== obj.constructor) obj = new Model(data);
 
-  Model.notifyObserversOf('before save', { Model: Model, instance: obj }, function(err) {
+  Model.notifyObserversOf('before save', {
+    Model: Model, instance: obj, hookState: hookState
+  }, function(err) {
     if (err) return cb(err);
 
     data = obj.toObject(true);
@@ -268,7 +271,9 @@ DataAccessObject.create = function (data, options, cb) {
               if (err) {
                 return cb(err, obj);
               }
-              Model.notifyObserversOf('after save', { Model: Model, instance: obj }, function(err) {
+              Model.notifyObserversOf('after save', {
+                Model: Model, instance: obj, hookState: hookState
+              }, function(err) {
                 cb(err, obj);
                 if(!err) Model.emit('changed', obj);
               });
@@ -345,20 +350,25 @@ DataAccessObject.updateOrCreate = DataAccessObject.upsert = function upsert(data
 
   var self = this;
   var Model = this;
+  var hookState = {};
 
   var id = getIdValue(this, data);
   if (!id) {
     return this.create(data, options, cb);
   }
 
-  Model.notifyObserversOf('access', { Model: Model, query: byIdQuery(Model, id) }, doUpdateOrCreate);
+  Model.notifyObserversOf('access', { 
+    Model: Model, query: byIdQuery(Model, id), hookState: hookState
+  }, doUpdateOrCreate);
 
   function doUpdateOrCreate(err, ctx) {
     if (err) return cb(err);
 
     var isOriginalQuery = isWhereByGivenId(Model, ctx.query.where, id)
     if (Model.getDataSource().connector.updateOrCreate && isOriginalQuery) {
-      var context = { Model: Model, where: ctx.query.where, data: data };
+      var context = { 
+        Model: Model, where: ctx.query.where, data: data, hookState: hookState
+      };
       Model.notifyObserversOf('before save', context, function(err, ctx) {
         if (err) return cb(err);
 
@@ -394,7 +404,9 @@ DataAccessObject.updateOrCreate = DataAccessObject.upsert = function upsert(data
               Model.emit('changed', inst);
             }
           } else {
-            Model.notifyObserversOf('after save', { Model: Model, instance: obj }, function(err) {
+            Model.notifyObserversOf('after save', { 
+              Model: Model, instance: obj, hookState: hookState 
+            }, function(err) {
               cb(err, obj);
               if(!err) {
                 Model.emit('changed', inst);
@@ -478,6 +490,7 @@ DataAccessObject.findOrCreate = function findOrCreate(query, data, options, cb) 
 
   var Model = this;
   var self = this;
+  var hookState = {};
 
   function _findOrCreate(query, data) {
     var modelName = self.modelName;
@@ -493,8 +506,9 @@ DataAccessObject.findOrCreate = function findOrCreate(query, data, options, cb) 
         }
 
         if (created) {
-          Model.notifyObserversOf('after save', { Model: Model, instance: obj },
-            function(err) {
+          Model.notifyObserversOf('after save', { 
+            Model: Model, instance: obj, hookState: hookState
+          }, function(err) {
               if (cb.promise) {
                 cb(err, [obj, created]);
               } else {
@@ -526,8 +540,9 @@ DataAccessObject.findOrCreate = function findOrCreate(query, data, options, cb) 
 
     this.applyScope(query);
 
-    Model.notifyObserversOf('access', { Model: Model, query: query },
-      function (err, ctx) {
+    Model.notifyObserversOf('access', { 
+      Model: Model, query: query, hookState: hookState 
+    }, function (err, ctx) {
       if (err) return cb(err);
 
       var query = ctx.query;
@@ -539,8 +554,9 @@ DataAccessObject.findOrCreate = function findOrCreate(query, data, options, cb) 
       Model.applyProperties(enforced, obj);
       obj.setAttributes(enforced);
 
-      Model.notifyObserversOf('before save', { Model: Model, instance: obj },
-        function(err, ctx) {
+      Model.notifyObserversOf('before save', { 
+        Model: Model, instance: obj, hookState: hookState
+      }, function(err, ctx) {
         if (err) return cb(err);
 
         var obj = ctx.instance;
@@ -1081,6 +1097,7 @@ DataAccessObject.find = function find(query, options, cb) {
   assert(typeof cb === 'function', 'The cb argument must be a function');
 
   var self = this;
+  var hookState = {};
 
   try {
     this._normalize(query);
@@ -1105,7 +1122,9 @@ DataAccessObject.find = function find(query, options, cb) {
       // using all documents
       // TODO [fabien] use default scope here?
 
-      self.notifyObserversOf('access', { Model: self, query: query }, function(err, ctx) {
+      self.notifyObserversOf('access', {
+        Model: self, query: query, hookState: hookState
+      }, function(err, ctx) {
         if (err) return cb(err);
 
         self.getDataSource().connector.all(self.modelName, {}, function (err, data) {
@@ -1199,7 +1218,9 @@ DataAccessObject.find = function find(query, options, cb) {
   if (options.notify === false) {
     self.getDataSource().connector.all(self.modelName, query, allCb);
   } else {
-    this.notifyObserversOf('access', { Model: this, query: query }, function(err, ctx) {
+    this.notifyObserversOf('access', {
+      Model: this, query: query, hookState: hookState
+    }, function(err, ctx) {
       if (err) return cb(err);
       var query = ctx.query;
       self.getDataSource().connector.all(self.modelName, query, allCb);
@@ -1296,16 +1317,22 @@ DataAccessObject.remove = DataAccessObject.deleteAll = DataAccessObject.destroyA
   this.applyScope(query);
   where = query.where;
 
-  var context = { Model: Model, where: whereIsEmpty(where) ? {} : where };
+  var hookState = {};
+  var context = {
+    Model: Model, where: whereIsEmpty(where) ? {} : where, hookState: hookState
+  };
+
   if (options.notify === false) {
     doDelete(where);
   } else {
     query = { where: whereIsEmpty(where) ? {} : where };
-    Model.notifyObserversOf('access',
-      { Model: Model, query: query },
-      function(err, ctx) {
+    Model.notifyObserversOf('access', { 
+      Model: Model, query: query, hookState: hookState
+    }, function(err, ctx) {
         if (err) return cb(err);
-        var context = { Model: Model, where: ctx.query.where };
+        var context = {
+          Model: Model, where: ctx.query.where, hookState: hookState
+        };
         Model.notifyObserversOf('before delete', context, function(err, ctx) {
           if (err) return cb(err);
           doDelete(ctx.where);
@@ -1338,7 +1365,9 @@ DataAccessObject.remove = DataAccessObject.deleteAll = DataAccessObject.destroyA
         return cb(err, data);
       }
 
-      Model.notifyObserversOf('after delete', { Model: Model, where: where }, function(err) {
+      Model.notifyObserversOf('after delete', {
+        Model: Model, where: where, hookState: hookState
+      }, function(err) {
         cb(err, data);
         if (!err)
           Model.emit('deletedAll', whereIsEmpty(where) ? undefined : where);
@@ -1459,7 +1488,11 @@ DataAccessObject.count = function (where, options, cb) {
   }
 
   var Model = this;
-  this.notifyObserversOf('access', { Model: Model, query: { where: where } }, function(err, ctx) {
+  var hookState = {};
+
+  this.notifyObserversOf('access', {
+    Model: Model, query: { where: where }, hookState: hookState
+  }, function(err, ctx) {
       if (err) return cb(err);
       where = ctx.query.where;
       Model.getDataSource().connector.count(Model.modelName, cb, where);
@@ -1506,8 +1539,11 @@ DataAccessObject.prototype.save = function (options, cb) {
 
   var inst = this;
   var modelName = Model.modelName;
+  var hookState = {};
 
-  Model.notifyObserversOf('before save', { Model: Model, instance: inst }, function(err) {
+  Model.notifyObserversOf('before save', {
+    Model: Model, instance: inst, hookState: hookState
+  }, function(err) {
     if (err) return cb(err);
 
     var data = inst.toObject(true);
@@ -1542,7 +1578,9 @@ DataAccessObject.prototype.save = function (options, cb) {
               return cb(err, inst);
             }
             inst._initProperties(data, { persisted: true });
-            Model.notifyObserversOf('after save', { Model: Model, instance: inst }, function(err) {
+            Model.notifyObserversOf('after save', {
+              Model: Model, instance: inst, hookState: hookState
+            }, function(err) {
               if (err) return cb(err, inst);
               updateDone.call(inst, function () {
                 saveDone.call(inst, function () {
@@ -1625,15 +1663,19 @@ DataAccessObject.updateAll = function (where, data, options, cb) {
   where = query.where;
 
   var Model = this;
+  var hookState = {};
 
-  Model.notifyObserversOf('access', { Model: Model, query: { where: where } }, function(err, ctx) {
+  Model.notifyObserversOf('access', {
+    Model: Model, query: { where: where }, hookState: hookState
+  }, function(err, ctx) {
     if (err) return cb(err);
     Model.notifyObserversOf(
       'before save',
       {
         Model: Model,
         where: ctx.query.where,
-        data: data
+        data: data,
+        hookState: hookState
       },
       function(err, ctx) {
         if (err) return cb(err);
@@ -1662,7 +1704,8 @@ DataAccessObject.updateAll = function (where, data, options, cb) {
         {
           Model: Model,
           where: where,
-          data: data
+          data: data,
+          hookState: hookState
         },
         function(err, ctx) {
           return cb(err, count);
@@ -1714,16 +1757,15 @@ DataAccessObject.prototype.remove =
       var self = this;
       var Model = this.constructor;
       var id = getIdValue(this.constructor, this);
+      var hookState = {};
 
-      Model.notifyObserversOf(
-        'access',
-        { Model: Model, query: byIdQuery(Model, id) },
-        function(err, ctx) {
+      Model.notifyObserversOf('access', { 
+        Model: Model, query: byIdQuery(Model, id), hookState: hookState 
+      }, function(err, ctx) {
           if (err) return cb(err);
-          Model.notifyObserversOf(
-            'before delete',
-            { Model: Model, where: ctx.query.where },
-            function(err, ctx) {
+          Model.notifyObserversOf('before delete',{ 
+            Model: Model, where: ctx.query.where, hookState: hookState
+          }, function(err, ctx) {
               if (err) return cb(err);
               doDeleteInstance(ctx.where);
             });
@@ -1736,7 +1778,9 @@ DataAccessObject.prototype.remove =
           // We must switch to full query-based delete.
           Model.deleteAll(where, { notify: false }, function(err) {
             if (err) return cb(err);
-            Model.notifyObserversOf('after delete', { Model: Model, where: where }, function(err) {
+            Model.notifyObserversOf('after delete', {
+              Model: Model, where: where, hookState: hookState
+            }, function(err) {
               cb(err);
               if (!err) Model.emit('deleted', id);
             });
@@ -1751,7 +1795,9 @@ DataAccessObject.prototype.remove =
             }
 
             destroyed(function () {
-              Model.notifyObserversOf('after delete', { Model: Model, where: where }, function(err) {
+              Model.notifyObserversOf('after delete', {
+                Model: Model, where: where, hookState: hookState
+              }, function(err) {
                 cb(err);
                 if (!err) Model.emit('deleted', id);
               });
@@ -1858,7 +1904,8 @@ DataAccessObject.prototype.updateAttributes = function updateAttributes(data, op
   var inst = this;
   var Model = this.constructor;
   var model = Model.modelName;
-
+  var hookState = {};
+  
   // Convert the data to be plain object so that update won't be confused
   if (data instanceof Model) {
     data = data.toObject(false);
@@ -1868,7 +1915,8 @@ DataAccessObject.prototype.updateAttributes = function updateAttributes(data, op
   var context = {
     Model: Model,
     where: byIdQuery(Model, getIdValue(Model, inst)).where,
-    data: data
+    data: data,
+    hookState: hookState
   };
 
   Model.notifyObserversOf('before save', context, function(err, ctx) {
@@ -1905,7 +1953,9 @@ DataAccessObject.prototype.updateAttributes = function updateAttributes(data, op
             done.call(inst, function () {
               saveDone.call(inst, function () {
                 if (err) return cb(err, inst);
-                Model.notifyObserversOf('after save', { Model: Model, instance: inst }, function(err) {
+                Model.notifyObserversOf('after save', {
+                  Model: Model, instance: inst, hookState: hookState
+                }, function(err) {
                   if(!err) Model.emit('changed', inst);
                   cb(err, inst);
                 });

--- a/test/persistence-hooks.suite.js
+++ b/test/persistence-hooks.suite.js
@@ -1095,6 +1095,31 @@ module.exports = function(dataSource, should) {
         });
       });
 
+      it('applies propagates hookState from `before delete` to `after delete` hook', function(done) {
+        TestModel.observe('before delete', pushContextAndNext(function(ctx) {
+          ctx.hookState.foo = 'bar';
+        }));
+
+        TestModel.observe('after delete', pushContextAndNext(function(ctx) {
+          ctx.hookState.foo = ctx.hookState.foo.toUpperCase();
+        }));
+
+        existingInstance.delete(function(err) {
+          if (err) return done(err);
+          observedContexts.should.eql([
+            aTestModelCtx({ 
+              hookState: { foo: 'bar', test: true },
+              where: { id: '1' }
+            }),
+            aTestModelCtx({ 
+              hookState: { foo: 'BAR', test: true },
+              where: { id: '1' }
+            })
+          ]);
+          done();
+        });
+      });
+
       it('triggers hooks only once', function(done) {
         TestModel.observe('access', pushNameAndNext('access'));
         TestModel.observe('after delete', pushNameAndNext('after delete'));
@@ -1202,9 +1227,14 @@ module.exports = function(dataSource, should) {
       });
     });
 
-    function pushContextAndNext() {
+    function pushContextAndNext(fn) {
       return function(context, next) {
+        if (typeof fn === 'function') {
+          fn(context);
+        }
+
         context = deepCloneToObject(context);
+        context.hookState.test = true;
 
         if (typeof observedContexts === 'string') {
           observedContexts = context;
@@ -1246,6 +1276,9 @@ module.exports = function(dataSource, should) {
 
     function aTestModelCtx(ctx) {
       ctx.Model = TestModel;
+      if (!ctx.hookState) {
+        ctx.hookState = { test: true };
+      }
       return deepCloneToObject(ctx);
     }
 

--- a/test/persistence-hooks.suite.js
+++ b/test/persistence-hooks.suite.js
@@ -1095,7 +1095,7 @@ module.exports = function(dataSource, should) {
         });
       });
 
-      it('applies propagates hookState from `before delete` to `after delete` hook', function(done) {
+      it('propagates hookState from `before delete` to `after delete`', function(done) {
         TestModel.observe('before delete', pushContextAndNext(function(ctx) {
           ctx.hookState.foo = 'bar';
         }));

--- a/test/persistence-hooks.suite.js
+++ b/test/persistence-hooks.suite.js
@@ -540,7 +540,8 @@ module.exports = function(dataSource, should) {
           if (err) return done(err);
           observedContexts.should.eql(aTestModelCtx({
             where: { id: existingInstance.id },
-            data: { name: 'changed' }
+            data: { name: 'changed' },
+            currentInstance: existingInstance
           }));
           done();
         });
@@ -736,10 +737,18 @@ module.exports = function(dataSource, should) {
           { id: existingInstance.id, name: 'updated name' },
           function(err, instance) {
             if (err) return done(err);
-            observedContexts.should.eql(aTestModelCtx({
-              where: { id: existingInstance.id },
-              data: { id: existingInstance.id, name: 'updated name' }
-            }));
+            if (dataSource.connector.findOrCreate) {
+              observedContexts.should.eql(aTestModelCtx({
+                where: { id: existingInstance.id },
+                data: { id: existingInstance.id, name: 'updated name' }
+              }));
+            } else {
+              observedContexts.should.eql(aTestModelCtx({
+                where: { id: existingInstance.id },
+                data: { id: existingInstance.id, name: 'updated name' },
+                currentInstance: existingInstance
+              }));
+            }
             done();
           });
       });
@@ -1026,7 +1035,8 @@ module.exports = function(dataSource, should) {
         existingInstance.delete(function(err) {
           if (err) return done(err);
           observedContexts.should.eql(aTestModelCtx({
-             where: { id: existingInstance.id }
+             where: { id: existingInstance.id },
+             instance: existingInstance
           }));
           done();
         });
@@ -1068,7 +1078,8 @@ module.exports = function(dataSource, should) {
         existingInstance.delete(function(err) {
           if (err) return done(err);
           observedContexts.should.eql(aTestModelCtx({
-            where: { id: existingInstance.id }
+             where: { id: existingInstance.id },
+             instance: existingInstance
           }));
           done();
         });
@@ -1109,11 +1120,13 @@ module.exports = function(dataSource, should) {
           observedContexts.should.eql([
             aTestModelCtx({ 
               hookState: { foo: 'bar', test: true },
-              where: { id: '1' }
+              where: { id: '1' },
+              instance: existingInstance
             }),
             aTestModelCtx({ 
               hookState: { foo: 'BAR', test: true },
-              where: { id: '1' }
+              where: { id: '1' },
+              instance: existingInstance
             })
           ]);
           done();

--- a/test/persistence-hooks.suite.js
+++ b/test/persistence-hooks.suite.js
@@ -535,13 +535,15 @@ module.exports = function(dataSource, should) {
       it('triggers `before save` hook', function(done) {
         TestModel.observe('before save', pushContextAndNext());
 
-        existingInstance.name = 'changed';
+        var currentInstance = deepCloneToObject(existingInstance);
+
         existingInstance.updateAttributes({ name: 'changed' }, function(err) {
           if (err) return done(err);
+          existingInstance.name.should.equal('changed');
           observedContexts.should.eql(aTestModelCtx({
             where: { id: existingInstance.id },
             data: { name: 'changed' },
-            currentInstance: existingInstance
+            currentInstance: currentInstance
           }));
           done();
         });


### PR DESCRIPTION
This is a combined PR - because of the expected conflicts/overlap of changes.

It implements the following improvements:

To maintain 'state' between `before` and `after` hooks, a `hookState` (object) property was introduced to `context`.

For consistency, all instance-level operations (`prototype.updateAttributes` and `prototype.delete`) will now have access to the current instance as part of the hook's `context`:

- `prototype.save` + `before save`:  the instance will be available as `instance` (unchanged behavior).

- `prototype.save` + `after save`:  the instance will be available as `instance` (unchanged behavior).

- `prototype.updateAttributes` + `before save`: because the instance should not be manipulated directly, the instance will be available as **currentInstance** to distinguish between the `instance` that *can* be directly modified (it is omitted now). In other words, `currentInstance` provides the current 'state' of the instance, and it should be regarded as immutable. Any modifications should be applied to `context.data`, which incorporates the partial nature of the `updateAttributes` operation.

- `prototype.updateAttributes` + `after save`: in *after* hooks, this difference is not important, and thus, the instance will be simply be available as `instance`.

- `prototype.remove/destroy/delete` + `before save`: again, the difference is irrelevant, so the instance will be available as `instance`.

- `prototype.remove/destroy/delete` + `after save`:  the instance will be available as `instance`.