### PR TITLE
Add unit-test for "array" type

### DIFF
--- a/test/model-definition.test.js
+++ b/test/model-definition.test.js
@@ -390,5 +390,15 @@ describe('ModelDefinition class', function () {
       done();
     });
   });
+
+  it('should support "array" type shortcut', function() {
+    var Model = memory.createModel('TwoArrays', {
+      regular: Array,
+      sugar: 'array'
+    });
+
+    var props = Model.definition.properties;
+    props.regular.type.should.equal(props.sugar.type);
+  });
 });
 


### PR DESCRIPTION
Add a unit-test to capture the fact that a property type can be specified as `type: 'array'`.

Connect to strongloop/loopback#1327

/to @raymondfeng please review
/cc @fabien @PradnyaBaviskar 
/cc @ritch IIRC, you were the one who told me that "array" string is not a valid LDL property type. Well, it turns out it is a valid type :)

