### PR TITLE
Notify observers for embedded relations

### DIFF
--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -1856,27 +1856,35 @@ EmbedsOne.prototype.create = function (targetModelData, cb) {
 
   var inst = this.callScopeMethod('build', targetModelData);
 
-  var updateEmbedded = function() {
+  var updateEmbedded = function(callback) {
     modelInstance.updateAttribute(propertyName,
       inst, function(err) {
-      cb(err, err ? null : inst);
+      callback(err, err ? null : inst);
     });
   };
 
   if (this.definition.options.persistent) {
     inst.save(function(err) { // will validate
       if (err) return cb(err, inst);
-      updateEmbedded();
+      updateEmbedded(cb);
     });
   } else {
-    var err = inst.isValid() ? null : new ValidationError(inst);
-    if (err) {
-      process.nextTick(function() {
-        cb(err);
-      });
-    } else {
-      updateEmbedded();
-    }
+    var context = { Model: modelTo, instance: inst, hookState: {} };
+    modelTo.notifyObserversOf('before save', context, function(err) {
+      err = err || (inst.isValid() ? null : new ValidationError(inst));
+      if (err) {
+        process.nextTick(function() {
+          cb(err);
+        });
+      } else {
+        updateEmbedded(function(err, inst) {
+          if (err) return cb(err, null);
+          modelTo.notifyObserversOf('after save', context, function(err) {
+            cb(err, err ? null : inst);
+          });
+        });
+      }
+    });
   }
 };
 
@@ -1921,8 +1929,14 @@ EmbedsOne.prototype.update = function (targetModelData, cb) {
   if (embeddedInstance instanceof modelTo) {
     embeddedInstance.setAttributes(data);
     if (typeof cb === 'function') {
-      modelInstance.save(function(err, inst) {
-        cb(err, inst ? inst[propertyName] : embeddedInstance);
+      var context = { Model: modelTo, instance: embeddedInstance, hookState: {} };
+      modelTo.notifyObserversOf('before save', context, function(err) {
+        if (err) return cb(err);
+        modelInstance.save(function(err, inst) {
+          modelTo.notifyObserversOf('after save', context, function(err) {
+            cb(err, inst ? inst[propertyName] : embeddedInstance);
+          });
+        });
       });
     }
   } else if (!embeddedInstance && cb) {
@@ -1933,11 +1947,23 @@ EmbedsOne.prototype.update = function (targetModelData, cb) {
 };
 
 EmbedsOne.prototype.destroy = function (cb) {
+  var modelTo = this.definition.modelTo;
   var modelInstance = this.modelInstance;
   var propertyName = this.definition.keyFrom;
+  var embeddedInstance = modelInstance[propertyName];
+
+  if (!embeddedInstance) return cb && cb(null, 0);
+
   modelInstance.unsetAttribute(propertyName, true);
-  modelInstance.save(function (err, result) {
-    cb && cb(err, result);
+
+  var context = { Model: modelTo, instance: embeddedInstance, hookState: {} };
+  modelTo.notifyObserversOf('before delete', context, function(err) {
+    if (err) return cb && cb(err);
+    modelInstance.save(function(err, result) {
+      modelTo.notifyObserversOf('after delete', context, function(err) {
+        cb && cb(err, result);
+      });
+    });
   });
 };
 
@@ -2225,22 +2251,33 @@ EmbedsMany.prototype.updateById = function (fkId, data, cb) {
   var inst = this.findById(fkId);
 
   if (inst instanceof modelTo) {
-    if (typeof data === 'object') {
-        inst.setAttributes(data);
-    }
-    var err = inst.isValid() ? null : new ValidationError(inst);
-    if (err && typeof cb === 'function') {
-      return process.nextTick(function() {
-        cb(err, inst);
-      });
-    }
+    var context = { Model: modelTo, instance: inst, hookState: {} };
+    modelTo.notifyObserversOf('before save', context, function(err) {
+      if (err) return cb && cb(err);
 
-    if (typeof cb === 'function') {
-      modelInstance.updateAttribute(propertyName,
-        embeddedList, function(err) {
-        cb(err, inst);
-      });
-    }
+      if (typeof data === 'object') {
+          inst.setAttributes(data);
+      }
+
+      var err = inst.isValid() ? null : new ValidationError(inst);
+      if (err && typeof cb === 'function') {
+        return process.nextTick(function() {
+          cb(err, inst);
+        });
+      }
+
+      if (typeof cb === 'function') {
+        modelInstance.updateAttribute(propertyName,
+          embeddedList, function(err) {
+          if (err) return cb(err, inst);
+          modelTo.notifyObserversOf('after save', context, function(err) {
+            cb(err, inst);
+          });
+        });
+      } else {
+        modelTo.notifyObserversOf('after save', context);
+      }
+    });
   } else if (typeof cb === 'function') {
     process.nextTick(function() {
       cb(null, null); // not found
@@ -2259,15 +2296,23 @@ EmbedsMany.prototype.destroyById = function (fkId, cb) {
   var inst = (fkId instanceof modelTo) ? fkId : this.findById(fkId);
 
   if (inst instanceof modelTo) {
-    var index = embeddedList.indexOf(inst);
-    if (index > -1) embeddedList.splice(index, 1);
-    if (typeof cb === 'function') {
-      modelInstance.updateAttribute(propertyName,
-        embeddedList, function(err) {
-        cb(err);
-        modelTo.emit('deleted', inst.id, inst.toJSON());
-      });
-    }
+    var context = { Model: modelTo, instance: inst, hookState: {} };
+    modelTo.notifyObserversOf('before delete', context, function(err) {
+      var index = embeddedList.indexOf(inst);
+      if (index > -1) embeddedList.splice(index, 1);
+      if (typeof cb === 'function') {
+        modelInstance.updateAttribute(propertyName,
+          embeddedList, function(err) {
+          if (err) return cb(err);
+          modelTo.notifyObserversOf('after delete', context, function(err) {
+            cb(err);
+            if (!err) modelTo.emit('deleted', inst.id, inst.toJSON());
+          });
+        });
+      } else {
+        modelTo.notifyObserversOf('after delete', context);
+      }
+    });
   } else if (typeof cb === 'function') {
     process.nextTick(cb); // not found
   }
@@ -2312,17 +2357,17 @@ EmbedsMany.prototype.create = function (targetModelData, cb) {
 
   var inst = this.callScopeMethod('build', targetModelData);
 
-  var updateEmbedded = function() {
+  var updateEmbedded = function(callback) {
     modelInstance.updateAttribute(propertyName,
       embeddedList, function(err, modelInst) {
-      cb(err, err ? null : inst);
+      callback(err, err ? null : inst);
     });
   };
 
   if (this.definition.options.persistent) {
     inst.save(function(err) { // will validate
       if (err) return cb(err, inst);
-      updateEmbedded();
+      updateEmbedded(cb);
     });
   } else {
     var err = inst.isValid() ? null : new ValidationError(inst);
@@ -2331,9 +2376,19 @@ EmbedsMany.prototype.create = function (targetModelData, cb) {
         cb(err);
       });
     } else {
-      updateEmbedded();
+      var context = { Model: modelTo, instance: inst, hookState: {} };
+      modelTo.notifyObserversOf('before save', context, function(err) {
+        if (err) return cb(err);
+        updateEmbedded(function(err, inst) {
+          if (err) return cb(err, null);
+          modelTo.notifyObserversOf('after save', context, function(err) {
+            cb(err, err ? null : inst);
+          });
+        });
+      });
     }
   }
+  
 };
 
 EmbedsMany.prototype.build = function(targetModelData) {

--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -1924,20 +1924,40 @@ EmbedsOne.prototype.update = function (targetModelData, cb) {
 
   var isInst = targetModelData instanceof ModelBaseClass;
   var data = isInst ? targetModelData.toObject() : targetModelData;
+  data = typeof data === 'object' ? data : {};
 
   var embeddedInstance = modelInstance[propertyName];
   if (embeddedInstance instanceof modelTo) {
-    embeddedInstance.setAttributes(data);
     if (typeof cb === 'function') {
-      var context = { Model: modelTo, instance: embeddedInstance, hookState: {} };
+      var hookState = {};
+      var context = {
+        Model: modelTo,
+        currentInstance: embeddedInstance,
+        data: data, 
+        hookState: hookState
+      };
       modelTo.notifyObserversOf('before save', context, function(err) {
         if (err) return cb(err);
+
+        embeddedInstance.setAttributes(data);
+
+        var err = embeddedInstance.isValid() ? null : new ValidationError(embeddedInstance);
+        if (err && typeof cb === 'function') {
+          return process.nextTick(function() {
+            cb(err, embeddedInstance);
+          });
+        }
+
         modelInstance.save(function(err, inst) {
+          if (err) return cb(err);
+          context = { Model: modelTo, instance: embeddedInstance, hookState: hookState };
           modelTo.notifyObserversOf('after save', context, function(err) {
             cb(err, inst ? inst[propertyName] : embeddedInstance);
           });
         });
       });
+    } else {
+      embeddedInstance.setAttributes(data);
     }
   } else if (!embeddedInstance && cb) {
     this.callScopeMethod('create', data, cb);
@@ -2249,15 +2269,20 @@ EmbedsMany.prototype.updateById = function (fkId, data, cb) {
   var embeddedList = this.embeddedList();
 
   var inst = this.findById(fkId);
+  var data = typeof data === 'object' ? data : {};
 
   if (inst instanceof modelTo) {
-    var context = { Model: modelTo, instance: inst, hookState: {} };
+    var hookState = {};
+    var context = {
+      Model: modelTo,
+      currentInstance: inst,
+      data: data, 
+      hookState: hookState
+    };
     modelTo.notifyObserversOf('before save', context, function(err) {
       if (err) return cb && cb(err);
 
-      if (typeof data === 'object') {
-          inst.setAttributes(data);
-      }
+      inst.setAttributes(data);
 
       var err = inst.isValid() ? null : new ValidationError(inst);
       if (err && typeof cb === 'function') {
@@ -2265,6 +2290,8 @@ EmbedsMany.prototype.updateById = function (fkId, data, cb) {
           cb(err, inst);
         });
       }
+
+      context = { Model: modelTo, instance: inst, hookState: hookState };
 
       if (typeof cb === 'function') {
         modelInstance.updateAttribute(propertyName,

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -2385,6 +2385,15 @@ describe('relations', function () {
         p.passportItem.destroy(function(err) {
           should.not.exist(err);
           should.equal(p.passport, null);
+          
+          var expected = [
+            'Passport: before delete',
+            'Person: before save',
+            'Person: after save',
+            'Passport: after delete'
+          ];
+          combinedHooks.should.eql(expected);
+          
           done();
         });
       });
@@ -2732,6 +2741,15 @@ describe('relations', function () {
         p.addressList.destroy(address1.id, function(err) {
           should.not.exist(err);
           p.addresses.should.have.length(1);
+          
+          var expected = [
+            'Address: before delete',
+            'Person: before save',
+            'Person: after save',
+            'Address: after delete'
+          ];
+          combinedHooks.should.eql(expected);
+          
           done();
         });
       });

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -2202,13 +2202,6 @@ describe('relations', function () {
     var hooks = [];
     var combinedHooks = [];
 
-    function observeHook(Model, type) {
-      Model.observe(type, function(ctx, next) {
-        combinedHooks.push(ctx.Model.modelName + ': ' + type);
-        next();
-      });
-    };
-
     before(function () {
       tmp = getTransientDataSource();
       db = getSchema();
@@ -2241,44 +2234,10 @@ describe('relations', function () {
       observeHook(Passport, 'before delete');
       observeHook(Passport, 'after delete');
 
-      Passport.observe('before save', function(ctx, next) {
-        var info = { hook: 'before save' };
-        if (ctx.currentInstance) {
-          info.currentInstance = ctx.currentInstance.toObject();
-        } else {
-          info.instance = ctx.instance.toObject();
-        }
-        if (ctx.data) info.data = ctx.data;
-        hooks.push(info);
-        next();
-      });
-
-      Passport.observe('after save', function(ctx, next) {
-        var info = {
-          hook: 'after save',
-          instance: ctx.instance.toObject()
-        };
-        hooks.push(info);
-        next();
-      });
-
-      Passport.observe('before delete', function(ctx, next) {
-        var info = {
-          hook: 'before delete',
-          instance: ctx.instance.toObject()
-        };
-        hooks.push(info);
-        next();
-      });
-
-      Passport.observe('after delete', function(ctx, next) {
-        var info = {
-          hook: 'after delete',
-          instance: ctx.instance.toObject()
-        };
-        hooks.push(info);
-        next();
-      });
+      observeEmbedded(Passport, 'before save');
+      observeEmbedded(Passport, 'after save');
+      observeEmbedded(Passport, 'before delete');
+      observeEmbedded(Passport, 'after delete');
 
       db.automigrate(done);
     });
@@ -2456,6 +2415,27 @@ describe('relations', function () {
       hooks.should.eql(expected);
     });
 
+    function observeHook(Model, type) {
+      Model.observe(type, function(ctx, next) {
+        combinedHooks.push(ctx.Model.modelName + ': ' + type);
+        next();
+      });
+    };
+
+    function observeEmbedded(Model, type) {
+      Model.observe(type, function(ctx, next) {
+        var info = { hook: type };
+        if (ctx.currentInstance) {
+          info.currentInstance = ctx.currentInstance.toObject();
+        } else if (ctx.instance) {
+          info.instance = ctx.instance.toObject();
+        }
+        if (ctx.data) info.data = ctx.data;
+        hooks.push(info);
+        next();
+      });
+    };
+
   });
 
   describe('embedsOne - persisted model', function () {
@@ -2540,13 +2520,6 @@ describe('relations', function () {
     var hooks = [];
     var combinedHooks = [];
 
-    function observeHook(Model, type) {
-      Model.observe(type, function(ctx, next) {
-        combinedHooks.push(ctx.Model.modelName + ': ' + type);
-        next();
-      });
-    };
-
     before(function (done) {
       tmp = getTransientDataSource({defaultIdType: Number});
       db = getSchema();
@@ -2576,44 +2549,10 @@ describe('relations', function () {
       observeHook(Address, 'before delete');
       observeHook(Address, 'after delete');
 
-      Address.observe('before save', function(ctx, next) {
-        var info = { hook: 'before save' };
-        if (ctx.currentInstance) {
-          info.currentInstance = ctx.currentInstance.toObject();
-        } else {
-          info.instance = ctx.instance.toObject();
-        }
-        if (ctx.data) info.data = ctx.data;
-        hooks.push(info);
-        next();
-      });
-
-      Address.observe('after save', function(ctx, next) {
-        var info = {
-          hook: 'after save',
-          instance: ctx.instance.toObject()
-        };
-        hooks.push(info);
-        next();
-      });
-
-      Address.observe('before delete', function(ctx, next) {
-        var info = {
-          hook: 'before delete',
-          instance: ctx.instance.toObject()
-        };
-        hooks.push(info);
-        next();
-      });
-
-      Address.observe('after delete', function(ctx, next) {
-        var info = {
-          hook: 'after delete',
-          instance: ctx.instance.toObject()
-        };
-        hooks.push(info);
-        next();
-      });
+      observeEmbedded(Address, 'before save');
+      observeEmbedded(Address, 'after save');
+      observeEmbedded(Address, 'before delete');
+      observeEmbedded(Address, 'after delete');
 
       db.automigrate(done);
     });
@@ -2835,6 +2774,27 @@ describe('relations', function () {
       ];
       hooks.should.eql(expected);
     });
+
+    function observeHook(Model, type) {
+      Model.observe(type, function(ctx, next) {
+        combinedHooks.push(ctx.Model.modelName + ': ' + type);
+        next();
+      });
+    };
+
+    function observeEmbedded(Model, type) {
+      Model.observe(type, function(ctx, next) {
+        var info = { hook: type };
+        if (ctx.currentInstance) {
+          info.currentInstance = ctx.currentInstance.toObject();
+        } else if (ctx.instance) {
+          info.instance = ctx.instance.toObject();
+        }
+        if (ctx.data) info.data = ctx.data;
+        hooks.push(info);
+        next();
+      });
+    };
 
   });
 


### PR DESCRIPTION
Fixes #497 by triggering `before/after save` and `before/after delete` hooks on the embedded model instance. Because such instances are usually transient, the expected hooks were not called.