### PR TITLE
Fix isNewInstance tests + code cleanup

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -370,7 +370,7 @@ DataAccessObject.updateOrCreate = DataAccessObject.upsert = function upsert(data
   }
 
   var context = {
-    Model: Model, 
+    Model: Model,
     query: byIdQuery(Model, id),
     hookState: hookState,
     options: options
@@ -410,7 +410,7 @@ DataAccessObject.updateOrCreate = DataAccessObject.upsert = function upsert(data
         self.getDataSource().connector
           .updateOrCreate(Model.modelName, update, done);
 
-        function done(err, data, result) {
+        function done(err, data, info) {
           var obj;
           if (data && !(data instanceof Model)) {
             inst._initProperties(data, { persisted: true });
@@ -427,7 +427,7 @@ DataAccessObject.updateOrCreate = DataAccessObject.upsert = function upsert(data
             var context = {
               Model: Model,
               instance: obj,
-              isNewInstance: result ? result.isNewInstance : undefined,
+              isNewInstance: info ? info.isNewInstance : undefined,
               hookState: hookState,
               options: options
             };
@@ -1356,11 +1356,11 @@ DataAccessObject.remove = DataAccessObject.deleteAll = DataAccessObject.destroyA
   cb = cb || utils.createPromiseCallback();
   where = where || {};
   options = options || {};
-  
+
   assert(typeof where === 'object', 'The where argument must be an object');
   assert(typeof options === 'object', 'The options argument must be an object');
   assert(typeof cb === 'function', 'The cb argument must be a function');
-  
+
   var hookState = {};
 
   var query = { where: where };
@@ -1593,7 +1593,7 @@ DataAccessObject.prototype.save = function (options, cb) {
 
   assert(typeof options === 'object', 'The options argument should be an object');
   assert(typeof cb === 'function', 'The cb argument should be a function');
-  
+
   var hookState = {};
 
   if (options.validate === undefined) {

--- a/test/persistence-hooks.suite.js
+++ b/test/persistence-hooks.suite.js
@@ -525,7 +525,8 @@ module.exports = function(dataSource, should) {
               extra: undefined
             },
             isNewInstance: false,
-            options: { throws: false, validate: true } }));
+            options: { throws: false, validate: true }
+          }));
           done();
         });
       });
@@ -533,7 +534,10 @@ module.exports = function(dataSource, should) {
       it('triggers `after save` hook on create', function(done) {
         TestModel.observe('after save', pushContextAndNext());
 
-        var instance = new TestModel({ name: 'created' });
+        var instance = new TestModel(
+          { id: 'new-id', name: 'created' },
+          { persisted: true });
+
         instance.save(function(err, instance) {
           if (err) return done(err);
           observedContexts.should.eql(aTestModelCtx({
@@ -542,7 +546,8 @@ module.exports = function(dataSource, should) {
               name: 'created',
               extra: undefined
             },
-            isNewInstance: true
+            isNewInstance: true,
+            options: { throws: false, validate: true }
           }));
           done();
         });


### PR DESCRIPTION
Fix test for "after save" called on save/CREATE - make it correctly trigger the code path where the connector decides whether a new record is created or an existing one is updated.

Rename callback argument "result" to "info" to make it consistent with other places where we use "info" too.

Remove traling whitespace.

/to @raymondfeng please review