### PR TITLE
Add abilities to remove and clear observers - Operation Hooks.

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -579,6 +579,30 @@ ModelBaseClass.observe = function(operation, listener) {
 };
 
 /**
+ * Unregister an asynchronous observer for the given operation (event).
+ * @param {String} operation The operation name.
+ * @callback {function} listener The listener function.
+ * @end
+ */
+ModelBaseClass.removeObserver = function(operation, listener) {
+  if (!this._observers[operation]) return;
+  
+  var index = this._observers[operation].indexOf(listener);
+  if (index != -1) this._observers[operation].splice(index, 1);
+};
+
+/**
+ * Unregister all asynchronous observers for the given operation (event).
+ * @param {String} operation The operation name.
+ * @end
+ */
+ModelBaseClass.clearObservers = function(operation) {
+  if (!this._observers[operation]) return;
+
+  this._observers[operation].length = 0;
+};
+
+/**
  * Invoke all async observers for the given operation.
  * @param {String} operation The operation name.
  * @param {Object} context Operation-specific context.

--- a/test/async-observer.test.js
+++ b/test/async-observer.test.js
@@ -79,6 +79,44 @@ describe('async observer', function() {
     });
   });
 
+  it('can remove observers', function(done) {
+    var notifications = [];
+
+    function call(ctx, next) {
+      notifications.push('call');
+      process.nextTick(next);
+    };
+
+    TestModel.observe('event', call);
+    TestModel.removeObserver('event', call);
+
+    TestModel.notifyObserversOf('event', {}, function(err) {
+      if (err) return done(err);
+      notifications.should.eql([]);
+      done();
+    });
+  });
+
+  it('can clear all observers', function(done) {
+    var notifications = [];
+
+    function call(ctx, next) {
+      notifications.push('call');
+      process.nextTick(next);
+    };
+
+    TestModel.observe('event', call);
+    TestModel.observe('event', call);
+    TestModel.observe('event', call);
+    TestModel.clearObservers('event');
+
+    TestModel.notifyObserversOf('event', {}, function(err) {
+      if (err) return done(err);
+      notifications.should.eql([]);
+      done();
+    });
+  });
+
   it('handles no observers', function(done) {
     TestModel.notifyObserversOf('no-observers', {}, function(err) {
       // the test passes when no error was raised


### PR DESCRIPTION
Users need to keep function references to be able to remove them from operation hooks.