### PR TITLE
default values are being overwritten in upsert

### DIFF
--- a/lib/connectors/memory.js
+++ b/lib/connectors/memory.js
@@ -238,6 +238,7 @@ Memory.prototype.updateOrCreate = function (model, data, options, callback) {
 };
 
 Memory.prototype.save = function save(model, data, options, callback) {
+  var self = this;
   var id = this.getIdValue(model, data);
   var cachedModels = this.collection(model);
   var modelData = cachedModels && this.collection(model)[id];
@@ -247,7 +248,7 @@ Memory.prototype.save = function save(model, data, options, callback) {
   }
   this.collection(model)[id] = serialize(data);
   this.saveToFile(data, function(err) {
-    callback(err, data, { isNewInstance: !modelData });
+    callback(err, self.fromDb(model, data), { isNewInstance: !modelData });
   });
 };
 

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -445,8 +445,8 @@ DataAccessObject.updateOrCreate = DataAccessObject.upsert = function upsert(data
         data = ctx.data;
         var update = data;
         var inst = data;
-        if(!(data instanceof Model)) {
-          inst = new Model(data);
+        if (!(data instanceof Model)) {
+          inst = new Model(data, { applyDefaultValues: false });
         }
         update = inst.toObject(false);
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -43,6 +43,9 @@ function ModelBaseClass(data, options) {
     // Default to true
     options.applySetters = true;
   }
+  if (!('applyDefaultValues' in options)) {
+    options.applyDefaultValues = true;
+  }
   this._initProperties(data, options);
 }
 
@@ -51,6 +54,7 @@ function ModelBaseClass(data, options) {
  * @param {Object} data The data object
  * @param {Object} options An object to control the instantiation
  * @property {Boolean} applySetters Controls if the setters will be applied
+ * @property {Boolean} applyDefaultValues Default attributes and values will be applied
  * @property {Boolean} strict Set the instance level strict mode
  * @property {Boolean} persisted Whether the instance has been persisted
  * @private
@@ -72,6 +76,7 @@ ModelBaseClass.prototype._initProperties = function (data, options) {
 
   options = options || {};
   var applySetters = options.applySetters;
+  var applyDefaultValues = options.applyDefaultValues;
   var strict = options.strict;
 
   if(strict === undefined) {
@@ -243,7 +248,7 @@ ModelBaseClass.prototype._initProperties = function (data, options) {
     var type = properties[p].type;
 
     // Set default values
-    if (propVal === undefined) {
+    if (applyDefaultValues && propVal === undefined) {
       var def = properties[p]['default'];
       if (def !== undefined) {
         if (typeof def === 'function') {
@@ -265,7 +270,7 @@ ModelBaseClass.prototype._initProperties = function (data, options) {
     }
 
     // Set default value using a named function
-    if (propVal === undefined) {
+    if (applyDefaultValues && propVal === undefined) {
       var defn = properties[p].defaultFn;
       switch (defn) {
         case undefined:

--- a/test/defaults.test.js
+++ b/test/defaults.test.js
@@ -9,7 +9,8 @@ describe('defaults', function () {
   before(function () {
     Server = db.define('Server', {
       host: String,
-      port: {type: Number, default: 80}
+      port: {type: Number, default: 80},
+      createdAt: {type: Date, default: '$now'}
     });
   });
 
@@ -44,6 +45,25 @@ describe('defaults', function () {
         servers[0].host.should.equal('localhost');
         servers[0].should.have.property('host');
         servers[0].should.have.property('port', undefined);
+        done();
+      });
+    });
+  });
+
+  it('should apply defaults in upsert create', function (done) {
+    Server.upsert({port: 8181 }, function(err, server) {
+      should.not.exist(err);
+      should.exist(server.createdAt);
+      done();
+    });
+  });
+
+  it('should preserve defaults in upsert update', function (done) {
+    Server.findOne({}, function(err, server) {
+      Server.upsert({id:server.id, port: 1337 }, function(err, s) {
+        should.not.exist(err);
+        (Number(1337)).should.equal(s.port);
+        server.createdAt.should.eql(s.createdAt);
         done();
       });
     });

--- a/test/memory.test.js
+++ b/test/memory.test.js
@@ -389,6 +389,19 @@ describe('Memory connector', function() {
         });
     });
 
+    it('should deserialize values after saving in upsert', function(done) {
+      User.findOne({where: {seq: 1}}, function(err, paul) {
+        User.updateOrCreate({id: paul.id, name: 'Sir Paul McCartney'},
+          function(err, sirpaul) {
+            should.not.exist(err);
+            sirpaul.birthday.should.be.instanceOf(Date);
+            sirpaul.order.should.be.instanceOf(Number);
+            sirpaul.vip.should.be.instanceOf(Boolean);
+            done();
+          });
+      });
+    });
+
     function seed(done) {
       var beatles = [
         {


### PR DESCRIPTION
clarkbw/loopback-ds-timestamp-mixin#11 was filed and it appears to be an issue with the upsert coming from juggler.

This PR creates a test that fails and I believe I’ve tracked down the area of the code that causes the issue, wrapped in `console.log` statements currently.

When you run the test it will print the following information:
```
not instance { id: 1000, name: 'updated name' }
inst { id: 1000,
  name: 'updated name',
  createdAt: Fri Jun 05 2015 09:59:03 GMT-0700 (PDT) }
      1) should preserve default property values
```

As you can see in the debug output the `createdAt` field is being generated and then overwriting the existing `createdAt` field.  We need to prevent the default fields from being generated or passed to the update because default functions that are not idempotent will always be storing new values.

I’m investigating a solution, any comments are appreciated.