### PR TITLE
Fixed ReferencesMany .findById to check the given id in the modelInstance[fk]

### DIFF
--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -2985,7 +2985,7 @@ ReferencesMany.prototype.findById = function (fkId, options, cb) {
     fkId = fkId.toString(); // mongodb
   }
 
-  var ids = [fkId];
+  var ids = modelInstance[fk] || [];
 
   var filter = {};
 
@@ -2993,7 +2993,7 @@ ReferencesMany.prototype.findById = function (fkId, options, cb) {
 
   cb = cb || utils.createPromiseCallback();
 
-  modelTo.findByIds(ids, filter, options, function (err, instances) {
+  modelTo.findByIds([fkId], filter, options, function (err, instances) {
     if (err) {
       return cb(err);
     }


### PR DESCRIPTION
### Issue
`findById` in `ReferencesMany` was comparing the `fkId` with itself. Hence `findById` method always returns the `modelTo` instance whether the `modelFrom` instance contains it or not.

### Fix
Fixed the above issue by checking whether the `fkId` is present in `modelInstance[fk]`. 

cc: @fabien