### PR TITLE
Reject CREATE with a duplicate id

### DIFF
--- a/lib/connectors/memory.js
+++ b/lib/connectors/memory.js
@@ -210,6 +210,13 @@ Memory.prototype.create = function create(model, data, callback) {
   if(!this.collection(model)) {
     this.collection(model, {});
   }
+
+  if (this.collection(model)[id]) {
+    return process.nextTick(function() {
+      callback(new Error('Duplicate entry for ' + model + '.' + idName));
+    });
+  }
+
   this.collection(model)[id] = serialize(data);
   this.saveToFile(id, callback);
 };

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -393,7 +393,7 @@ DataAccessObject.updateOrCreate = DataAccessObject.upsert = function upsert(data
         function done(err, data) {
           var obj;
           if (data && !(data instanceof Model)) {
-            inst._initProperties(data);
+            inst._initProperties(data, { persisted: true });
             obj = inst;
           } else {
             obj = data;

--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -567,6 +567,15 @@ describe('manipulation', function () {
             });
         });
     });
+
+    it('should allow save() of the created instance', function(done) {
+      Person.updateOrCreate(
+        { id: 'new-id', name: 'a-name' },
+        function(err, inst) {
+          if (err) return done(err);
+          inst.save(done);
+        });
+    });
   });
 
   describe('findOrCreate', function() {

--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -291,6 +291,25 @@ describe('manipulation', function () {
         });
     });
 
+    it('should refuse to create object with duplicate id', function(done) {
+      // NOTE(bajtos) We cannot reuse Person model here,
+      // `settings.forceId` aborts the CREATE request at the validation step.
+      var Product = db.define('Product', { name: String });
+      db.automigrate(function(err) {
+        if (err) return done(err);
+
+        Product.create({ name: 'a-name' }, function(err, p) {
+          if (err) return done(err);
+          Product.create({ id: p.id, name: 'duplicate' }, function(err) {
+            if (!err) {
+              return done(new Error('Create should have rejected duplicate id.'));
+            }
+            err.message.should.match(/duplicate/i);
+            done();
+          });
+        });
+      });
+    });
   });
 
   describe('save', function () {


### PR DESCRIPTION
Modify the memory connector to reject requests to create a record with a duplicate id.

Add a unit-test to verify this behaviour across all connectors.

Connect to https://github.com/strongloop/loopback/issues/986

/to @raymondfeng please review