### PR TITLE
Return info in the third arg for update and delete

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1375,16 +1375,16 @@ DataAccessObject.remove = DataAccessObject.deleteAll = DataAccessObject.destroyA
 
     }
 
-    function done(err, data) {
+    function done(err, data, info) {
       if (err) return cb(err);
 
       if (options.notify === false) {
-        return cb(err, data);
+        return cb(err, data, info);
       }
 
       var context = { Model: Model, where: where, hookState: hookState };
       Model.notifyObserversOf('after delete', context, function(err) {
-        cb(err, data);
+        cb(err, data, info);
         if (!err)
           Model.emit('deletedAll', whereIsEmpty(where) ? undefined : where);
       });
@@ -1710,13 +1710,13 @@ DataAccessObject.updateAll = function (where, data, options, cb) {
     }
 
     var connector = Model.getDataSource().connector;
-    connector.update(Model.modelName, where, data, function(err, count) {
-      if (err) return cb (err);
+    connector.update(Model.modelName, where, data, function(err, count, info) {
+      if (err) return cb(err);
       var context = {
         Model: Model, where: where, data: data, hookState: hookState
       };
       Model.notifyObserversOf('after save', context, function(err, ctx) {
-          return cb(err, count);
+          return cb(err, count, info);
         });
     });
   }

--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -777,7 +777,7 @@ describe('manipulation', function () {
 
       it('should only delete instances that satisfy the where condition',
           function(done) {
-        Person.deleteAll({name: 'John'}, function(err, info) {
+        Person.deleteAll({name: 'John'}, function(err, data, info) {
           if (err) return done(err);
           info.count.should.equal(1);
           Person.find({where: {name: 'John'}}, function(err, data) {
@@ -794,7 +794,7 @@ describe('manipulation', function () {
 
       it('should report zero deleted instances when no matches are found',
           function(done) {
-        Person.deleteAll({name: 'does-not-match'}, function(err, info) {
+        Person.deleteAll({name: 'does-not-match'}, function(err, data, info) {
           if (err) return done(err);
           info.count.should.equal(0);
           Person.count(function(err, count) {
@@ -807,7 +807,7 @@ describe('manipulation', function () {
 
       it('should delete all instances when the where condition is not provided',
           function(done) {
-        Person.deleteAll(function (err, info) {
+        Person.deleteAll(function (err, data, info) {
           if (err) return done(err);
           info.count.should.equal(2);
           Person.count(function(err, count) {
@@ -1049,9 +1049,8 @@ describe('manipulation', function () {
       it('should not update instances that do not satisfy the where condition',
           function(done) {
         Person.update({name: 'Harry Hoe'}, {name: 'Marta Moe'}, function(err,
-            info) {
+            data, info) {
           if (err) return done(err);
-          should.not.exist(err);
           info.count.should.equal(0);
           Person.find({where: {name: 'Harry Hoe'}}, function(err, people) {
             if (err) return done(err);
@@ -1064,7 +1063,7 @@ describe('manipulation', function () {
       it('should update instances that satisfy the where condition',
           function(done) {
         Person.update({name: 'Brett Boe'}, {name: 'Harry Hoe'}, function(err,
-            info) {
+            data, info) {
           if (err) return done(err);
           info.count.should.equal(1);
           Person.find({where: {age: 19}}, function(err, people) {
@@ -1078,7 +1077,7 @@ describe('manipulation', function () {
 
       it('should update all instances when the where condition is not provided',
           function(done) {
-        Person.update({name: 'Harry Hoe'}, function(err, info) {
+        Person.update({name: 'Harry Hoe'}, function(err, data, info) {
           if (err) return done(err);
           info.count.should.equal(5);
           Person.find({where: {name: 'Brett Boe'}}, function(err, people) {
@@ -1096,7 +1095,7 @@ describe('manipulation', function () {
       it('should ignore where conditions with undefined values',
           function(done) {
         Person.update({name: 'Brett Boe'}, {name: undefined, gender: 'male'},
-            function(err, info) {
+            function(err, data, info) {
           if (err) return done(err);
           info.count.should.equal(1);
           Person.find({where: {name: 'Brett Boe'}}, function(err, people) {


### PR DESCRIPTION
This change is required to make the API consistent across all connectors. Since
the postgres connector already uses the second arg for `data.rows`, we use the
third arg in all connectors to return metadata.

Connect to strongloop/loopback-connector-mysql#90