### PR TITLE
Add new hook `persist`

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -284,6 +284,7 @@ DataAccessObject.create = function (data, options, cb) {
             return cb(err, obj);
           }
           obj.__persisted = true;
+
           saveDone.call(obj, function () {
             createDone.call(obj, function () {
               if (err) {
@@ -304,11 +305,23 @@ DataAccessObject.create = function (data, options, cb) {
           });
         }
 
-        if (connector.create.length === 4) {
-          connector.create(modelName, this.constructor._forDB(val), options, createCallback);
-        } else {
-          connector.create(modelName, this.constructor._forDB(val), createCallback);
-        }
+        context = {
+          Model: Model,
+          data: val,
+          isNewInstance: true,
+          currentInstance: obj,
+          hookState: hookState,
+          options: options
+        };
+        Model.notifyObserversOf('persist', context, function(err) {
+          if (err) return cb(err);
+
+          if (connector.create.length === 4) {
+            connector.create(modelName, obj.constructor._forDB(context.data), options, createCallback);
+          } else {
+            connector.create(modelName, obj.constructor._forDB(context.data), createCallback);
+          }
+        });
       }, obj, cb);
     }, obj, cb);
   }
@@ -425,12 +438,7 @@ DataAccessObject.updateOrCreate = DataAccessObject.upsert = function upsert(data
         var connector = self.getConnector();
 
         if (Model.settings.validateUpsert === false) {
-          update = removeUndefined(update);
-          if (connector.updateOrCreate.length === 4) {
-            connector.updateOrCreate(Model.modelName, update, options, done);
-          } else {
-            connector.updateOrCreate(Model.modelName, update, done);
-          }
+          callConnector();
         } else {
           inst.isValid(function(valid) {
             if (!valid) {
@@ -443,16 +451,29 @@ DataAccessObject.updateOrCreate = DataAccessObject.upsert = function upsert(data
                 // continue with updateOrCreate
               }
             }
+            callConnector();
+          }, update);
+        }
 
-            update = removeUndefined(update);
+        function callConnector() {
+          update = removeUndefined(update);
+          context = {
+            Model: Model,
+            where: ctx.where,
+            data: update,
+            currentInstance: inst,
+            hookState: ctx.hookState,
+            options: options
+          };
+          Model.notifyObserversOf('persist', context, function(err) {
+            if (err) return done(err);
             if (connector.updateOrCreate.length === 4) {
               connector.updateOrCreate(Model.modelName, update, options, done);
             } else {
               connector.updateOrCreate(Model.modelName, update, done);
             }
-          }, update);
+          });
         }
