### PR TITLE
Fix ReferenceError: definition is not defined

### DIFF
--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -1753,6 +1753,7 @@ HasOne.prototype.destroy = function (options, cb) {
     options = {};
   }
   cb = cb || utils.createPromiseCallback();
+  var definition = this.definition;
   this.fetch(function(err, targetModel) {
     if (targetModel instanceof ModelBaseClass) {
       targetModel.destroy(options, cb);


### PR DESCRIPTION
occure when try to delete object in has one relation, but object not created yet