### PR TITLE
Indicate result of destroyById/protototype.destroy

### DIFF
--- a/lib/connectors/memory.js
+++ b/lib/connectors/memory.js
@@ -265,8 +265,9 @@ Memory.prototype.find = function find(model, id, options, callback) {
 };
 
 Memory.prototype.destroy = function destroy(model, id, options, callback) {
+  var exists = this.collection(model)[id];
   delete this.collection(model)[id];
-  this.saveToFile(null, callback);
+  this.saveToFile({ count: exists ? 1 : 0 }, callback);
 };
 
 Memory.prototype.fromDb = function (model, data) {

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1697,11 +1697,18 @@ DataAccessObject.removeById = DataAccessObject.destroyById = DataAccessObject.de
 
   var Model = this;
 
-  this.remove(byIdQuery(this, id).where, options, function(err) {
-    if ('function' === typeof cb) {
-      cb(err);
+  this.remove(byIdQuery(this, id).where, options, function(err, info) {
+    if (err) return cb(err);
+    var deleted = info && info.count > 0;
+    if (Model.settings.strictDelete && !deleted) {
+      err = new Error('No instance with id ' + id + ' found for ' + Model.modelName);
+      err.code = 'NOT_FOUND';
+      err.statusCode = 404;
+      return cb(err);
     }
-    if(!err) Model.emit('deleted', id);
+
+    cb(null, info);
+    Model.emit('deleted', id);
   });
   return cb.promise;
 };
@@ -2149,8 +2156,15 @@ DataAccessObject.prototype.remove =
           // A hook modified the query, it is no longer
           // a simple 'delete model with the given id'.
           // We must switch to full query-based delete.
-          Model.deleteAll(where, { notify: false }, function(err) {
-            if (err) return cb(err);
+          Model.deleteAll(where, { notify: false }, function(err, info) {
+            if (err) return cb(err, false);
+            var deleted = info && info.count > 0;
+            if (Model.settings.strictDelete && !deleted) {
+              err = new Error('No instance with id ' + id + ' found for ' + Model.modelName);
+              err.code = 'NOT_FOUND';
+              err.statusCode = 404;
+              return cb(err, false);
+            }
             var context = {
               Model: Model,
               where: where,
@@ -2159,7 +2173,7 @@ DataAccessObject.prototype.remove =
               options: options
             };
             Model.notifyObserversOf('after delete', context, function(err) {
-              cb(err);
+              cb(err, info);
               if (!err) Model.emit('deleted', id);
             });
           });
@@ -2167,8 +2181,13 @@ DataAccessObject.prototype.remove =
         }
 
         inst.trigger('destroy', function (destroyed) {
-          function destroyCallback(err) {
-            if (err) {
+          function destroyCallback(err, info) {
+            if (err) return cb(err);
+            var deleted = info && info.count > 0;
+            if (Model.settings.strictDelete && !deleted) {
+              err = new Error('No instance with id ' + id + ' found for ' + Model.modelName);
+              err.code = 'NOT_FOUND';
+              err.statusCode = 404;
               return cb(err);
             }
 
@@ -2181,7 +2200,7 @@ DataAccessObject.prototype.remove =
                 options: options
               };
               Model.notifyObserversOf('after delete', context, function(err) {
-                cb(err);
+                cb(err, info);
                 if (!err) Model.emit('deleted', id);
               });
             });

--- a/test/crud-with-options.test.js
+++ b/test/crud-with-options.test.js
@@ -413,12 +413,12 @@ describe('crud-with-options', function () {
     it('should allow save(options, cb)', function (done) {
       var options = { foo: 'bar' };
       var opts;
-      
+
       User.observe('after save', function(ctx, next) {
         opts = ctx.options;
         next();
       });
-      
+
       var u = new User();
       u.save(options, function(err) {
         should.not.exist(err);
@@ -478,12 +478,6 @@ describe('crud-with-options', function () {
       });
     });
 
-  });
-
-  describe('deleteById', function() {
-    it('should allow deleteById(id)', function () {
-      User.deleteById(1);
-    });
   });
 
   describe('updateAll ', function () {


### PR DESCRIPTION
Return `info.count` to the callback to indicate whether the model instance was deleted or not. When `options.strict` is true, return 404 error when the model instance was not found.

See #521 for the initial solution.

/to @raymondfeng @fabien please review