### PR TITLE
Don't silently swallow db errors on validation.

### DIFF
--- a/lib/validations.js
+++ b/lib/validations.js
@@ -344,9 +344,8 @@ function validateUniqueness(attr, conf, err, done) {
 
   this.constructor.find(cond, function (error, found) {
     if (error) {
-      return err();
-    }
-    if (found.length > 1) {
+      err(error);
+    } else if (found.length > 1) {
       err();
     } else if (found.length === 1 && (!this.id || !found[0].id || found[0].id.toString() != this.id.toString())) {
       err();


### PR DESCRIPTION
I had an issue in a test recently (using loopback-testing) where the test db was missing a column.

When running the test, the callback was never called and I get this very unhelpful message:

```
> NODE_ENV=test mocha --bail --compilers js:babel/register -R spec test/spec/*.js

Browse your REST API at http://0.0.0.0:8378/
LoopBack server listening @ http://0.0.0.0:8378/
  accessTokens
    when called by logged in user
      GET /api/v1/position
        1) "before each" hook

  0 passing (2s)
  1 failing

  1) accessTokens when called by logged in user "before each" hook:
     Error: timeout of 2000ms exceeded
      at [object Object].<anonymous> (/Users/user/git/api/node_modules/mocha/lib/runnable.js:159:19)
      at Timer.listOnTimeout (timers.js:110:15)
```

With this fix, I realize now that the column is missing:

```
  accessTokens
    when called by logged in user
      GET /api/v1/position
The `User` instance is not valid. Details: `username` is invalid (value: "test"); `email` is invalid (value: "test@test.com").
{ context: 'User',
  codes:
   { username: [ 'uniqueness.error: column "relaxipcheck" does not exist' ],
     email: [ 'uniqueness.error: column "relaxipcheck" does not exist' ] },
  messages: { username: [ 'is invalid' ], email: [ 'is invalid' ] } }
        1) "before each" hook

  0 passing (162ms)
  1 failing

  1) accessTokens when called by logged in user "before each" hook:
     ValidationError: The `User` instance is not valid. Details: `username` is invalid (value: "test"); `email` is invalid (value: "test@test.com").
      at /Users/user/api/node_modules/loopback-datasource-juggler/lib/dao.js:264:12
      at ModelConstructor.<anonymous> (/Users/user/api/node_modules/loopback-datasource-juggler/lib/validations.js:483:13)
      at ModelConstructor.next (/Users/user/api/node_modules/loopback-datasource-juggler/lib/hooks.js:75:12)
      at done (/Users/user/api/node_modules/loopback-datasource-juggler/lib/validations.js:480:25)
      at /Users/user/api/node_modules/loopback-datasource-juggler/lib/validations.js:554:7
      at ModelConstructor.<anonymous> (/Users/user/api/node_modules/loopback-datasource-juggler/lib/validations.js:353:5)
      at allCb (/Users/user/api/node_modules/loopback-datasource-juggler/lib/dao.js:1339:7)
      at PostgreSQL.<anonymous> (/Users/user/api/node_modules/loopback-connector-postgresql/lib/postgresql.js:720:14)
      at [object Object].callback (/Users/user/api/node_modules/loopback-connector-postgresql/lib/postgresql.js:122:7)
      at [object Object].Query.handleError (/Users/user/api/node_modules/loopback-connector-postgresql/node_modules/pg/lib/query.js:97:17)
      at [object Object].<anonymous> (/Users/user/api/node_modules/loopback-connector-postgresql/node_modules/pg/lib/client.js:166:26)
      at [object Object].emit (events.js:107:17)
      at Socket.<anonymous> (/Users/user/api/node_modules/loopback-connector-postgresql/node_modules/pg/lib/connection.js:109:12)
      at Socket.emit (events.js:107:17)
      at readableAddChunk (_stream_readable.js:163:16)
      at Socket.Readable.push (_stream_readable.js:126:10)
      at TCP.onread (net.js:538:20)
```