### PR TITLE
enabled saving of embedded models in embedsMany relationship

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -165,6 +165,7 @@ ModelBaseClass.prototype._initProperties = function (data, options) {
 
   var size = keys.length;
   var p, propVal;
+
   for (var k = 0; k < size; k++) {
     p = keys[k];
     propVal = data[p];
@@ -208,6 +209,14 @@ ModelBaseClass.prototype._initProperties = function (data, options) {
             fields.push(ctor.relations[p].keyTo);
           }
           self.__data[p] = new modelTo(propVal, { fields: fields, applySetters: false, persisted: options.persisted });
+        }
+      }
+
+      else if (relationType === 'embedsMany' && propVal !== null && propVal.length > 0){
+
+        self.__data[ctor.relations[p].keyFrom] = [];
+        for (var i = 0; i < propVal.length; i++) {
+          self[ctor.relations[p].name].build(propVal[i]);
         }
       }
 

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -4150,17 +4150,29 @@ describe('relations', function () {
       });
     });
 
-    it('should not create embedded from attributes - relation name', function(done) {
+    it('should validate embedded items created from attributes', function(done) {
+      Person.create({name: 'Dr. Funky Machine', addresses: [{}]}, function(err, p) {
+        should.exist(err);
+        err.name.should.equal('ValidationError');
+        err.details.codes.street.should.eql(['invalid']);
+        done();
+      });
+    });
+
+    //https://groups.google.com/forum/#!searchin/loopbackjs/embedded$20model/loopbackjs/dYbYXMXsxgU/6R1AH8wWL0QJ
+    //https://github.com/strongloop/loopback/issues/1196
+    it('should create embedded from attributes - relation name', function(done) {
       var addresses = [
         {id: 'home', street: 'Home Street'},
         {id: 'work', street: 'Work Street'}
       ];
       Person.create({name: 'Wilma', addressList: addresses}, function(err, p) {
         should.not.exist(err);
-        p.addresses.should.have.length(0);
+        p.addresses.should.have.length(2);
         done();
       });
     });
+
 
     it('should create embedded items with auto-generated id', function(done) {
       Person.create({ name: 'Wilma' }, function(err, p) {

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -4152,10 +4152,8 @@ describe('relations', function () {
 
     it('should validate embedded items created from attributes', function(done) {
       Person.create({name: 'Dr. Funky Machine', addresses: [{}]}, function(err, p) {
-
         should.exist(err);
         err.name.should.equal('ValidationError');
-
         err.details.codes.addresses.should.eql(['invalid']);
         done();
       });

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -4152,9 +4152,11 @@ describe('relations', function () {
 
     it('should validate embedded items created from attributes', function(done) {
       Person.create({name: 'Dr. Funky Machine', addresses: [{}]}, function(err, p) {
+
         should.exist(err);
         err.name.should.equal('ValidationError');
-        err.details.codes.street.should.eql(['invalid']);
+
+        err.details.codes.addresses.should.eql(['invalid']);
         done();
       });
     });

--- a/test/validations.test.js
+++ b/test/validations.test.js
@@ -36,11 +36,21 @@ describe('validations', function () {
       createdByScript: Boolean,
       updatedAt: Date
     });
+
+
+    Entry2 = db.define('Entry', {
+      anotherID: { type: 'string', id: true, generated: false },
+      name: { type: 'string' }
+    });
+    Entry2.validatesUniquenessOf('anotherID');
+
+
     Entry = db.define('Entry', {
       id: { type: 'string', id: true, generated: false },
       name: { type: 'string' }
     });
     Entry.validatesUniquenessOf('id');
+
     db.automigrate(done);
   });
 

--- a/test/validations.test.js
+++ b/test/validations.test.js
@@ -37,14 +37,6 @@ describe('validations', function () {
       updatedAt: Date
     });
 
-
-    Entry2 = db.define('Entry', {
-      anotherID: { type: 'string', id: true, generated: false },
-      name: { type: 'string' }
-    });
-    Entry2.validatesUniquenessOf('anotherID');
-
-
     Entry = db.define('Entry', {
       id: { type: 'string', id: true, generated: false },
       name: { type: 'string' }


### PR DESCRIPTION
We think that it could be nice if it was possible to populate embeddedMany relations in the create() method by providing an array of related models. For example, given  a Person model with an embedsMany relationship called addresses:

```
  var addresses = [
      //Some data
  ];
  Person.create({name: 'Johnny B.', addresses: addresses}, function(err, inst) {

    inst.addresses(); //returns the embedded addresses
    done();
  });
```

We are aware that the current code contains a test which asserts the impossibility of doing this, anyway we still think it could be a useful feature:
   https://groups.google.com/forum/#!searchin/loopbackjs/embedded$20model/loopbackjs/dYbYXMXsxgU/6R1AH8wWL0QJ
https://github.com/strongloop/loopback/issues/1196
