### PR TITLE
Ensure boolean value for isNewInstance

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -417,7 +417,7 @@ DataAccessObject.updateOrCreate = DataAccessObject.upsert = function upsert(data
             var context = {
               Model: Model,
               instance: obj,
-              isNewInstance: result ? result.isNewInstance : undefined,
+              isNewInstance: !!(result && result.isNewInstance),
               hookState: hookState
             };
             Model.notifyObserversOf('after save', context, function(err) {
@@ -1595,7 +1595,7 @@ DataAccessObject.prototype.save = function (options, cb) {
             var context = {
               Model: Model,
               instance: inst,
-              isNewInstance: result && result.isNewInstance,
+              isNewInstance: !!(result && result.isNewInstance),
               hookState: hookState
             };
             Model.notifyObserversOf('after save', context, function(err) {


### PR DESCRIPTION
The tests are testing for true/false, not truthy/falsy, so the value
should be coerced to match.

@bajtos I found this while tinkering with strongloop/loopback-connector-mongodb#116