### PR TITLE
Fix the test cases so that they be run with the mssql connector

### DIFF
--- a/test/basic-querying.test.js
+++ b/test/basic-querying.test.js
@@ -63,12 +63,12 @@ describe('basic-querying', function () {
     var createdUsers;
     before(function(done) {
       var people = [
-        { id: 1, name: 'a', vip: true },
-        { id: 2, name: 'b' },
-        { id: 3, name: 'c' },
-        { id: 4, name: 'd', vip: true },
-        { id: 5, name: 'e' },
-        { id: 6, name: 'f' }
+        { name: 'a', vip: true },
+        { name: 'b' },
+        { name: 'c' },
+        { name: 'd', vip: true },
+        { name: 'e' },
+        { name: 'f' }
       ];
       db.automigrate(['User'], function(err) {
         User.create(people, function(err, users) {

--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -295,7 +295,7 @@ describe('manipulation', function () {
     it('should refuse to create object with duplicate id', function(done) {
       // NOTE(bajtos) We cannot reuse Person model here,
       // `settings.forceId` aborts the CREATE request at the validation step.
-      var Product = db.define('Product', { name: String });
+      var Product = db.define('ProductTest', { name: String });
       db.automigrate(function(err) {
         if (err) return done(err);
 


### PR DESCRIPTION
/to @bajtos 

For SQL server, if the PK is an identity, the id cannot be set for insert.

We also need to fix https://github.com/strongloop/loopback-datasource-juggler/blob/feature/fix-test-case/test/manipulation.test.js#L308 because not all connectors produce a message that contains `duplicate`.