### PR TITLE
Remove all usages of lodash

### DIFF
--- a/lib/jutil.js
+++ b/lib/jutil.js
@@ -1,5 +1,5 @@
 var util = require('util');
-var _ = require('lodash');
+
 /**
  *
  * @param newClass
@@ -77,7 +77,7 @@ function mixInto(sourceScope, targetScope, options) {
     var shouldOverride = options.override || !targetPropertyExists || isDelegate;
 
     if (propertyName == '_mixins') {
-      targetScope._mixins = _.union(targetScope._mixins, sourceScope._mixins);
+      mergeMixins(sourceScope._mixins, targetScope._mixins);
       return;
     }
 
@@ -85,4 +85,13 @@ function mixInto(sourceScope, targetScope, options) {
       Object.defineProperty(targetScope, propertyName, sourceProperty);
     }
   });
+}
+
+function mergeMixins(source, target) {
+  // hand-written equivalent of lodash.union()
+  for (var ix in source) {
+    var mx = source[ix];
+    if (target.indexOf(mx) === -1)
+      target.push(mx);
+  }
 }

--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -6,7 +6,6 @@ var util = require('util');
 var async = require('async');
 var utils = require('./utils');
 var i8n = require('inflection');
-var _ = require('lodash');
 var defineScope = require('./scope.js').defineScope;
 var mergeQuery = utils.mergeQuery;
 var ModelBaseClass = require('./model.js');
@@ -493,11 +492,16 @@ util.inherits(ReferencesMany, Relation);
  * @returns {Array} The array of matching relation objects
  */
 function findBelongsTo(modelFrom, modelTo, keyTo) {
-  return _.pluck(_.filter(modelFrom.relations, function (rel) {
-    return (rel.type === RelationTypes.belongsTo &&
-            rel.modelTo === modelTo &&
-            (keyTo === undefined || rel.keyTo === keyTo));
-  }), 'keyFrom');
+  return Object.keys(modelFrom.relations)
+    .map(function(k) { return modelFrom.relations[k]; })
+    .filter(function(rel) {
+      return (rel.type === RelationTypes.belongsTo &&
+              rel.modelTo === modelTo &&
+              (keyTo === undefined || rel.keyTo === keyTo));
+    })
+    .map(function(rel) {
+      return rel.keyFrom;
+    });
 }
 
 /*!

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "debug": "^2.1.1",
     "depd": "^1.0.0",
     "inflection": "^1.6.0",
-    "lodash": "~3.0.1",
     "loopback-connector": "1.x",
     "node-uuid": "^1.4.2",
     "qs": "^2.3.3",


### PR DESCRIPTION
This commit is dropping lodash in favour of a hand-written implementation based on ES5 Array methods. As a result, the size of the (unminified) loopback browser bundle is decreased by approx 360KB (20%).

See https://github.com/strongloop/loopback/issues/989

/to @raymondfeng @fabien @ritch please review