### PR TITLE
Promisify 'automigrate'

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -775,9 +775,12 @@ DataSource.prototype.automigrate = function (models, cb) {
     models = undefined;
   }
 
+  cb = cb || utils.createPromiseCallback();
+
   if (!this.connector.automigrate) {
     // NOOP
-    return cb && process.nextTick(cb);
+    process.nextTick(cb);
+    return cb.promise;
   }
 
   // First argument is a model name
@@ -791,7 +794,8 @@ DataSource.prototype.automigrate = function (models, cb) {
     models = models || Object.keys(attachedModels);
 
     if (models.length === 0) {
-      return cb && process.nextTick(cb);
+      process.nextTick(cb);
+      return cb.promise;
     }
 
     var invalidModels = models.filter(function (m) {
@@ -799,16 +803,16 @@ DataSource.prototype.automigrate = function (models, cb) {
     });
 
     if (invalidModels.length) {
-      return process.nextTick(function () {
-        if (cb) {
+      process.nextTick(function () {
           cb(new Error('Cannot migrate models not attached to this datasource: ' +
           invalidModels.join(' ')));
-        }
       });
+      return cb.promise;
     }
   }
 
   this.connector.automigrate(models, cb);
+  return cb.promise;
 };
 
 /**

--- a/test/memory.test.js
+++ b/test/memory.test.js
@@ -463,10 +463,30 @@ describe('Memory connector', function() {
       });
     });
 
+    it('automigrate all models - promise variant', function(done) {
+      ds.automigrate()
+        .then(function(result) {
+          done();
+        })
+        .catch(function(err){
+          done(err);
+        });
+    });
+
     it('automigrate one model', function(done) {
       ds.automigrate('m1', function(err) {
         done(err);
       });
+    });
+
+    it('automigrate one model - promise variant', function(done) {
+      ds.automigrate('m1')
+        .then(function(result) {
+          done();
+        })
+        .catch(function(err){
+          done(err);
+        });
     });
 
     it('automigrate one or more models in an array', function(done) {
@@ -475,13 +495,59 @@ describe('Memory connector', function() {
       });
     });
 
+    it('automigrate one or more models in an array - promise variant', function(done) {
+      ds.automigrate(['m1'])
+        .then(function(result) {
+          done();
+        })
+        .catch(function(err){
+          done(err);
+        });
+    });
+
     it('automigrate reports errors for models not attached', function(done) {
       ds.automigrate(['m1', 'm2'], function(err) {
         err.should.be.an.instanceOf(Error);
         done();
       });
     });
+
+    it('automigrate reports errors for models not attached - promise variant', function(done) {
+      ds.automigrate(['m1', 'm2'])
+        .then(function(){
+          done(new Error('automigrate() should have failed'));
+        })
+        .catch(function(err){
+          err.should.be.an.instanceOf(Error);
+          done();
+        });
+    });
+
   });
+
+  describe('automigrate when NO models are attached', function() {
+    var ds;
+    beforeEach(function() {
+      ds = new DataSource({
+        connector: 'memory'
+      });
+    });
+
+    it('automigrate does NOT report error when NO models are attached', function(done) {
+      ds.automigrate(function(err) {
+        done();
+      })
+    });
+
+    it('automigrate does NOT report error when NO models are attached - promise variant', function(done) {
+      ds.automigrate()
+        .then(done)
+        .catch(function(err){
+          done(err);
+        });
+    });
+  });
+
 });
 
 describe('Optimized connector', function() {


### PR DESCRIPTION
Connect https://github.com/strongloop/loopback/issues/418

This PL, provides `promise` support to `automigrate` method of juggler's datasource.

@bajtos - can you review?