### PR TITLE
dao: support validateUpsert:false

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -403,22 +403,28 @@ DataAccessObject.updateOrCreate = DataAccessObject.upsert = function upsert(data
         Model.applyProperties(update, inst);
         Model = Model.lookupModel(update);
 
-        inst.isValid(function(valid) {
-          if (!valid) {
-            // TODO(bajtos) Remove validateUpsert option in v3.0
-            if (Model.settings.validateUpsert) {
-              return cb(new ValidationError(inst), inst);
-            } else {
-              console.warn('Ignoring validation errors in updateOrCreate():');
-              console.warn('  %s', new ValidationError(inst).message);
-              // continue with updateOrCreate
-            }
-          }
-
+        if (Model.settings.validateUpsert === false) {
           update = removeUndefined(update);
           self.getDataSource().connector
             .updateOrCreate(Model.modelName, update, done);
-        }, update);
+        } else {
+          inst.isValid(function(valid) {
+            if (!valid) {
+              if (Model.settings.validateUpsert) {
+                return cb(new ValidationError(inst), inst);
+              } else {
+                // TODO(bajtos) Remove validateUpsert:undefined in v3.0
+                console.warn('Ignoring validation errors in updateOrCreate():');
+                console.warn('  %s', new ValidationError(inst).message);
+                // continue with updateOrCreate
+              }
+            }
+
+            update = removeUndefined(update);
+            self.getDataSource().connector
+              .updateOrCreate(Model.modelName, update, done);
+          }, update);
+        }
 
         function done(err, data, info) {
           var obj;

--- a/test/validations.test.js
+++ b/test/validations.test.js
@@ -184,12 +184,27 @@ describe('validations', function () {
         });
       });
 
-      it('should be skipped on upsert by default', function(done) {
+      it('should ignore errors on upsert by default', function(done) {
         delete User.validations;
         User.validatesPresenceOf('name');
         // It's important to pass an id value, otherwise DAO falls back
         // to regular create()
         User.updateOrCreate({ id: 999 }, done);
+      });
+
+      it('should be skipped by upsert when disabled via settings', function(done) {
+        var Customer = User.extend('Customer');
+        Customer.attachTo(db);
+        db.autoupdate(function(err) {
+          if (err) return done(err);
+          Customer.prototype.isValid = function() {
+            throw new Error('isValid() should not be called at all');
+          };
+          Customer.settings.validateUpsert = false;
+          // It's important to pass an id value, otherwise DAO falls back
+          // to regular create()
+          Customer.updateOrCreate({ id: 999 }, done);
+        });
       });
 
       it('should work on upsert when enabled via settings', function(done) {


### PR DESCRIPTION
 - `validateUpsert:true` reports validation errors back to the callback
 - `validateUpsert:false` does not call `isValid()` at all
 - any other value report validation errors via `console.warn`

Fix #570

This is a quick fix to support existing applications that are using MongoDB's `$setOnInsert` together with `updateOrCreate`, see #570 for more details. In the future, I'd like to implement `$setOnInsert` as a feature, see https://github.com/strongloop/loopback/issues/1360.

/to @raymondfeng please review
/cc @PuKoren Is this a good solution for your problem described in #570?