### PR TITLE
Implement before/after validation hook

### DIFF
--- a/lib/validations.js
+++ b/lib/validations.js
@@ -410,16 +410,33 @@ function getConfigurator(name, opts) {
 Validatable.prototype.isValid = function (callback, data) {
   var valid = true, inst = this, wait = 0, async = false;
   var validations = this.constructor.validations;
+  var ctor = this.constructor;
+  var inst = this;
+
+  var context = {
+    Model: ctor,
+    instance: this,
+    hookState: {}
+  };
+
+  if (data) context.data = data;
 
   // exit with success when no errors
   if (typeof validations !== 'object') {
     cleanErrors(this);
     if (callback) {
-      this.trigger('validate', function (validationsDone) {
-        validationsDone.call(inst, function () {
-          callback(valid);
-        });
-      }, data, callback);
+      ctor.notifyObserversOf('before validate', context, function(err) {
+        if (err) return callback(false);
+        inst.trigger('validate', function (validationsDone) {
+          validationsDone.call(inst, function () {
+            context.isValid = valid;
+            ctor.notifyObserversOf('after validate', context, function(err) {
+              if (err) return callback(false);
+              callback(context.isValid);
+            });
+          });
+        }, data, callback);
+      });
     }
     return valid;
   }
@@ -430,51 +447,68 @@ Validatable.prototype.isValid = function (callback, data) {
     value: new Errors
   });
 
-  this.trigger('validate', function (validationsDone) {
-    var inst = this,
-      asyncFail = false;
+  function performValidation() {
+    inst.trigger('validate', function (validationsDone) {
+      var asyncFail = false;
 
-    var attrs = Object.keys(validations || {});
+      var attrs = Object.keys(validations || {});
 
-    attrs.forEach(function(attr) {
-      var attrValidations = validations[attr] || [];
-      attrValidations.forEach(function(v) {
-        if (v.options && v.options.async) {
-          async = true;
-          wait += 1;
-          process.nextTick(function () {
-            validationFailed(inst, attr, v, done);
-          });
-        } else {
-          if (validationFailed(inst, attr, v)) {
-            valid = false;
+      attrs.forEach(function(attr) {
+        var attrValidations = validations[attr] || [];
+        attrValidations.forEach(function(v) {
+          if (v.options && v.options.async) {
+            async = true;
+            wait += 1;
+            process.nextTick(function () {
+              validationFailed(inst, attr, v, done);
+            });
+          } else {
+            if (validationFailed(inst, attr, v)) {
+              valid = false;
+            }
           }
-        }
+        });
       });
-    });
 
-    if (!async) {
-      validationsDone.call(inst, function () {
-        if (valid) cleanErrors(inst);
-        if (callback) {
-          callback(valid);
-        }
-      });
-    }
-
-    function done(fail) {
-      asyncFail = asyncFail || fail;
-      if (--wait === 0) {
+      if (!async) {
         validationsDone.call(inst, function () {
-          if (valid && !asyncFail) cleanErrors(inst);
+          if (valid) cleanErrors(inst);
           if (callback) {
-            callback(valid && !asyncFail);
+            notifyDone(valid);
           }
         });
       }
-    }
 
-  }, data, callback);
+      function done(fail) {
+        asyncFail = asyncFail || fail;
+        if (--wait === 0) {
+          validationsDone.call(inst, function () {
+            if (valid && !asyncFail) cleanErrors(inst);
+            if (callback) {
+              notifyDone(valid && !asyncFail);
+            }
+          });
+        }
+      }
+
+      function notifyDone(isValid) {
+        context.isValid = isValid;
+        ctor.notifyObserversOf('after validate', context, function(err) {
+          if (err) return callback(false);
+          callback(context.isValid);
+        });
+      }
+    }, data, callback);
+  };
+
+  if (callback) {
+    ctor.notifyObserversOf('before validate', context, function(err) {
+      if (err) return callback(false);
+      performValidation();
+    });
+  } else {
+    performValidation();
+  }
 
   if (async) {
     // in case of async validation we should return undefined here,


### PR DESCRIPTION
Consider the following scenario (which is somewhat similar to what @clarkorz describes here #433):

1. in `beforeRemote('create', ...)` uploaded files (multipart/form-data) are handled
2. this adds the stored filename/path to `ctx.args.data` so the model will save this
3. however, the model appears to be invalid for some reason (unrelated to the uploaded file)
4. now, validation fails and there's no way to purge the now orphaned uploaded file from storage/disk

Or more elaborately:

1. in `beforeRemote('create', ...)` uploaded files (multipart/form-data) are handled
2. this adds the stored **temporary** filename/path to `ctx.args.data` so the model **can use** this later
3. however, the model appears to be invalid for some reason (unrelated to the uploaded file)
4. now, validation fails and there's no way to purge the uploaded file from storage/disk
5. if the model would have been valid, an `after validate` hook handler would have moved the file to its permanent destination and update the instance's `filepath` attribute.
6. the model would be saved as expected

At point `4` there should be a way to cleanup any intermediate (but now invalidated/orphaned) data. In this example scenario there's no way to handle everything in the 'safe' `after save` handler, because the form-data needs to be parsed first, so there will always be artifacts already created; it cannot be done side-effect-free. 

This PR introduces such an `after validate` hook, and pairs it with the expected `before validate` hook, which is executed *after* the data has been set - but *before* the model is actually validated. Just like the now deprecated hook event 'validate'.

Ref: #433 (the proposed solution proved unsatisfactory) and pending #262

/cc @raymondfeng @bajtos 