### PR TITLE
Allow leading slash for `path` in model settings

### DIFF
--- a/lib/model-builder.js
+++ b/lib/model-builder.js
@@ -218,7 +218,11 @@ ModelBuilder.prototype.define = function defineClass(className, properties, sett
   hiddenProperty(ModelClass, 'dataSource', null); // Keep for back-compatibility
   hiddenProperty(ModelClass, 'pluralModelName', pluralName);
   hiddenProperty(ModelClass, 'relations', {});
-  hiddenProperty(ModelClass, 'http', { path: '/' + pathName });
+  if (pathName[0] !== '/') {
+    // Support both flavors path: 'x' and path: '/x'
+    pathName = '/' + pathName;
+  }
+  hiddenProperty(ModelClass, 'http', { path: pathName });
   hiddenProperty(ModelClass, 'base', ModelBaseClass);
   hiddenProperty(ModelClass, '_observers', {});
 

--- a/test/loopback-dl.test.js
+++ b/test/loopback-dl.test.js
@@ -643,6 +643,15 @@ describe('DataSource define model', function () {
     User.http.path.should.equal('/accounts');
   });
 
+  it('should allow an explicit remoting path with leading /', function () {
+    var ds = new DataSource('memory');
+
+    var User = ds.define('User', {name: String, bio: String}, {
+      http: { path: '/accounts' }
+    });
+    User.http.path.should.equal('/accounts');
+  });
+
 });
 
 describe('Load models with base', function () {


### PR DESCRIPTION
/to @bajtos 