### PR TITLE
Allow submodel to hide base properties

### DIFF
--- a/lib/model-builder.js
+++ b/lib/model-builder.js
@@ -241,6 +241,14 @@ ModelBuilder.prototype.define = function defineClass(className, properties, sett
   ModelClass.getter = {};
   ModelClass.setter = {};
 
+  // Remove properties that reverted by the subclass
+  for (var p in properties) {
+    if (properties[p] === null || properties[p] === false) {
+      // Hide the base property
+      delete properties[p];
+    }
+  }
+
   var modelDefinition = new ModelDefinition(this, className, properties, settings);
 
   this.definitions[className] = modelDefinition;
@@ -343,7 +351,7 @@ ModelBuilder.prototype.define = function defineClass(className, properties, sett
     // Check if subclass redefines the ids
     var idFound = false;
     for (var k in subclassProperties) {
-      if (subclassProperties[k].id) {
+      if (subclassProperties[k] && subclassProperties[k].id) {
         idFound = true;
         break;
       }

--- a/test/loopback-dl.test.js
+++ b/test/loopback-dl.test.js
@@ -671,6 +671,29 @@ describe('Load models with base', function () {
     Customer.definition.properties.name.should.have.property('type', String);
   });
 
+  it('should revert properties from base model', function() {
+    var ds = new ModelBuilder();
+
+    var User = ds.define('User', {username: String, email: String});
+
+    var Customer = ds.define('Customer',
+      {name: String, username: null, email: false},
+      {base: 'User'});
+
+    Customer.definition.properties.should.have.property('name');
+    // username/email are now shielded
+    Customer.definition.properties.should.not.have.property('username');
+    Customer.definition.properties.should.not.have.property('email');
+    var c = new Customer({name: 'John'});
+    c.should.have.property('username', undefined);
+    c.should.have.property('email', undefined);
+    c.should.have.property('name', 'John');
+    var u = new User({username: 'X', email: 'x@y.com'});
+    u.should.not.have.property('name');
+    u.should.have.property('username', 'X');
+    u.should.have.property('email', 'x@y.com');
+  });
+
 
   it('should set up base class via parent arg', function () {
     var ds = new ModelBuilder();


### PR DESCRIPTION
/to @ritch @bajtos 

The PR allows sub-models to hide properties from its base. For example,
```json
"Customer": {
  "base": "User",
  "name": "String",
  "username": null // or false
}
```
