### PR TITLE
fix foreign key dataType bug

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -1710,7 +1710,7 @@ DataSource.prototype.defineForeignKey = function defineForeignKey(className, key
   }
 
   var fkDef = {type: pkType};
-  var foreignMeta = this.columnMetadata(foreignClassName, key);
+  var foreignMeta = this.columnMetadata(foreignClassName, pkName);
   if(foreignMeta && foreignMeta.dataType) {
     fkDef[this.connector.name] = {};
     fkDef[this.connector.name].dataType = foreignMeta.dataType;


### PR DESCRIPTION
Use PK name of foreign class  to get columnMetadata.
Details: https://github.com/strongloop/loopback-connector-mysql/issues/84