### PR TITLE
Make sure base property definitions are cloned

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -498,6 +498,7 @@ DataSource.prototype.setupDataAccess = function (modelClass, settings) {
       // Set the default id type from connector's ability
       var idType = this.connector.getDefaultIdType() || String;
       idProp.type = idType;
+      modelClass.definition.rawProperties[idName].type = idType;
       modelClass.definition.properties[idName].type = idType;
       if (settings.forceId) {
         modelClass.validatesAbsenceOf(idName, {if: 'isNewRecord'});

--- a/lib/model-builder.js
+++ b/lib/model-builder.js
@@ -377,7 +377,13 @@ ModelBuilder.prototype.define = function defineClass(className, properties, sett
         continue;
       }
       if (subclassProperties[key] === undefined) {
-        subclassProperties[key] = properties[key];
+        var baseProp = properties[key];
+        var basePropCopy = baseProp;
+        if (baseProp && typeof baseProp === 'object') {
+          // Deep clone the base prop
+          basePropCopy = mergeSettings(null, baseProp);
+        }
+        subclassProperties[key] = basePropCopy;
       }
     }
 

--- a/test/loopback-dl.test.js
+++ b/test/loopback-dl.test.js
@@ -691,6 +691,22 @@ describe('Load models with base', function () {
     Customer.definition.properties.name.should.have.property('type', String);
   });
 
+  it('should inherit properties by clone from base option', function () {
+    var ds = new ModelBuilder();
+
+    var User = ds.define('User', {name: String});
+
+    var Customer1 = ds.define('Customer1', {vip: Boolean}, {base: 'User'});
+    var Customer2 = ds.define('Customer2', {vip: Boolean}, {base: 'User'});
+
+    Customer1.definition.properties.should.have.property('name');
+    Customer2.definition.properties.should.have.property('name');
+    Customer1.definition.properties.name.should.not.be.equal(
+      Customer2.definition.properties.name);
+    Customer1.definition.properties.name.should.eql(
+      Customer2.definition.properties.name);
+  });
+
   it('should revert properties from base model', function() {
     var ds = new ModelBuilder();
 


### PR DESCRIPTION
/to @fabien 
/cc @ritch 

Sub models sometimes need to customize the properties from the base model.
This change allows each sub model has its own copy of the base property
definition to avoid potential conflicts across multiple sub models of the
same base.