### PR TITLE
Filter attributes when strict: true

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -2297,6 +2297,7 @@ DataAccessObject.prototype.updateAttributes = function updateAttributes(data, op
   assert(typeof connector.updateAttributes === 'function',
     'updateAttributes() must be implemented by the connector');
 
+  var strict = this.__strict;
   var model = Model.modelName;
   var hookState = {};
 
@@ -2333,6 +2334,12 @@ DataAccessObject.prototype.updateAttributes = function updateAttributes(data, op
   Model.notifyObserversOf('before save', context, function(err, ctx) {
     if (err) return cb(err);
     data = ctx.data;
+
+    if (strict) {
+      var keys = Object.keys(Model.definition.properties);
+      data = utils.selectFields(keys)(data);
+      data = removeUndefined(data);
+    }
 
     // update instance's properties
     inst.setAttributes(data);

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -2336,9 +2336,21 @@ DataAccessObject.prototype.updateAttributes = function updateAttributes(data, op
     data = ctx.data;
 
     if (strict) {
-      var keys = Object.keys(Model.definition.properties);
-      data = utils.selectFields(keys)(data);
-      data = removeUndefined(data);
+      var props = Model.definition.properties;
+      var keys = Object.keys(data);
+      var result = {};
+      for (var i = 0; i < keys.length; i++) {
+        key = keys[i];
+        if (props[key]) {
+          result[key] = data[key];
+        } else if (strict === 'throw') {
+          cb(new Error('Unknown property: ' + key));
+          return;
+        } else if (strict === 'validate') {
+          inst.__unknownProperties.push(key);
+        } 
+      }
+      data = removeUndefined(result);
     }
 
     // update instance's properties

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -2297,6 +2297,9 @@ DataAccessObject.prototype.updateAttributes = function updateAttributes(data, op
   assert(typeof connector.updateAttributes === 'function',
     'updateAttributes() must be implemented by the connector');
 
+  var allowExtendedOperators = connector.settings
+    && connector.settings.allowExtendedOperators;
+
   var strict = this.__strict;
   var model = Model.modelName;
   var hookState = {};
@@ -2335,7 +2338,7 @@ DataAccessObject.prototype.updateAttributes = function updateAttributes(data, op
     if (err) return cb(err);
     data = ctx.data;
 
-    if (strict) {
+    if (strict && !allowExtendedOperators) {
       var props = Model.definition.properties;
       var keys = Object.keys(data);
       var result = {};

--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -19,7 +19,7 @@ describe('manipulation', function () {
       age: {type: Number, index: true},
       dob: Date,
       createdAt: {type: Date, default: Date}
-    }, { forceId: true });
+    }, { forceId: true, strict: true });
 
     db.automigrate(done);
 
@@ -490,6 +490,19 @@ describe('manipulation', function () {
           });
         });
     });
+    
+    it('should ignore unknown attributes', function(done) {
+      person.updateAttributes({foo:'bar'},
+        function(err, p) {
+          if (err) return done(err);
+          should.not.exist(p.foo);
+          Person.findById(p.id, function(e, p) {
+            if (e) return done(e);
+            should.not.exist(p.foo);
+            done();
+          });
+        });
+    });
 
     it('should allow same id value on updateAttributes', function(done) {
       person.updateAttributes({id: person.id, name: 'John'},
@@ -532,7 +545,7 @@ describe('manipulation', function () {
         });
     });
 
-    it('should allows model instance on updateAttributes', function(done) {
+    it('should allow model instance on updateAttributes', function(done) {
       person.updateAttributes(new Person({'name': 'John', age: undefined}),
         function(err, p) {
           if (err) return done(err);
@@ -545,7 +558,7 @@ describe('manipulation', function () {
         });
     });
 
-    it('should allows model instance on updateAttributes (promise variant)', function(done) {
+    it('should allow model instance on updateAttributes (promise variant)', function(done) {
       person.updateAttributes(new Person({'name': 'Jane', age: undefined}))
         .then(function(p) {
           return Person.findById(p.id)

--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -491,7 +491,7 @@ describe('manipulation', function () {
         });
     });
     
-    it('should ignore unknown attributes', function(done) {
+    it('should ignore unknown attributes when strict: true', function(done) {
       person.updateAttributes({foo:'bar'},
         function(err, p) {
           if (err) return done(err);
@@ -502,6 +502,41 @@ describe('manipulation', function () {
             done();
           });
         });
+    });
+    
+    it('should throw error on unknown attributes when strict: throw', function(done) {
+      Person.definition.settings.strict = 'throw';
+      Person.findById(person.id, function(err, p) {
+        p.updateAttributes({foo:'bar'},
+          function(err, p) {
+            should.exist(err);
+            err.name.should.equal('Error');
+            err.message.should.equal('Unknown property: foo');
+            should.not.exist(p);
+            Person.findById(person.id, function(e, p) {
+              if (e) return done(e);
+              should.not.exist(p.foo);
+              done();
+            });
+          });
+      });
+    });
+    
+    it('should throw error on unknown attributes when strict: throw', function(done) {
+      Person.definition.settings.strict = 'validate';
+      Person.findById(person.id, function(err, p) {
+        p.updateAttributes({foo:'bar'},
+          function(err, p) {
+            should.exist(err);
+            err.name.should.equal('ValidationError');
+            err.message.should.containEql('`foo` is not defined in the model');
+            Person.findById(person.id, function(e, p) {
+              if (e) return done(e);
+              should.not.exist(p.foo);
+              done();
+            });
+          });
+      });
     });
 
     it('should allow same id value on updateAttributes', function(done) {


### PR DESCRIPTION
This fixes https://github.com/strongloop/loopback/issues/742 in the following way:

- with strict: true, only known properties should be written to the dataSource
- from my findings, the data never made it to the dataSource, even before this fix (unlike what the issue above states)
- what **did** happen though, is that the in-memory representation was altered and returned, which was unaware of what was filtered or not (eg. actually written to the dataSource)

This distinction was clear from the test I added. Even before this fix, the last `should.not.exist(p.foo)` would pass correctly, however, the former `should.not.exist(p.foo)` call would not. With this fix, both pass.