### PR TITLE
Fix for https://github.com/strongloop/loopback-datasource-juggler/issues/571

### DIFF
--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -870,8 +870,8 @@ var throughKeys = function(definition) {
         //Fix for bug - https://github.com/strongloop/loopback-datasource-juggler/issues/571
         //Make sure that first key is mapped to modelFrom
         //& second key to modelTo. Order matters
-      return (definition.keyTo === fk1) ? -1 : 1;
-    });
+        return (definition.keyTo === fk1) ? -1 : 1;
+      });
   } else {
     var fk1 = findBelongsTo(modelThrough, definition.modelFrom,
                             definition.keyFrom)[0];

--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -865,7 +865,13 @@ var throughKeys = function(definition) {
       var fk2 = definition.keyThrough;
     }
   } else if (definition.modelFrom === definition.modelTo) {
-    return findBelongsTo(modelThrough, definition.modelTo, pk2);
+    return findBelongsTo(modelThrough, definition.modelTo, pk2).
+      sort(function (fk1, fk2) {
+        //Fix for bug - https://github.com/strongloop/loopback-datasource-juggler/issues/571
+        //Make sure that first key is mapped to modelFrom
+        //& second key to modelTo. Order matters
+      return (definition.keyTo === fk1) ? -1 : 1;
+    });
   } else {
     var fk1 = findBelongsTo(modelThrough, definition.modelFrom,
                             definition.keyFrom)[0];


### PR DESCRIPTION
HasManyThrough is inconsistent because of arbitrary order of foreign keys returned by findBelongsTo. This fix sorts the result so that the first key is the one that is mapped to the base (modelFrom) model.