-
         function done(err, data, info) {
           var obj;
           if (data && !(data instanceof Model)) {
@@ -562,9 +583,8 @@ DataAccessObject.findOrCreate = function findOrCreate(query, data, options, cb) 
   var self = this;
   var connector = Model.getConnector();
 
-  function _findOrCreate(query, data) {
+  function _findOrCreate(query, data, currentInstance) {
     var modelName = self.modelName;
-    data = removeUndefined(data);
     function findOrCreateCallback(err, data, created) {
       var obj, Model = self.lookupModel(data);
 
@@ -598,11 +618,26 @@ DataAccessObject.findOrCreate = function findOrCreate(query, data, options, cb) 
       }
     }
 
-    if (connector.findOrCreate.length === 5) {
-      connector.findOrCreate(modelName, query, self._forDB(data), options, findOrCreateCallback);
-    } else {
-      connector.findOrCreate(modelName, query, self._forDB(data), findOrCreateCallback);
-    }
+    data = removeUndefined(data);
+    var context = {
+      Model: Model,
+      where: query.where,
+      data: data,
+      isNewInstance: true,
+      currentInstance : currentInstance,
+      hookState: hookState,
+      options: options
+    };
+
+    Model.notifyObserversOf('persist', context, function(err) {
+      if (err) return cb(err);
+
+      if (connector.findOrCreate.length === 5) {
+        connector.findOrCreate(modelName, query, self._forDB(context.data), options, findOrCreateCallback);
+      } else {
+        connector.findOrCreate(modelName, query, self._forDB(context.data), findOrCreateCallback);
+      }
+    });
   }
 
   if (connector.findOrCreate) {
@@ -653,7 +688,7 @@ DataAccessObject.findOrCreate = function findOrCreate(query, data, options, cb) 
         // validation required
         obj.isValid(function (valid) {
           if (valid) {
-            _findOrCreate(query, data);
+            _findOrCreate(query, data, obj);
           } else {
             cb(new ValidationError(obj), obj);
           }
@@ -1789,11 +1824,25 @@ DataAccessObject.prototype.save = function (options, cb) {
             });
           }
 
-          if (connector.save.length === 4) {
-            connector.save(modelName, inst.constructor._forDB(data), options, saveCallback);
-          } else {
-            connector.save(modelName, inst.constructor._forDB(data), saveCallback);
-          }
+          context = {
+            Model: Model,
+            data: data,
+            where: byIdQuery(Model, getIdValue(Model, inst)).where,
+            currentInstance: inst,
+            hookState: hookState,
+            options: options
+          };
+
+          Model.notifyObserversOf('persist', context, function(err) {
+            if (err) return cb(err);
+
+            if (connector.save.length === 4) {
+              connector.save(modelName, inst.constructor._forDB(data), options, saveCallback);
+            } else {
+              connector.save(modelName, inst.constructor._forDB(data), saveCallback);
+            }
+          });
+
         }, data, cb);
       }, data, cb);
     }
@@ -1919,11 +1968,22 @@ DataAccessObject.updateAll = function (where, data, options, cb) {
       });
     }
 
-    if (connector.update.length === 5) {
-      connector.update(Model.modelName, where, data, options, updateCallback);
-    } else {
-      connector.update(Model.modelName, where, data, updateCallback);
-    }
+    var context = {
+      Model: Model,
+      where: where,
+      data: data,
+      hookState: hookState,
+      options: options
+    };
+    Model.notifyObserversOf('persist', context, function(err, ctx) {
+      if (err) return cb (err);
+
+      if (connector.update.length === 5) {
+        connector.update(Model.modelName, where, data, options, updateCallback);
+      } else {
+        connector.update(Model.modelName, where, data, updateCallback);
+      }
+    });
   }
   return cb.promise;
 };
@@ -2249,13 +2309,23 @@ DataAccessObject.prototype.updateAttributes = function updateAttributes(data, op
             });
           }
 
-          if (connector.updateAttributes.length === 5) {
-            connector.updateAttributes(model, getIdValue(inst.constructor, inst),
-              inst.constructor._forDB(typedData), options, updateAttributesCallback);
-          } else {
-            connector.updateAttributes(model, getIdValue(inst.constructor, inst),
-              inst.constructor._forDB(typedData), updateAttributesCallback);
-          }
+          context = {
+            Model: Model,
+            where: byIdQuery(Model, getIdValue(Model, inst)).where,
+            data: data,
+            currentInstance: inst,
+            hookState: hookState,
+            options: options
+          };
+          Model.notifyObserversOf('persist', context, function(err) {
+            if (connector.updateAttributes.length === 5) {
+              connector.updateAttributes(model, getIdValue(inst.constructor, inst),
+                inst.constructor._forDB(typedData), options, updateAttributesCallback);
+            } else {
+              connector.updateAttributes(model, getIdValue(inst.constructor, inst),
+                inst.constructor._forDB(typedData), updateAttributesCallback);
+            }
+          });
         }, data, cb);
       }, data, cb);
     }, data);


### PR DESCRIPTION
Connect to #559

Points to note -
 - During `create` the updates applied through `persist` hook are reflected into the database, but the same updates are NOT reflected in the `instance` object obtained in callback of `create`.
 - Secondly, `findOrCreate`, creates a new instance of the object every time. So, 
  - Both `ctx.data.id` and `ctx.currentInstance.id` are set to new id. 
  - And, `ctx.isNewInstance` is `true`
  
 
@bajtos, can you please review?