### PR TITLE
Improve instance-level operation hooks

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1732,18 +1732,23 @@ DataAccessObject.prototype.remove =
       assert(typeof options === 'object', 'The options argument should be an object');
       assert(typeof cb === 'function', 'The cb argument should be a function');
 
-      var self = this;
+      var inst = this;
       var Model = this.constructor;
       var id = getIdValue(this.constructor, this);
       var hookState = {};
 
       var context = { 
-        Model: Model, query: byIdQuery(Model, id), hookState: hookState 
+        Model: Model, query: byIdQuery(Model, id), hookState: hookState
       };
 
       Model.notifyObserversOf('access', context, function(err, ctx) {
           if (err) return cb(err);
-          var context = { Model: Model, where: ctx.query.where, hookState: hookState };
+          var context = {
+            Model: Model,
+            where: ctx.query.where,
+            instance: inst,
+            hookState: hookState
+          };
           Model.notifyObserversOf('before delete', context, function(err, ctx) {
               if (err) return cb(err);
               doDeleteInstance(ctx.where);
@@ -1757,7 +1762,12 @@ DataAccessObject.prototype.remove =
           // We must switch to full query-based delete.
           Model.deleteAll(where, { notify: false }, function(err) {
             if (err) return cb(err);
-            var context = { Model: Model, where: where, hookState: hookState };
+            var context = {
+              Model: Model,
+              where: where,
+              instance: inst,
+              hookState: hookState
+            };
             Model.notifyObserversOf('after delete', context, function(err) {
               cb(err);
               if (!err) Model.emit('deleted', id);
@@ -1766,14 +1776,19 @@ DataAccessObject.prototype.remove =
           return;
         }
 
-        self.trigger('destroy', function (destroyed) {
-          self._adapter().destroy(self.constructor.modelName, id, function (err) {
+        inst.trigger('destroy', function (destroyed) {
+          inst._adapter().destroy(inst.constructor.modelName, id, function (err) {
             if (err) {
               return cb(err);
             }
 
             destroyed(function () {
-              var context = { Model: Model, where: where, hookState: hookState };
+              var context = {
+                Model: Model,
+                where: where,
+                instance: inst,
+                hookState: hookState
+              };
               Model.notifyObserversOf('after delete', context, function(err) {
                 cb(err);
                 if (!err) Model.emit('deleted', id);
@@ -1893,6 +1908,7 @@ DataAccessObject.prototype.updateAttributes = function updateAttributes(data, op
     Model: Model,
     where: byIdQuery(Model, getIdValue(Model, inst)).where,
     data: data,
+    currentInstance: inst,
     hookState: hookState
   };
 

--- a/test/persistence-hooks.suite.js
+++ b/test/persistence-hooks.suite.js
@@ -535,12 +535,15 @@ module.exports = function(dataSource, should) {
       it('triggers `before save` hook', function(done) {
         TestModel.observe('before save', pushContextAndNext());
 
-        existingInstance.name = 'changed';
+        var currentInstance = deepCloneToObject(existingInstance);
+
         existingInstance.updateAttributes({ name: 'changed' }, function(err) {
           if (err) return done(err);
+          existingInstance.name.should.equal('changed');
           observedContexts.should.eql(aTestModelCtx({
             where: { id: existingInstance.id },
-            data: { name: 'changed' }
+            data: { name: 'changed' },
+            currentInstance: currentInstance
           }));
           done();
         });
@@ -736,10 +739,24 @@ module.exports = function(dataSource, should) {
           { id: existingInstance.id, name: 'updated name' },
           function(err, instance) {
             if (err) return done(err);
-            observedContexts.should.eql(aTestModelCtx({
-              where: { id: existingInstance.id },
-              data: { id: existingInstance.id, name: 'updated name' }
-            }));
+            if (dataSource.connector.updateOrCreate) {
+              // Atomic implementations of `updateOrCreate` cannot
+              // provide full instance as that depends on whether
+              // UPDATE or CREATE will be triggered
+              observedContexts.should.eql(aTestModelCtx({
+                where: { id: existingInstance.id },
+                data: { id: existingInstance.id, name: 'updated name' }
+              }));
+            } else {
+              // currentInstance is set, because a non-atomic `updateOrCreate`
+              // will use `prototype.updateAttributes` internally, which
+              // exposes this to the context
+              observedContexts.should.eql(aTestModelCtx({
+                where: { id: existingInstance.id },
+                data: { id: existingInstance.id, name: 'updated name' },
+                currentInstance: existingInstance
+              }));
+            }
             done();
           });
       });
@@ -1026,7 +1043,8 @@ module.exports = function(dataSource, should) {
         existingInstance.delete(function(err) {
           if (err) return done(err);
           observedContexts.should.eql(aTestModelCtx({
-             where: { id: existingInstance.id }
+           where: { id: existingInstance.id },
+           instance: existingInstance
           }));
           done();
         });
@@ -1068,7 +1086,8 @@ module.exports = function(dataSource, should) {
         existingInstance.delete(function(err) {
           if (err) return done(err);
           observedContexts.should.eql(aTestModelCtx({
-            where: { id: existingInstance.id }
+            where: { id: existingInstance.id },
+            instance: existingInstance
           }));
           done();
         });
@@ -1109,11 +1128,13 @@ module.exports = function(dataSource, should) {
           observedContexts.should.eql([
             aTestModelCtx({ 
               hookState: { foo: 'bar', test: true },
-              where: { id: '1' }
+              where: { id: '1' },
+              instance: existingInstance
             }),
             aTestModelCtx({ 
               hookState: { foo: 'BAR', test: true },
-              where: { id: '1' }
+              where: { id: '1' },
+              instance: existingInstance
             })
           ]);
           done();


### PR DESCRIPTION
For consistency, all instance-level operations (`prototype.updateAttributes` and `prototype.delete`) will now have access to the current instance as part of the hook's `context`:

- `prototype.save` + `before save`:  the instance will be available as `instance` (unchanged behavior).

- `prototype.save` + `after save`:  the instance will be available as `instance` (unchanged behavior).

- `prototype.updateAttributes` + `before save`: because the instance should not be manipulated directly, the instance will be available as **currentInstance** to distinguish between the `instance` that *can* be directly modified (it is omitted now). In other words, `currentInstance` provides the current 'state' of the instance, and it should be regarded as immutable. Any modifications should be applied to `context.data`, which incorporates the partial nature of the `updateAttributes` operation.

- `prototype.updateAttributes` + `after save`: in *after* hooks, this difference is not important, and thus, the instance will be simply be available as `instance`.

- `prototype.remove/destroy/delete` + `before save`: again, the difference is irrelevant, so the instance will be available as `instance`.

- `prototype.remove/destroy/delete` + `after save`:  the instance will be available as `instance`.