### PR TITLE
Enable more CRUD remoting methods for embedsOne

### DIFF
--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -1816,11 +1816,25 @@ RelationDefinition.embedsOne = function (modelFrom, modelTo, params) {
   // FIXME: [rfeng] Wrap the property into a function for remoting
   // so that it can be accessed as /api/<model>/<id>/<embedsOneRelationName>
   // For example, /api/orders/1/customer
-  var fn = function() {
+  modelFrom.prototype['__get__' + relationName] = function() {
     var f = this[relationName];
     f.apply(this, arguments);
   };
-  modelFrom.prototype['__get__' + relationName] = fn;
+
+  modelFrom.prototype['__create__' + relationName] = function() {
+    var f = this[relationName].create;
+    f.apply(this, arguments);
+  };
+
+  modelFrom.prototype['__update__' + relationName] = function() {
+    var f = this[relationName].update;
+    f.apply(this, arguments);
+  };
+
+  modelFrom.prototype['__destroy__' + relationName] = function() {
+    var f = this[relationName].destroy;
+    f.apply(this, arguments);
+  };
 
   return definition;
 };


### PR DESCRIPTION
Aparently only `__get__` was supported, while Loopback's `hasOneRemoting` already supported the other standard CRUD methods, leading to an exception in remoting's `SharedMethod.invoke` call.

There's a PR over at `loopback` with additional integration tests covering these methods.