### PR TITLE
Fix #623 - use actual id order

### DIFF
--- a/lib/include.js
+++ b/lib/include.js
@@ -407,6 +407,7 @@ Inclusion.include = function (objects, include, options, cb) {
      * @param callback
      */
     function includeReferencesMany(callback) {
+      var modelToIdName = idName(relation.modelTo);
       var allTargetIds = [];
       //Map for Indexing objects by their id for faster retrieval
       var targetObjsMap = {};
@@ -461,6 +462,7 @@ Inclusion.include = function (objects, include, options, cb) {
             relation.modelTo.include(targets, subInclude, options, next);
           });
         }
+        targets = utils.sortObjectsByIds(modelToIdName, allTargetIds, targets);
         //process each target object
         tasks.push(targetLinkingTask);
         function targetLinkingTask(next) {


### PR DESCRIPTION
In order to fix @623 completely, the array of a referencesMany ids should be used for the order of returned items.

For this, `sortObjectsByIds` is appropriate. Somehow the Juggler tests did not uncover this pending issue, despite checking the order in reverse as well (see: https://github.com/strongloop/loopback-datasource-juggler/blob/master/test/relations.test.js#L4895)

I only was able to find this after I finally updated my app (running with MongoDB) and running test there.

/cc @ningsuhen @bajtos