### PR TITLE
Save parent model of embedded relations

### DIFF
--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -1900,10 +1900,17 @@ EmbedsOne.prototype.create = function (targetModelData, cb) {
   var inst = this.callScopeMethod('build', targetModelData);
 
   var updateEmbedded = function() {
-    modelInstance.updateAttribute(propertyName,
-      inst, function(err) {
-      cb(err, err ? null : inst);
-    });
+    if (modelInstance.isNewRecord()) {
+      modelInstance.setAttribute(propertyName, inst);
+      modelInstance.save(function(err) {
+          cb(err, err ? null : inst);
+      });
+    } else {
+      modelInstance.updateAttribute(propertyName,
+        inst, function(err) {
+        cb(err, err ? null : inst);
+      });
+    }
   };
 
   if (this.definition.options.persistent) {
@@ -2385,10 +2392,17 @@ EmbedsMany.prototype.create = function (targetModelData, cb) {
   var inst = this.callScopeMethod('build', targetModelData);
 
   var updateEmbedded = function() {
-    modelInstance.updateAttribute(propertyName,
-      embeddedList, function(err, modelInst) {
-      cb(err, err ? null : inst);
-    });
+    if (modelInstance.isNewRecord()) {
+      modelInstance.setAttribute(propertyName, embeddedList);
+      modelInstance.save(function(err) {
+          cb(err, err ? null : inst);
+      });
+    } else {
+      modelInstance.updateAttribute(propertyName,
+        embeddedList, function(err) {
+        cb(err, err ? null : inst);
+      });
+    }
   };
 
   if (this.definition.options.persistent) {

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -2407,6 +2407,17 @@ describe('relations', function () {
       });
     });
 
+    it('should save an unsaved model', function(done) {
+      var p = new Person({name: 'Fred'});
+      p.isNewRecord().should.be.true;
+      p.passportItem.create({name: 'Fredric'}, function(err, passport) {
+        should.not.exist(err);
+        p.passport.should.equal(passport);
+        p.isNewRecord().should.be.false;
+        done();
+      });
+    });
+
   });
 
   describe('embedsOne - persisted model', function () {
@@ -2707,6 +2718,17 @@ describe('relations', function () {
     it('should have removed all embedded items - verify', function(done) {
       Person.findOne(function(err, p) {
         p.addresses.should.have.length(0);
+        done();
+      });
+    });
+    
+    it('should save an unsaved model', function(done) {
+      var p = new Person({name: 'Fred'});
+      p.isNewRecord().should.be.true;
+      p.addressList.create({ street: 'Street 4' }, function(err, address) {
+        should.not.exist(err);
+        address.street.should.equal('Street 4');
+        p.isNewRecord().should.be.false;
         done();
       });
     });


### PR DESCRIPTION
This fixes the situation where you may only have built an instance, and you're trying to persist an embedded model on it. Before, only `updateAttributes` would be performed, which then complained about a not existing model. 

(more specifically, in my case I would validate the existence of an embedsOne item, which would create a catch-22 type situation, when trying to save the parent model first).