### PR TITLE
Add model setting "persistUndefinedAsNull"

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1878,7 +1878,7 @@ DataAccessObject.prototype.setAttributes = function setAttributes(data) {
 };
 
 DataAccessObject.prototype.unsetAttribute = function unsetAttribute(name, nullify) {
-  if (nullify) {
+  if (nullify || this.constructor.definition.settings.persistUndefinedAsNull) {
     this[name] = this.__data[name] = null;
   } else {
     delete this[name];

--- a/lib/model-builder.js
+++ b/lib/model-builder.js
@@ -429,6 +429,12 @@ ModelBuilder.prototype.define = function defineClass(className, properties, sett
         } else if (typeof DataType === 'string') {
           DataType = modelBuilder.resolveType(DataType);
         }
+
+        var persistUndefinedAsNull = ModelClass.definition.settings.persistUndefinedAsNull;
+        if (value === undefined && persistUndefinedAsNull) {
+          value = null;
+        }
+
         if (ModelClass.setter[propertyName]) {
           ModelClass.setter[propertyName].call(this, value); // Try setter first
         } else {

--- a/lib/model.js
+++ b/lib/model.js
@@ -77,6 +77,8 @@ ModelBaseClass.prototype._initProperties = function (data, options) {
     strict = ctor.definition.settings.strict;
   }
 
+  var persistUndefinedAsNull = ctor.definition.settings.persistUndefinedAsNull;
+
   if (ctor.hideInternalProperties) {
     // Object.defineProperty() is expensive. We only try to make the internal
     // properties hidden (non-enumerable) if the model class has the
@@ -151,6 +153,11 @@ ModelBaseClass.prototype._initProperties = function (data, options) {
     if (typeof propVal === 'function') {
       continue;
     }
+
+    if (propVal === undefined && persistUndefinedAsNull) {
+      propVal = null;
+    }
+
     if (properties[p]) {
       // Managed property
       if (applySetters || properties[p].id) {
@@ -257,6 +264,10 @@ ModelBaseClass.prototype._initProperties = function (data, options) {
         self.__data[p] = propVal;
     }
 
+    if (propVal === undefined && persistUndefinedAsNull) {
+      self.__data[p] = propVal = null;
+    }
+
     // Handle complex types (JSON/Object)
     if (!BASE_TYPES[type.name]) {
 
@@ -345,6 +356,7 @@ ModelBaseClass.prototype.toObject = function (onlySchema, removeHidden, removePr
 
   var strict = this.__strict;
   var schemaLess = (strict === false) || !onlySchema;
+  var persistUndefinedAsNull = Model.definition.settings.persistUndefinedAsNull;
 
   var props = Model.definition.properties;
   var keys = Object.keys(props);
@@ -373,6 +385,9 @@ ModelBaseClass.prototype.toObject = function (onlySchema, removeHidden, removePr
       if (val !== undefined && val !== null && val.toObject) {
         data[propertyName] = val.toObject(!schemaLess, removeHidden, true);
       } else {
+        if (val === undefined && persistUndefinedAsNull) {
+          val = null;
+        }
         data[propertyName] = val;
       }
     }
@@ -398,8 +413,11 @@ ModelBaseClass.prototype.toObject = function (onlySchema, removeHidden, removePr
       if (removeProtected && Model.isProtectedProperty(propertyName)) {
         continue;
       }
+      if (data[propertyName] !== undefined) {
+        continue;
+      }
       val = self[propertyName];
-      if (val !== undefined && data[propertyName] === undefined) {
+      if (val !== undefined) {
         if (typeof val === 'function') {
           continue;
         }
@@ -408,6 +426,8 @@ ModelBaseClass.prototype.toObject = function (onlySchema, removeHidden, removePr
         } else {
           data[propertyName] = val;
         }
+      } else if (persistUndefinedAsNull) {
+        data[propertyName] = null;
       }
     }
     // Now continue to check __data
@@ -434,6 +454,8 @@ ModelBaseClass.prototype.toObject = function (onlySchema, removeHidden, removePr
 
         if (val !== undefined && val !== null && val.toObject) {
           data[propertyName] = val.toObject(!schemaLess, removeHidden, true);
+        } else if (val === undefined && persistUndefinedAsNull) {
+          data[propertyName] = null;
         } else {
           data[propertyName] = val;
         }


### PR DESCRIPTION
When the setting "persistUndefinedAsNull" is true, the model will use `null` instead of `undefined` in all property values:

 - Known optional model properties are set to `null` when no value  was provided.

 - When setting model properties, `undefined` is always converted  to `null`. This applies to both known (model-defined) properties  and additional (custom, dynamic) properties.

 - The instance method `toObject()` converts `undefined` to `null` too. Because `toJSON()` calls `toObject()` under the hood, the change applies to `toJSON()` too.

Connect to strongloop/loopback#1215.

Once landed, the recommended model configuration will become

```json
{
  "base": "PersistedModel",
  "strict": true,
  "persistUndefinedAsNull": true,
  "trackChanges": true
}
```

/to @ritch @raymondfeng please review
/cc @fabien @BerkeleyTrue 