### PR TITLE
Do not coerce RegExp objects to strings

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1196,8 +1196,11 @@ DataAccessObject._coerce = function (where) {
       }
     } else {
       if (val != null) {
-        if (operator === 'regexp' && val instanceof RegExp) {
-          // do not coerce regex literals/objects
+        if (operator === null && val instanceof RegExp) {
+          // Normalize {name: /A/} to {name: {regexp: /A/}}
+          operator = 'regexp';
+        } else if (operator === 'regexp' && val instanceof RegExp) {
+          // Do not coerce regex literals/objects
         } else if (!((operator === 'like' || operator === 'nlike') && val instanceof RegExp)) {
           val = DataType(val);
         }

--- a/test/memory.test.js
+++ b/test/memory.test.js
@@ -356,6 +356,16 @@ describe('Memory connector', function() {
       });
     });
 
+    it('should work when a regex is provided without the regexp operator',
+        function(done) {
+      User.find({where: {name: /John.*/i}}, function(err, users) {
+        should.not.exist(err);
+        users.length.should.equal(1);
+        users[0].name.should.equal('John Lennon');
+        done();
+      });
+    });
+
     it('should support the regexp operator with regex strings', function(done) {
       User.find({where: {name: {regexp: '^J'}}}, function(err, users) {
         should.not.exist(err);


### PR DESCRIPTION
Queries like `{where: {name: /John.*/i}}` should work. Notice there is no
`regexp` operator (ie. `{where: {name: {regexp: /John.*/i}}}`).

Connect to #681 