### PR TITLE
Merge inclusion in default scope with inclusion in query.

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -60,7 +60,7 @@ ScopeDefinition.prototype.related = function(receiver, scopeParams, condOrRefres
   if (!self.__cachedRelations || self.__cachedRelations[name] === undefined
     || actualRefresh) {
     // It either doesn't hit the cache or refresh is required
-    var params = mergeQuery(actualCond, scopeParams);
+    var params = mergeQuery(actualCond, scopeParams, {nestedInclude: true});
     var targetModel = this.targetModel(receiver);
     targetModel.find(params, function (err, data) {
       if (!err && saveOnCache) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,6 +9,7 @@ exports.defineCachedRelations = defineCachedRelations;
 exports.sortObjectsByIds = sortObjectsByIds;
 exports.setScopeValuesFromWhere = setScopeValuesFromWhere;
 exports.mergeQuery = mergeQuery;
+exports.mergeIncludes = mergeIncludes;
 exports.createPromiseCallback = createPromiseCallback
 
 var traverse = require('traverse');
@@ -53,6 +54,87 @@ function setScopeValuesFromWhere(data, where, targetModel) {
   }
 }
 
+/**
+ * Merge include options of default scope with runtime include option.
+ * exhibits the _.extend behaviour. Property value of source overrides
+ * property value of destination if property name collision occurs
+ * @param {String|Array|Object} destination The default value of `include` option
+ * @param {String|Array|Object} source The runtime value of `include` option
+ * @returns {Object}
+ */
+function mergeIncludes(destination, source) {
+  var destArray = convertToArray(destination);
+  var sourceArray = convertToArray(source);
+  if (destArray.length === 0) {
+    return sourceArray;
+  }
+  if (sourceArray.length === 0) {
+    return destArray;
+  }
+  var relationNames = [];
+  var resultArray = [];
+  for (var j in sourceArray) {
+    var sourceEntry = sourceArray[j];
+    var sourceEntryRelationName = (typeof (sourceEntry.rel || sourceEntry.relation) === 'string') ?
+      sourceEntry.relation : Object.keys(sourceEntry)[0];
+    relationNames.push(sourceEntryRelationName);
+    resultArray.push(sourceEntry);
+  }
+  for (var i in destArray) {
+    var destEntry = destArray[i];
+    var destEntryRelationName = (typeof (destEntry.rel || destEntry.relation) === 'string') ?
+      destEntry.relation : Object.keys(destEntry)[0];
+    if (relationNames.indexOf(destEntryRelationName) === -1) {
+      resultArray.push(destEntry);
+    }
+  }
+  return resultArray;
+}
+
+/**
+ * Converts input parameter into array of objects which wraps the value.
+ * "someValue" is converted to [{"someValue":true}]
+ * ["someValue"] is converted to [{"someValue":true}]
+ * {"someValue":true} is converted to [{"someValue":true}]
+ * @param {String|Array|Object} param - Input parameter to be converted
+ * @returns {Array}
+ */
+function convertToArray(include) {
+  if (typeof include === 'string') {
+    var obj = {};
+    obj[include] = true;
+    return [obj];
+  } else if (isPlainObject(include)) {
+    //if include is of the form - {relation:'',scope:''}
+    if (include.rel || include.relation) {
+      return [include];
+    }
+    // Build an array of key/value pairs
+    var newInclude = [];
+    for (var key in include) {
+      var obj = {};
+      obj[key] = include[key];
+      newInclude.push(obj);
+    }
+    return newInclude;
+  } else if (Array.isArray(include)) {
+    var normalized = [];
+    for (var i in include) {
+      var includeEntry = include[i];
+      if (typeof includeEntry === 'string') {
+        var obj = {};
+        obj[includeEntry] = true;
+        normalized.push(obj)
+      }
+      else{
+        normalized.push(includeEntry);
+      }
+    }
+    return normalized;
+  }
+  return [];
+}
+
 /*!
  * Merge query parameters
  * @param {Object} base The base object to contain the merged results
@@ -81,9 +163,19 @@ function mergeQuery(base, update, spec) {
     if (!base.include) {
       base.include = update.include;
     } else {
-      var saved = base.include;
-      base.include = {};
-      base.include[update.include] = saved;
+      if (spec.nestedInclude === true){
+        //specify nestedInclude=true to force nesting of inclusions on scoped
+        //queries. e.g. In physician.patients.getAsync({include: 'address'}),
+        //inclusion should be on patient model, not on physician model.
+        var saved = base.include;
+        base.include = {};
+        base.include[update.include] = saved;
+      }
+      else{
+        //default behaviour of inclusion merge - merge inclusions at the same
+        //level. - https://github.com/strongloop/loopback-datasource-juggler/pull/569#issuecomment-95310874
+        base.include = mergeIncludes(base.include, update.include);
+      }
     }
   }
   


### PR DESCRIPTION
It should merge include filter in default scope (model definition) with the include filter in query.

In Model definition
```json
"scope":{
"include":"owner"
}
```

In query 
```js
Model.find({
  include:{
    posts:'comments'
  }
})
```
After merging, the resulting query will be:

```js
{
  include:{
    owner:true
    posts:'comments'
  }
}
```