### PR TITLE
Fix regression in DAO.prototype.save

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1587,7 +1587,7 @@ DataAccessObject.prototype.save = function (options, cb) {
       inst.trigger('save', function (saveDone) {
         inst.trigger('update', function (updateDone) {
           data = removeUndefined(data);
-          inst._adapter().save(modelName, inst.constructor._forDB(data), function (err, data, result) {
+          inst._adapter().save(modelName, inst.constructor._forDB(data), function (err, unusedData, result) {
             if (err) {
               return cb(err, inst);
             }

--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -617,7 +617,7 @@ describe('manipulation', function () {
 
     it('should allow save() of the created instance', function(done) {
       Person.updateOrCreate(
-        { id: 'new-id', name: 'a-name' },
+        { id: 999 /* a new id */, name: 'a-name' },
         function(err, inst) {
           if (err) return done(err);
           inst.save(done);

--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -769,9 +769,9 @@ describe('manipulation', function () {
     });
 
     it('should only delete instances that satisfy the where condition', function (done) {
-      Person.deleteAll({name: 'John'}, function (err, data) {
+      Person.deleteAll({name: 'John'}, function (err, result) {
         if (err) return done(err);
-        data.count.should.equal(1);
+        result.should.have.property('count', 1);
         Person.find({where: {name: 'John'}}, function (err, data) {
           if (err) return done(err);
           data.should.have.length(0);
@@ -785,9 +785,9 @@ describe('manipulation', function () {
     });
 
     it('should report zero deleted instances', function (done) {
-      Person.deleteAll({name: 'does-not-match'}, function (err, data) {
+      Person.deleteAll({name: 'does-not-match'}, function (err, result) {
         if (err) return done(err);
-        data.count.should.equal(0);
+        result.should.have.property('count', 0);
         Person.count(function(err, count) {
           if (err) return done(err);
           count.should.equal(2);
@@ -797,9 +797,9 @@ describe('manipulation', function () {
     });
 
     it('should delete all instances when "where" is not provided', function(done) {
-      Person.deleteAll(function (err, data) {
+      Person.deleteAll(function (err, result) {
         if (err) return done(err);
-        data.count.should.equal(2);
+        result.should.have.property('count', 2);
         Person.count(function(err, count) {
           if (err) return done(err);
           count.should.equal(0);
@@ -1039,7 +1039,7 @@ describe('manipulation', function () {
       Person.update({name: 'Harry Hoe'}, {name: 'Marta Moe'}, function(err,
           results) {
         should.not.exist(err);
-        results.count.should.equal(0);
+        results.should.have.property('count', 0);
         Person.find({where: {name: 'Harry Hoe'}}, function(err, people) {
           should.not.exist(err);
           people.should.be.empty;
@@ -1053,7 +1053,7 @@ describe('manipulation', function () {
       Person.update({name: 'Brett Boe'}, {name: 'Harry Hoe'}, function(err,
           results) {
         should.not.exist(err);
-        results.count.should.equal(1);
+        results.should.have.property('count', 1);
         Person.find({where: {age: 19}}, function(err, people) {
           should.not.exist(err);
           people.should.have.length(1);
@@ -1067,7 +1067,7 @@ describe('manipulation', function () {
         function(done) {
       Person.update({name: 'Harry Hoe'}, function(err, results) {
         should.not.exist(err);
-        results.count.should.equal(5);
+        results.should.have.property('count', 5);
         Person.find({where: {name: 'Brett Boe'}}, function(err, people) {
           should.not.exist(err);
           people.should.be.empty;
@@ -1085,7 +1085,7 @@ describe('manipulation', function () {
       Person.update({name: 'Brett Boe'}, {name: undefined, gender: 'male'},
           function(err, results) {
         should.not.exist(err);
-        results.count.should.equal(1);
+        results.should.have.property('count', 1)
         Person.find({where: {name: 'Brett Boe'}}, function(err, people) {
           should.not.exist(err);
           people.should.have.length(1);

--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -340,6 +340,7 @@ describe('manipulation', function () {
         p.name = 'Hans';
         p.save(function (err) {
           should.not.exist(err);
+          p.name.should.equal('Hans');
           Person.findOne(function (err, p) {
             should.not.exist(err);
             p.name.should.equal('Hans');


### PR DESCRIPTION
ffcaa4e added a "data" argument to the callback function, which shadowed the original data with the data returned by a connector. Not all connectors are returning a data object though, in which casethe model instance ("this" object) is updated with wrong values.

This patch fixes the problem by renaming the second callback argument to "unusedData".

While I was working on this fix, I also improved the error messages reported by recently added unit-tests and replaced 

    foo.count.should.equal(X)
    Uncaught TypeError: Cannot read property 'should' of undefined

with more friendly

    foo.should.have.property('count', X)`
    Uncaught AssertionError: expected 0 to have property count

I am landing this without waiting for review to fix broken master ASAP. I'll address any comments in a follow-up pull request.

@fabien @raymondfeng @superkhau

Close #523