### PR TITLE
Fix regexp error for the memory connector

### DIFF
--- a/lib/connectors/memory.js
+++ b/lib/connectors/memory.js
@@ -461,14 +461,14 @@ function applyFilter(filter) {
       return value.match(example);
     }
 
-    if (example.regexp)
-      return value.match(example.regexp);
-
     if (example === undefined) {
       return undefined;
     }
 
     if (typeof example === 'object' && example !== null) {
+      if (example.regexp)
+        return value.match(example.regexp);
+
       // ignore geo near filter
       if (example.near) {
         return true;


### PR DESCRIPTION
- Check for undefined/null values when accessing `regexp` key