### PR TITLE
Fixed the dateType validation to allow null, string and object, else …

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -956,11 +956,22 @@ DataAccessObject._normalize = function (filter) {
 };
 
 function DateType(arg) {
-  var d = new Date(arg);
-  if (isNaN(d.getTime())) {
+  if (arg == null) {
+    return null;
+  } else if(typeof arg === 'object' && typeof arg.getTime === 'function') {
+    if (isNaN(arg.getTime())) {
+      throw new Error('Invalid date: ' + arg);
+    }
+    return arg;
+  } else if(typeof arg === 'string') {
+    var d = new Date(arg);
+    if (isNaN(d.getTime())) {
+      throw new Error('Invalid date: ' + arg);
+    }
+    return d;
+  } else {
     throw new Error('Invalid date: ' + arg);
   }
-  return d;
 }
 
 function BooleanType(arg) {


### PR DESCRIPTION
The new validation supports: null, string or Date Object.

Fix #592
