### PR TITLE
primaryKey to hasOne relation

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -1796,11 +1796,12 @@ DataSource.prototype.idProperty = function (modelName) {
  * @param {String} className The model name that owns the key
  * @param {String} key Name of key field
  * @param {String} foreignClassName The foreign model name
+ * @param {String} pkName (optional) primary key used for foreignKey
  */
-DataSource.prototype.defineForeignKey = function defineForeignKey(className, key, foreignClassName) {
+DataSource.prototype.defineForeignKey = function defineForeignKey(className, key, foreignClassName, pkName) {
   var pkType = null;
   var foreignModel = this.getModelDefinition(foreignClassName);
-  var pkName = foreignModel && foreignModel.idName();
+  pkName = pkName || foreignModel && foreignModel.idName();
   if (pkName) {
     pkType = foreignModel.properties[pkName].type;
   }

--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -1600,7 +1600,7 @@ RelationDefinition.hasOne = function (modelFrom, modelTo, params) {
   params = params || {};
   modelTo = lookupModelTo(modelFrom, modelTo, params);
 
-  var pk = modelFrom.dataSource.idName(modelFrom.modelName) || 'id';
+  var pk = params.primaryKey || modelFrom.dataSource.idName(modelFrom.modelName) || 'id';
   var relationName = params.as || i8n.camelize(modelTo.modelName, true);
 
   var fk = params.foreignKey || i8n.camelize(modelFrom.modelName + '_id', true);
@@ -1630,7 +1630,7 @@ RelationDefinition.hasOne = function (modelFrom, modelTo, params) {
     methods: params.methods
   });
 
-  modelTo.dataSource.defineForeignKey(modelTo.modelName, fk, modelFrom.modelName);
+  modelTo.dataSource.defineForeignKey(modelTo.modelName, fk, modelFrom.modelName, pk);
 
   // Define a property for the scope so that we have 'this' for the scoped methods
   Object.defineProperty(modelFrom.prototype, relationName, {

--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -588,7 +588,7 @@ RelationDefinition.hasMany = function hasMany(modelFrom, modelTo, params) {
   var fk = params.foreignKey || i8n.camelize(thisClassName + '_id', true);
   var keyThrough = params.keyThrough || i8n.camelize(modelTo.modelName + '_id', true);
 
-  var idName = modelFrom.dataSource.idName(modelFrom.modelName) || 'id';
+  var pkName = params.primaryKey || modelFrom.dataSource.idName(modelFrom.modelName) || 'id';
   var discriminator, polymorphic;
 
   if (params.polymorphic) {
@@ -610,7 +610,7 @@ RelationDefinition.hasMany = function hasMany(modelFrom, modelTo, params) {
     name: relationName,
     type: RelationTypes.hasMany,
     modelFrom: modelFrom,
-    keyFrom: idName,
+    keyFrom: pkName,
     keyTo: fk,
     modelTo: modelTo,
     multiple: true,
@@ -629,7 +629,7 @@ RelationDefinition.hasMany = function hasMany(modelFrom, modelTo, params) {
     // obviously, modelTo should have attribute called `fk`
     // for polymorphic relations, it is assumed to share the same fk type for all
     // polymorphic models
-    modelTo.dataSource.defineForeignKey(modelTo.modelName, fk, modelFrom.modelName);
+    modelTo.dataSource.defineForeignKey(modelTo.modelName, fk, modelFrom.modelName, pkName);
   }
 
   var scopeMethods = {
@@ -680,7 +680,7 @@ RelationDefinition.hasMany = function hasMany(modelFrom, modelTo, params) {
   defineScope(modelFrom.prototype, params.through || modelTo, relationName, function () {
     var filter = {};
     filter.where = {};
-    filter.where[fk] = this[idName];
+    filter.where[fk] = this[pkName];
 
     definition.applyScope(this, filter);
 
@@ -1216,7 +1216,7 @@ RelationDefinition.belongsTo = function (modelFrom, modelTo, params) {
     modelTo = lookupModelTo(modelFrom, modelTo, params);
   }
 
-  var idName, relationName, fk;
+  var pkName, relationName, fk;
   if (params.polymorphic) {
     relationName = params.as || (typeof modelTo === 'string' ? modelTo : null); // initially
 
@@ -1229,7 +1229,7 @@ RelationDefinition.belongsTo = function (modelFrom, modelTo, params) {
 
     modelTo = null; // will lookup dynamically
 
-    idName = params.idName || 'id';
+    pkName = params.primaryKey || params.idName || 'id';
     relationName = params.as || polymorphic.as; // finally
     fk = polymorphic.foreignKey;
     discriminator = polymorphic.discriminator;
@@ -1237,16 +1237,16 @@ RelationDefinition.belongsTo = function (modelFrom, modelTo, params) {
     if (polymorphic.idType) { // explicit key type
       modelFrom.dataSource.defineProperty(modelFrom.modelName, fk, { type: polymorphic.idType, index: true });
     } else { // try to use the same foreign key type as modelFrom
-      modelFrom.dataSource.defineForeignKey(modelFrom.modelName, fk, modelFrom.modelName);
+      modelFrom.dataSource.defineForeignKey(modelFrom.modelName, fk, modelFrom.modelName, pkName);
     }
 
     modelFrom.dataSource.defineProperty(modelFrom.modelName, discriminator, { type: 'string', index: true });
   } else {
-    idName = modelTo.dataSource.idName(modelTo.modelName) || 'id';
+    pkName = params.primaryKey || modelTo.dataSource.idName(modelTo.modelName) || 'id';
     relationName = params.as || i8n.camelize(modelTo.modelName, true);
     fk = params.foreignKey || relationName + 'Id';
 
-    modelFrom.dataSource.defineForeignKey(modelFrom.modelName, fk, modelTo.modelName);
+    modelFrom.dataSource.defineForeignKey(modelFrom.modelName, fk, modelTo.modelName, pkName);
   }
 
   var definition = modelFrom.relations[relationName] = new RelationDefinition({
@@ -1254,7 +1254,7 @@ RelationDefinition.belongsTo = function (modelFrom, modelTo, params) {
     type: RelationTypes.belongsTo,
     modelFrom: modelFrom,
     keyFrom: fk,
-    keyTo: idName,
+    keyTo: pkName,
     modelTo: modelTo,
     multiple: false,
     properties: params.properties,


### PR DESCRIPTION
Support for primaryKey for hasOne relation
```js
 "lastData": {
      "type": "hasOne",
      "model": "LastData",
      "foreignKey": "dataId",
      "primaryKey": "dataId"
    }
```

Were mentioned here: 
http://stackoverflow.com/questions/26802071/loopback-relationship-on-non-id-field
https://groups.google.com/forum/#!topic/loopbackjs/F1JcB4bTtxM