### PR TITLE
Return true/false result for destroyById/prototype.destroy

### DIFF
--- a/lib/connectors/memory.js
+++ b/lib/connectors/memory.js
@@ -260,8 +260,9 @@ Memory.prototype.find = function find(model, id, callback) {
 };
 
 Memory.prototype.destroy = function destroy(model, id, callback) {
+  var exists = this.collection(model)[id];
   delete this.collection(model)[id];
-  this.saveToFile(null, callback);
+  this.saveToFile({ count: exists ? 1 : 0 }, callback);
 };
 
 Memory.prototype.fromDb = function (model, data) {

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1413,11 +1413,17 @@ DataAccessObject.removeById = DataAccessObject.destroyById = DataAccessObject.de
 
   var Model = this;
 
-  this.remove(byIdQuery(this, id).where, options, function(err) {
+  this.remove(byIdQuery(this, id).where, options, function(err, data) {
+    var deleted = data && data.count > 0;
     if ('function' === typeof cb) {
-      cb(err);
+      if (options.reportFailureAsError && !err && !deleted) {
+        err = new Error('No instance with id ' + id + ' found for ' + Model.modelName);
+        cb(err, false);
+      } else {
+        cb(err, deleted);
+      }
     }
-    if(!err) Model.emit('deleted', id);
+    if(!err && deleted) Model.emit('deleted', id);
   });
   return cb.promise;
 };
@@ -1760,8 +1766,13 @@ DataAccessObject.prototype.remove =
           // A hook modified the query, it is no longer
           // a simple 'delete model with the given id'.
           // We must switch to full query-based delete.
-          Model.deleteAll(where, { notify: false }, function(err) {
-            if (err) return cb(err);
+          Model.deleteAll(where, { notify: false }, function(err, data) {
+            if (err) return cb(err, false);
+            var deleted = data && data.count > 0;
+            if (options.reportFailureAsError && !deleted) {
+              err = new Error('No instance with id ' + id + ' found for ' + Model.modelName);
+              return cb(err, false);
+            }
             var context = {
               Model: Model,
               where: where,
@@ -1769,17 +1780,20 @@ DataAccessObject.prototype.remove =
               hookState: hookState
             };
             Model.notifyObserversOf('after delete', context, function(err) {
-              cb(err);
-              if (!err) Model.emit('deleted', id);
+              cb(err, deleted);
+              if (!err && !deleted) Model.emit('deleted', id);
             });
           });
           return;
         }
 
         inst.trigger('destroy', function (destroyed) {
-          inst._adapter().destroy(inst.constructor.modelName, id, function (err) {
-            if (err) {
-              return cb(err);
+          inst._adapter().destroy(inst.constructor.modelName, id, function (err, data) {
+            if (err) return cb(err, false);
+            var deleted = data && data.count > 0;
+            if (options.reportFailureAsError && !deleted) {
+              err = new Error('No instance with id ' + id + ' found for ' + Model.modelName);
+              return cb(err, false);
             }
 
             destroyed(function () {
@@ -1790,8 +1804,8 @@ DataAccessObject.prototype.remove =
                 hookState: hookState
               };
               Model.notifyObserversOf('after delete', context, function(err) {
-                cb(err);
-                if (!err) Model.emit('deleted', id);
+                cb(err, deleted);
+                if (!err && !deleted) Model.emit('deleted', id);
               });
             });
           });

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1416,14 +1416,15 @@ DataAccessObject.removeById = DataAccessObject.destroyById = DataAccessObject.de
   this.remove(byIdQuery(this, id).where, options, function(err, data) {
     var deleted = data && data.count > 0;
     if ('function' === typeof cb) {
-      if (options.reportFailureAsError && !err && !deleted) {
+      if (options.strict && !err && !deleted) {
         err = new Error('No instance with id ' + id + ' found for ' + Model.modelName);
         cb(err, false);
       } else {
         cb(err, deleted);
       }
     }
-    if(!err && deleted) Model.emit('deleted', id);
+    if (options.strict && !deleted) return;
+    if(!err) Model.emit('deleted', id);
   });
   return cb.promise;
 };
@@ -1769,7 +1770,7 @@ DataAccessObject.prototype.remove =
           Model.deleteAll(where, { notify: false }, function(err, data) {
             if (err) return cb(err, false);
             var deleted = data && data.count > 0;
-            if (options.reportFailureAsError && !deleted) {
+            if (options.strict && !deleted) {
               err = new Error('No instance with id ' + id + ' found for ' + Model.modelName);
               return cb(err, false);
             }
@@ -1781,7 +1782,7 @@ DataAccessObject.prototype.remove =
             };
             Model.notifyObserversOf('after delete', context, function(err) {
               cb(err, deleted);
-              if (!err && !deleted) Model.emit('deleted', id);
+              if (!err) Model.emit('deleted', id);
             });
           });
           return;
@@ -1791,7 +1792,7 @@ DataAccessObject.prototype.remove =
           inst._adapter().destroy(inst.constructor.modelName, id, function (err, data) {
             if (err) return cb(err, false);
             var deleted = data && data.count > 0;
-            if (options.reportFailureAsError && !deleted) {
+            if (options.strict && !deleted) {
               err = new Error('No instance with id ' + id + ' found for ' + Model.modelName);
               return cb(err, false);
             }
@@ -1805,7 +1806,7 @@ DataAccessObject.prototype.remove =
               };
               Model.notifyObserversOf('after delete', context, function(err) {
                 cb(err, deleted);
-                if (!err && !deleted) Model.emit('deleted', id);
+                if (!err) Model.emit('deleted', id);
               });
             });
           });

--- a/test/crud-with-options.test.js
+++ b/test/crud-with-options.test.js
@@ -354,9 +354,81 @@ describe('crud-with-options', function () {
   });
 
   describe('deleteById', function() {
-    it('should allow deleteById(id)', function () {
-      User.deleteById(1);
+
+    beforeEach(seed);
+
+    it('should allow deleteById(id) - success', function (done) {
+      User.findOne(function (e, u) {
+        User.deleteById(u.id, function(err, deleted) {
+          should.not.exist(err);
+          deleted.should.be.true;
+          done();
+        });
+      });
     });
+
+    it('should allow deleteById(id) - fail', function (done) {
+      User.deleteById(9999, function(err, deleted) {
+        should.not.exist(err);
+        deleted.should.be.false;
+        done();
+      });
+    });
+
+    it('should allow deleteById(id) - fail with error', function (done) {
+      User.deleteById(9999, { reportFailureAsError: true }, function(err, deleted) {
+        should.exist(err);
+        deleted.should.be.false;
+        err.message.should.equal('No instance with id 9999 found for User');
+        done();
+      });
+    });
+
+  });
+
+  describe('prototype.delete', function() {
+
+    beforeEach(seed);
+
+    it('should allow delete(id) - success', function (done) {
+      User.findOne(function (e, u) {
+        u.delete(function(err, deleted) {
+          should.not.exist(err);
+          deleted.should.be.true;
+          done();
+        });
+      });
+    });
+
+    it('should allow delete(id) - fail', function (done) {
+      User.findOne(function (e, u) {
+        u.delete(function(err, deleted) {
+          should.not.exist(err);
+          deleted.should.be.true;
+          u.delete(function(err, deleted) {
+            should.not.exist(err);
+            deleted.should.be.false;
+            done();
+          });
+        });
+      });
+    });
+
+    it('should allow delete(id) - fail with error', function (done) {
+      User.findOne(function (e, u) {
+        u.delete(function(err, deleted) {
+          should.not.exist(err);
+          deleted.should.be.true;
+          u.delete({ reportFailureAsError: true }, function(err, deleted) {
+            should.exist(err);
+            deleted.should.be.false;
+            err.message.should.equal('No instance with id ' + u.id + ' found for User');
+            done();
+          });
+        });
+      });
+    });
+
   });
 
   describe('updateAll ', function () {

--- a/test/crud-with-options.test.js
+++ b/test/crud-with-options.test.js
@@ -376,7 +376,7 @@ describe('crud-with-options', function () {
     });
 
     it('should allow deleteById(id) - fail with error', function (done) {
-      User.deleteById(9999, { reportFailureAsError: true }, function(err, deleted) {
+      User.deleteById(9999, { strict: true }, function(err, deleted) {
         should.exist(err);
         deleted.should.be.false;
         err.message.should.equal('No instance with id 9999 found for User');
@@ -419,7 +419,7 @@ describe('crud-with-options', function () {
         u.delete(function(err, deleted) {
           should.not.exist(err);
           deleted.should.be.true;
-          u.delete({ reportFailureAsError: true }, function(err, deleted) {
+          u.delete({ strict: true }, function(err, deleted) {
             should.exist(err);
             deleted.should.be.false;
             err.message.should.equal('No instance with id ' + u.id + ' found for User');


### PR DESCRIPTION
See also: #321 - note that the memory connector has been fixed to have `destroy` also return `{ count: 1 }` feedback - this should also be done with the other connectors.

/cc @raymondfeng @bajtos @superkhau 