### PR TITLE
Pass-through options from save to create

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1635,6 +1635,10 @@ DataAccessObject.prototype.save = function (options, cb) {
   assert(typeof options === 'object', 'The options argument should be an object');
   assert(typeof cb === 'function', 'The cb argument should be a function');
 
+  if (this.isNewRecord()) {
+    return Model.create(this, options, cb);
+  }
+
   var hookState = {};
 
   if (options.validate === undefined) {
@@ -1642,10 +1646,6 @@ DataAccessObject.prototype.save = function (options, cb) {
   }
   if (options.throws === undefined) {
     options.throws = false;
-  }
-
-  if (this.isNewRecord()) {
-    return Model.create(this, cb);
   }
 
   var inst = this;

--- a/test/crud-with-options.test.js
+++ b/test/crud-with-options.test.js
@@ -408,6 +408,27 @@ describe('crud-with-options', function () {
 
   });
 
+  describe('save', function () {
+
+    it('should allow save(options, cb)', function (done) {
+      var options = { foo: 'bar' };
+      var opts;
+      
+      User.observe('after save', function(ctx, next) {
+        opts = ctx.options;
+        next();
+      });
+      
+      var u = new User();
+      u.save(options, function(err) {
+        should.not.exist(err);
+        options.should.equal(opts);
+        done();
+      });
+    });
+
+  });
+
   describe('destroyAll with options', function () {
 
     beforeEach(seed);


### PR DESCRIPTION
We should probably also consider implementing the `validate` option for other methods like `create`, for consistency.

/cc @raymondfeng 