### PR TITLE
Enable "between" filter for memory db connector

### DIFF
--- a/lib/connectors/memory.js
+++ b/lib/connectors/memory.js
@@ -455,7 +455,12 @@ function applyFilter(filter) {
       if ('neq' in example) {
         return compare(example.neq, value) !== 0;
       }
-
+      
+      if ('between' in example ) {
+        return ( testInEquality({gte:example.between[0]}, value) && 
+                 testInEquality({lte:example.between[1]}, value) );
+      }
+      
       if (example.like || example.nlike) {
 
         var like = example.like || example.nlike;

--- a/test/memory.test.js
+++ b/test/memory.test.js
@@ -224,6 +224,38 @@ describe('Memory connector', function() {
       });
     });
 
+    it('should successfully extract 5 users from the db', function(done) {
+      User.find({where: {seq: {between: [1,5]}}}, function(err, users) {
+        should(users.length).be.equal(5);
+        done();
+      });
+    });
+
+    it('should successfully extract 1 user (Lennon) from the db', function(done) {
+      User.find({where: {birthday: {between: [new Date(1970,0),new Date(1990,0)]}}}, 
+                function(err, users) {
+        should(users.length).be.equal(1);
+        should(users[0].name).be.equal('John Lennon');
+        done();
+      });
+    });
+
+    it('should successfully extract 2 users from the db', function(done) {
+      User.find({where: {birthday: {between: [new Date(1940,0),new Date(1990,0)]}}}, 
+                function(err, users) {
+        should(users.length).be.equal(2);
+        done();
+      });
+    });
+
+    it('should successfully extract 0 user from the db', function(done) {
+      User.find({where: {birthday: {between: [new Date(1990,0), Date.now()]}}}, 
+                function(err, users) {
+        should(users.length).be.equal(0);
+        done();
+      });
+    });
+
     it('should support order with multiple fields', function(done) {
       User.find({order: 'vip ASC, seq DESC'}, function(err, posts) {
         should.not.exist(err);


### PR DESCRIPTION
Hello,

I happen to be using the memory datasource a lot but couldn't get "between" requests to work as documented here:
http://docs.strongloop.com/display/public/LB/Where+filter#Wherefilter-between

After trying every combination I could think of I finally figured that it could be a bug on loopback's side.
So here is my modest contribution.

Daniel