### PR TITLE
Code cleanup in updateAll/deleteAll

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1302,7 +1302,7 @@ DataAccessObject.findOne = function findOne(query, options, cb) {
  *
  * @param {Object} [where] Optional object that defines the criteria.  This is a "where" object. Do NOT pass a filter object.
  * @param {Object) [options] Options
- * @param {Function} [cb] Callback called with (err)
+ * @param {Function} [cb] Callback called with (err, info)
  */
 DataAccessObject.remove = DataAccessObject.deleteAll = DataAccessObject.destroyAll = function destroyAll(where, options, cb) {
   var connectionPromise = stillConnecting(this.getDataSource(), this, arguments);
@@ -1375,16 +1375,16 @@ DataAccessObject.remove = DataAccessObject.deleteAll = DataAccessObject.destroyA
 
     }
 
-    function done(err, data) {
+    function done(err, info) {
       if (err) return cb(err);
 
       if (options.notify === false) {
-        return cb(err, data);
+        return cb(err, info);
       }
 
       var context = { Model: Model, where: where, hookState: hookState };
       Model.notifyObserversOf('after delete', context, function(err) {
-        cb(err, data);
+        cb(err, info);
         if (!err)
           Model.emit('deletedAll', whereIsEmpty(where) ? undefined : where);
       });
@@ -1631,7 +1631,7 @@ DataAccessObject.prototype.save = function (options, cb) {
  * @param {Object} [where] Search conditions (optional)
  * @param {Object} data Changes to be made
  * @param {Object} [options] Options for update
- * @param {Function} cb Callback, called with (err, count)
+ * @param {Function} cb Callback, called with (err, info)
  */
 DataAccessObject.update =
 DataAccessObject.updateAll = function (where, data, options, cb) {
@@ -1710,13 +1710,13 @@ DataAccessObject.updateAll = function (where, data, options, cb) {
     }
 
     var connector = Model.getDataSource().connector;
-    connector.update(Model.modelName, where, data, function(err, count) {
+    connector.update(Model.modelName, where, data, function(err, info) {
       if (err) return cb (err);
       var context = {
         Model: Model, where: where, data: data, hookState: hookState
       };
       Model.notifyObserversOf('after save', context, function(err, ctx) {
-          return cb(err, count);
+          return cb(err, info);
         });
     });
   }


### PR DESCRIPTION
Rename the second callback argument to `info` to make its purpose more
clear. Fix jsdoc comments, note that these comments are NOT shown
on http://apidocs.strongloop.com/.

Connect to #1167.

/to @raymondfeng please review
/cc @superkhau 