### PR TITLE
With simpe and fast hasmany

### DIFF
--- a/lib/include.js
+++ b/lib/include.js
@@ -845,7 +845,9 @@ Inclusion.include = function (objects, include, options, cb) {
      * @returns {*}
      */
     function processTargetObj(obj, callback) {
-      var inst = (obj instanceof self) ? obj : new self(obj);
+      
+      var isInst = obj instanceof self;
+
       // Calling the relation method on the instance
       if (relation.type === 'belongsTo') {
         // If the belongsTo relation doesn't have an owner
@@ -853,7 +855,7 @@ Inclusion.include = function (objects, include, options, cb) {
           defineCachedRelations(obj);
           // Set to null if the owner doesn't exist
           obj.__cachedRelations[relationName] = null;
-          if (obj === inst) {
+          if (isInst) {
             obj.__data[relationName] = null;
           } else {
             obj[relationName] = null;
@@ -867,7 +869,7 @@ Inclusion.include = function (objects, include, options, cb) {
        * @param cb
        */
       function setIncludeData(result, cb) {
-        if (obj === inst) {
+        if (isInst) {
           if (Array.isArray(result) && !(result instanceof List)) {
             result = new List(result, relation.modelTo);
           }
@@ -885,6 +887,9 @@ Inclusion.include = function (objects, include, options, cb) {
         return setIncludeData(obj.__cachedRelations[relationName],
           callback);
       }
+
+      var inst = (obj instanceof self) ? obj : new self(obj);
+
       //If related objects are not cached by include Handlers, directly call
       //related accessor function even though it is not very efficient
       var related; // relation accessor function

--- a/lib/include.js
+++ b/lib/include.js
@@ -1,6 +1,7 @@
 var async = require('async');
 var utils = require('./utils');
 var List = require('./list');
+var includeUtils = require('./include_utils');
 var isPlainObject = utils.isPlainObject;
 var defineCachedRelations = utils.defineCachedRelations;
 var uniq = utils.uniq;
@@ -267,6 +268,11 @@ Inclusion.include = function (objects, include, options, cb) {
       if (relation.type === 'referencesMany') {
         return includeReferencesMany(cb);
       }
+
+      //This handles exactly hasMany. Fast and straightforward. Without parallel, each and other boilerplate.
+      if(relation.type === 'hasMany' && relation.multiple && !subInclude) {
+        return includeHasManySimple(cb);
+      }
       //assuming all other relations with multiple=true as hasMany
       return includeHasMany(cb);
     }
@@ -478,6 +484,108 @@ Inclusion.include = function (objects, include, options, cb) {
           }
         }
 
+        execTasksWithInterLeave(tasks, callback);
+      }
+    }
+
+    /**
+     * Handle inclusion of HasMany relation
+     * @param callback
+     */
+    function includeHasManySimple(callback) {
+      //Map for Indexing objects by their id for faster retrieval
+      var objIdMap = includeUtils.buildOneToOneIdentityMap(objs, relation.keyFrom);
+      // all ids of primary objects to use in query
+      var sourceIds = Object.keys(objIdMap);
+
+      filter.where[relation.keyTo] = {
+        inq: uniq(sourceIds)
+      };
+
+      relation.applyScope(null, filter);
+      relation.modelTo.find(filter, options, targetFetchHandler2);
+
+      function targetFetchHandler2(err, targets) {
+        if(err) {
+          return callback(err);
+        }
+
+        var targetsIdMap = includeUtils.buildOneToManyIdentityMap(targets, relation.keyTo);
+        includeUtils.join(objIdMap, targetsIdMap, function(obj1, valueToMergeIn){
+          obj1[relation.name] = valueToMergeIn;
+        });
+        callback(err, objs);
+      }
+      /**
+       * Process fetched related objects
+       * @param err
+       * @param {Array<Model>} targets
+       * @returns {*}
+       */
+      function targetFetchHandler(err, targets) {
+        console.log("### query done. I'm in targetFetchHandler");
+        console.log("### obtained: \ntargets(permission) count: " + targets.length + "\nobjs(users) count: " + objs.length);
+        if (err) {
+          return callback(err);
+        }
+
+        var modelToFKIdMap = includeUtils.buildOneToManyIdentityMap(targets, relation.keyTo);
+
+        var tasks = [];
+        //simultaneously process subIncludes
+        if (subInclude && targets) {
+          tasks.push(function subIncludesTask(next) {
+            relation.modelTo.include(targets, subInclude, options, next);
+          });
+        }
+        //process each target object
+        tasks.push(targetLinkingTask);
+        function targetLinkingTask(next) {
+          if (targets.length === 0) {
+            return async.each(objs, function(obj, next) {
+              processTargetObj(obj, next);
+            }, next);
+          }
+          // TODO: show targets length
+          // почему так сложно???? Не очень понимаю.
+          async.each(targets, linkManyToOne, next);
+          function linkManyToOne(target, next) {
+            console.log("### processing target: " + JSON.stringify(target));
+            //fix for bug in hasMany with referencesMany
+            var targetIds = [].concat(target[relation.keyTo]);
+            console.log("### targetIds: " + JSON.stringify(targetIds));
+            async.each(targetIds, function (targetId, next) {
+              var obj = objIdMap[targetId.toString()];
+              if (!obj) return next();
+              obj.__cachedRelations[relationName].push(target);
+              //console.time("@@@Prepare1");
+              processTargetObj(obj, next);
+              //console.timeEnd("@@@Prepare1");
+            }, function(err, processedTargets) {
+              if (err) {
+                return next(err);
+              }
+              console.time("finding object with empty ids");
+              var objsWithEmptyRelation = objs.filter(function(obj) {
+                return obj.__cachedRelations[relationName].length === 0;
+              });
+              console.timeEnd("finding object with empty ids"); // 0-1 ms
+              console.log("### objs with empty relations count: " + objsWithEmptyRelation.length);
+              //next(processedTargets);
+              console.time("Prepare empty");
+              async.each(objsWithEmptyRelation, function(obj, next) {
+                console.time("Prepare one");
+                processTargetObj(obj, next);
+                console.timeEnd("Prepare one");
+              }, function(err) {
+                console.timeEnd("Prepare empty");
+                next(err, processedTargets);
+              });
+            });
+          }
+        }
+
+        console.log("### tasks count: " + tasks.length);
         execTasksWithInterLeave(tasks, callback);
       }
     }

--- a/lib/include.js
+++ b/lib/include.js
@@ -495,13 +495,9 @@ Inclusion.include = function (objects, include, options, cb) {
     function includeHasManySimple(callback) {
       //Map for Indexing objects by their id for faster retrieval
       var objIdMap2 = includeUtils.buildOneToOneIdentityMapWithOrigKeys(objs, relation.keyFrom);
-      console.log("### objIdMap2: " + JSON.stringify(objIdMap2));
-      // all ids of primary objects to use in query are original. So, ObjectIds stay ObjectIds and Ints stay Ints.
-      // No .toString() conversion.
-      var sourceIds = objIdMap2.originalKeys;
 
       filter.where[relation.keyTo] = {
-        inq: uniq(sourceIds)
+        inq: uniq(objIdMap2.getKeys())
       };
 
       relation.applyScope(null, filter);
@@ -511,8 +507,8 @@ Inclusion.include = function (objects, include, options, cb) {
         if(err) {
           return callback(err);
         }
-        var targetsIdMap = includeUtils.buildOneToManyIdentityMap(targets, relation.keyTo);
-        includeUtils.join(objIdMap2.simplified, targetsIdMap, function(obj1, valueToMergeIn){
+        var targetsIdMap = includeUtils.buildOneToManyIdentityMapWithOrigKeys(targets, relation.keyTo);
+        includeUtils.join(objIdMap2, targetsIdMap, function(obj1, valueToMergeIn){
           defineCachedRelations(obj1);
           obj1.__cachedRelations[relationName] = valueToMergeIn;
           processTargetObj(obj1, function(){});

--- a/lib/include.js
+++ b/lib/include.js
@@ -495,8 +495,10 @@ Inclusion.include = function (objects, include, options, cb) {
     function includeHasManySimple(callback) {
       //Map for Indexing objects by their id for faster retrieval
       var objIdMap2 = includeUtils.buildOneToOneIdentityMapWithOrigKeys(objs, relation.keyFrom);
-      // all ids of primary objects to use in query
-      var sourceIds = objIdMap2.originalKeys;//Object.keys(objIdMap);
+      console.log("### objIdMap2: " + JSON.stringify(objIdMap2));
+      // all ids of primary objects to use in query are original. So, ObjectIds stay ObjectIds and Ints stay Ints.
+      // No .toString() conversion.
+      var sourceIds = objIdMap2.originalKeys;
 
       filter.where[relation.keyTo] = {
         inq: uniq(sourceIds)

--- a/lib/include.js
+++ b/lib/include.js
@@ -270,7 +270,7 @@ Inclusion.include = function (objects, include, options, cb) {
       }
 
       //This handles exactly hasMany. Fast and straightforward. Without parallel, each and other boilerplate.
-      if(relation.type === 'hasMany' && relation.multiple && !subInclude) {
+      if(relation.type === 'hasMany' && relation.multiple && !subInclude){
         return includeHasManySimple(cb);
       }
       //assuming all other relations with multiple=true as hasMany
@@ -503,90 +503,19 @@ Inclusion.include = function (objects, include, options, cb) {
       };
 
       relation.applyScope(null, filter);
-      relation.modelTo.find(filter, options, targetFetchHandler2);
+      relation.modelTo.find(filter, options, targetFetchHandler);
 
-      function targetFetchHandler2(err, targets) {
+      function targetFetchHandler(err, targets) {
         if(err) {
           return callback(err);
         }
-
         var targetsIdMap = includeUtils.buildOneToManyIdentityMap(targets, relation.keyTo);
         includeUtils.join(objIdMap, targetsIdMap, function(obj1, valueToMergeIn){
-          obj1[relation.name] = valueToMergeIn;
+          defineCachedRelations(obj1);
+          obj1.__cachedRelations[relationName] = valueToMergeIn;
+          processTargetObj(obj1, function(){});
         });
         callback(err, objs);
-      }
-      /**
-       * Process fetched related objects
-       * @param err
-       * @param {Array<Model>} targets
-       * @returns {*}
-       */
-      function targetFetchHandler(err, targets) {
-        console.log("### query done. I'm in targetFetchHandler");
-        console.log("### obtained: \ntargets(permission) count: " + targets.length + "\nobjs(users) count: " + objs.length);
-        if (err) {
-          return callback(err);
-        }
-
-        var modelToFKIdMap = includeUtils.buildOneToManyIdentityMap(targets, relation.keyTo);
-
-        var tasks = [];
-        //simultaneously process subIncludes
-        if (subInclude && targets) {
-          tasks.push(function subIncludesTask(next) {
-            relation.modelTo.include(targets, subInclude, options, next);
-          });
-        }
-        //process each target object
-        tasks.push(targetLinkingTask);
-        function targetLinkingTask(next) {
-          if (targets.length === 0) {
-            return async.each(objs, function(obj, next) {
-              processTargetObj(obj, next);
-            }, next);
-          }
-          // TODO: show targets length
-          // почему так сложно???? Не очень понимаю.
-          async.each(targets, linkManyToOne, next);
-          function linkManyToOne(target, next) {
-            console.log("### processing target: " + JSON.stringify(target));
-            //fix for bug in hasMany with referencesMany
-            var targetIds = [].concat(target[relation.keyTo]);
-            console.log("### targetIds: " + JSON.stringify(targetIds));
-            async.each(targetIds, function (targetId, next) {
-              var obj = objIdMap[targetId.toString()];
-              if (!obj) return next();
-              obj.__cachedRelations[relationName].push(target);
-              //console.time("@@@Prepare1");
-              processTargetObj(obj, next);
-              //console.timeEnd("@@@Prepare1");
-            }, function(err, processedTargets) {
-              if (err) {
-                return next(err);
-              }
-              console.time("finding object with empty ids");
-              var objsWithEmptyRelation = objs.filter(function(obj) {
-                return obj.__cachedRelations[relationName].length === 0;
-              });
-              console.timeEnd("finding object with empty ids"); // 0-1 ms
-              console.log("### objs with empty relations count: " + objsWithEmptyRelation.length);
-              //next(processedTargets);
-              console.time("Prepare empty");
-              async.each(objsWithEmptyRelation, function(obj, next) {
-                console.time("Prepare one");
-                processTargetObj(obj, next);
-                console.timeEnd("Prepare one");
-              }, function(err) {
-                console.timeEnd("Prepare empty");
-                next(err, processedTargets);
-              });
-            });
-          }
-        }
-
-        console.log("### tasks count: " + tasks.length);
-        execTasksWithInterLeave(tasks, callback);
       }
     }
 

--- a/lib/include.js
+++ b/lib/include.js
@@ -494,9 +494,9 @@ Inclusion.include = function (objects, include, options, cb) {
      */
     function includeHasManySimple(callback) {
       //Map for Indexing objects by their id for faster retrieval
-      var objIdMap = includeUtils.buildOneToOneIdentityMap(objs, relation.keyFrom);
+      var objIdMap2 = includeUtils.buildOneToOneIdentityMapWithOrigKeys(objs, relation.keyFrom);
       // all ids of primary objects to use in query
-      var sourceIds = Object.keys(objIdMap);
+      var sourceIds = objIdMap2.originalKeys;//Object.keys(objIdMap);
 
       filter.where[relation.keyTo] = {
         inq: uniq(sourceIds)
@@ -510,7 +510,7 @@ Inclusion.include = function (objects, include, options, cb) {
           return callback(err);
         }
         var targetsIdMap = includeUtils.buildOneToManyIdentityMap(targets, relation.keyTo);
-        includeUtils.join(objIdMap, targetsIdMap, function(obj1, valueToMergeIn){
+        includeUtils.join(objIdMap2.simplified, targetsIdMap, function(obj1, valueToMergeIn){
           defineCachedRelations(obj1);
           obj1.__cachedRelations[relationName] = valueToMergeIn;
           processTargetObj(obj1, function(){});
@@ -845,7 +845,7 @@ Inclusion.include = function (objects, include, options, cb) {
      * @returns {*}
      */
     function processTargetObj(obj, callback) {
-      
+
       var isInst = obj instanceof self;
 
       // Calling the relation method on the instance

--- a/lib/include_utils.js
+++ b/lib/include_utils.js
@@ -1,7 +1,9 @@
 module.exports.buildOneToOneIdentityMap = buildOneToOneIdentityMap;
 module.exports.buildOneToManyIdentityMap = buildOneToManyIdentityMap;
 module.exports.buildOneToOneIdentityMapWithOrigKeys = buildOneToOneIdentityMapWithOrigKeys;
+module.exports.buildOneToManyIdentityMapWithOrigKeys = buildOneToManyIdentityMapWithOrigKeys;
 module.exports.join = join;
+module.exports.KVMap = KVMap;
 /**
  * Effectively builds associative map on id -> object relation.
  * Map returned in form of object with ids in keys and object as values.
@@ -21,71 +23,21 @@ function buildOneToOneIdentityMap(objs, idName) {
 }
 
 /**
- * Builds key -> value map on js object base. As js object keys can be only strings keys are stored on value side.
- * So, each value should be an object like that:
- * { origKey: 34, value: {...}}
- * origKey field name should be passed as parameter to function.
- *
- * @param origKeyField filed name on value side to pick original key from.
- * @returns empty object to be filled with key-value pair and additional methods `keys` and `originalKeys`
- */
-function newIdMap(origKeyField, valueField) {
-  //var idMap = Object.create(null); // not any single properties within our identity map
-  var idMap = {};
-  Object.defineProperty(idMap, "set", {
-    value: function(origKey, value){
-      var key = origKey.toString();
-      this[key] = {};
-      this[key][origKeyField] = origKey;
-      this[key][valueField] = value;
-    }
-  });
-  Object.defineProperty(idMap, "keys", {    // can ask for keys simply by idMap.keys
-    get: function(){ return Object.keys(this); },
-    enumerable: false // explicitly non-enumerable
-  });
-  Object.defineProperty(idMap, "originalKeys", {  // can ask for all original keys by idMap.originalKeys
-    get: function(){
-      var keys = this.keys;
-      var origKeys = [];
-      for(var i = 0; i < keys.length; i++) {
-        var origKey = this[keys[i]][origKeyField];
-        origKeys.push(origKey);
-      }
-      return origKeys;
-    },
-    enumerable: false // explicitly non-enumerable
-  });
-  Object.defineProperty(idMap, "simplified",{
-    get: function(){
-      var keys = this.keys;
-      var simplified = {};
-      for(var i = 0; i < keys.length; i++) {
-        var key = keys[i];
-        simplified[key] = this[key][valueField];
-      }
-      return simplified;
-    }
-  });
-  return idMap;
-}
-/**
  * Effectively builds associative map on id -> object relation and stores original keys.
  * Map returned in form of object with ids in keys and object as values.
  * @param objs array of objects to build from
  * @param idName name of property to be used as id. Such property considered to be unique across array.
  * In case of collisions last wins. For non-unique ids use buildOneToManyIdentityMap()
- * @returns {{}} object where keys are ids and values are objects itself
+ * @returns {} object where keys are ids and values are objects itself
  */
 function buildOneToOneIdentityMapWithOrigKeys(objs, idName) {
-  var idMap = newIdMap("originalKey", "value");
-
+  var kvMap = new KVMap();
   for(var i = 0; i < objs.length; i++) {
     var obj = objs[i];
     var id = obj[idName];
-    idMap.set(id, obj);
+    kvMap.set(id, obj);
   }
-  return idMap;
+  return kvMap;
 }
 
 /**
@@ -109,18 +61,15 @@ function buildOneToManyIdentityMap(objs, idName) {
 }
 
 function buildOneToManyIdentityMapWithOrigKeys(objs, idName) {
-  var idMap = newIdMap("originalKey", "value");
+  var kvMap = new KVMap();
   for(var i = 0; i < objs.length; i++) {
     var obj = objs[i];
     var id = obj[idName];
-    var idString = id.toString();
-    if(idString in idMap) {
-      idMap[idString]["value"].push(obj);
-    } else {
-      idMap.set(id, [obj]);
-    }
+    var value = kvMap.get(id) || [];
+    value.push(obj);
+    kvMap.set(id, value);
   }
-  return idMap;
+  return kvMap;
 }
 
 
@@ -132,11 +81,54 @@ function buildOneToManyIdentityMapWithOrigKeys(objs, idName) {
  * @param mergeF  function(obj, objectsToMergeIn)
  */
 function join(oneToOneIdMap, oneToManyIdMap, mergeF) {
-  var ids = Object.keys(oneToOneIdMap);
+  var ids = oneToOneIdMap.getKeys();
   for(var i = 0; i < ids.length; i++) {
     var id = ids[i];
-    var obj = oneToOneIdMap[id];
-    var objectsToMergeIn = oneToManyIdMap[id] || [];
+    var obj = oneToOneIdMap.get(id);
+    var objectsToMergeIn = oneToManyIdMap.get(id) || [];
     mergeF(obj, objectsToMergeIn);
   }
+}
+
+
+
+function KVMap(){
+  var _originalKeyFieldName = 'originalKey';
+  var _valueKeyFieldName = 'value';
+  var _dict = {};
+  var keyToString = function(key){ return key.toString() };
+  var mapImpl = {
+    set: function(key, value){
+      var recordObj = {};
+      recordObj[_originalKeyFieldName] = key;
+      recordObj[_valueKeyFieldName] = value;
+      _dict[keyToString(key)] = recordObj;
+      return true;
+    },
+    get: function(key){
+      var storeObj = _dict[keyToString(key)];
+      if(storeObj) {
+        return storeObj[_valueKeyFieldName];
+      } else {
+        return undefined;
+      }
+    },
+    remove: function(key){
+      delete _dict[keyToString(key)];
+      return true;
+    },
+    exist: function(key) {
+      var result = _dict.hasOwnProperty(keyToString(key));
+      return result;
+    },
+    getKeys: function(){
+      var result = [];
+      for(var key in _dict) {
+        result.push(_dict[key][_originalKeyFieldName]);
+      }
+      return result;
+    }
+
+  };
+  return mapImpl;
 }

--- a/lib/include_utils.js
+++ b/lib/include_utils.js
@@ -1,0 +1,58 @@
+module.exports.buildOneToOneIdentityMap = buildOneToOneIdentityMap;
+module.exports.buildOneToManyIdentityMap = buildOneToManyIdentityMap;
+module.exports.join = join;
+/**
+ * Effectivly builds associative map on id -> object relation.
+ * Map returned in form of object with ids in keys and object as values.
+ * @param objs array of objects to build from
+ * @param idName name of property to be used as id. Such property considered to be unique across array.
+ * In case of collisions last wins. For non-unique ids use buildOneToManyIdentityMap()
+ * @returns {{}} object where keys are ids and values are objects itself
+ */
+function buildOneToOneIdentityMap(objs, idName) {
+  var idMap = {};
+  for(var i = 0; i < objs.length; i++) {
+    var obj = objs[i];
+    var id = obj[idName].toString();
+    idMap[id] = obj;
+  }
+  return idMap;
+}
+
+/**
+ * Effectively builds associate map on id -> Array[Object].
+ * Map returned in form of object with ids in keys and array of objects with given id.
+ * @param objs array of objects to build from
+ * @param idName name of property to be used as id
+ */
+function buildOneToManyIdentityMap(objs, idName) {
+  var idMap = {};
+  for(var i = 0; i < objs.length; i++) {
+    var obj = objs[i];
+    var id = obj[idName].toString();
+    if(id in idMap) {
+      idMap[id].push(obj);
+    } else {
+      idMap[id] = [obj];
+    }
+  }
+  return idMap;
+}
+
+
+/**
+ * Yeah, it joins. You need three things id -> obj1 map, id -> [obj2] map and merge function.
+ * This functions will take each obj1, locate all data to join in map2 and call merge function.
+ * @param oneToOneIdMap
+ * @param oneToManyIdMap
+ * @param mergeF  function(obj, objectsToMergeIn)
+ */
+function join(oneToOneIdMap, oneToManyIdMap, mergeF) {
+  var ids = Object.keys(oneToOneIdMap);
+  for(var i = 0; i < ids.length; i++) {
+    var id = ids[i];
+    var obj = oneToOneIdMap[id];
+    var objectsToMergeIn = oneToManyIdMap[id] || [];
+    mergeF(obj, objectsToMergeIn);
+  }
+}

--- a/lib/include_utils.js
+++ b/lib/include_utils.js
@@ -91,7 +91,11 @@ function join(oneToOneIdMap, oneToManyIdMap, mergeF) {
 }
 
 
-
+/**
+ * Map with arbitrary keys and values. User .set() and .get() to work with values instead of []
+ * @returns {{set: Function, get: Function, remove: Function, exist: Function, getKeys: Function}}
+ * @constructor
+ */
 function KVMap(){
   var _originalKeyFieldName = 'originalKey';
   var _valueKeyFieldName = 'value';

--- a/lib/include_utils.js
+++ b/lib/include_utils.js
@@ -1,26 +1,7 @@
-module.exports.buildOneToOneIdentityMap = buildOneToOneIdentityMap;
-module.exports.buildOneToManyIdentityMap = buildOneToManyIdentityMap;
 module.exports.buildOneToOneIdentityMapWithOrigKeys = buildOneToOneIdentityMapWithOrigKeys;
 module.exports.buildOneToManyIdentityMapWithOrigKeys = buildOneToManyIdentityMapWithOrigKeys;
 module.exports.join = join;
 module.exports.KVMap = KVMap;
-/**
- * Effectively builds associative map on id -> object relation.
- * Map returned in form of object with ids in keys and object as values.
- * @param objs array of objects to build from
- * @param idName name of property to be used as id. Such property considered to be unique across array.
- * In case of collisions last wins. For non-unique ids use buildOneToManyIdentityMap()
- * @returns {{}} object where keys are ids and values are objects itself
- */
-function buildOneToOneIdentityMap(objs, idName) {
-  var idMap = {};
-  for(var i = 0; i < objs.length; i++) {
-    var obj = objs[i];
-    var id = obj[idName].toString();
-    idMap[id] = obj;
-  }
-  return idMap;
-}
 
 /**
  * Effectively builds associative map on id -> object relation and stores original keys.
@@ -38,26 +19,6 @@ function buildOneToOneIdentityMapWithOrigKeys(objs, idName) {
     kvMap.set(id, obj);
   }
   return kvMap;
-}
-
-/**
- * Effectively builds associate map on id -> Array[Object].
- * Map returned in form of object with ids in keys and array of objects with given id.
- * @param objs array of objects to build from
- * @param idName name of property to be used as id
- */
-function buildOneToManyIdentityMap(objs, idName) {
-  var idMap = {};
-  for(var i = 0; i < objs.length; i++) {
-    var obj = objs[i];
-    var id = obj[idName].toString();
-    if(id in idMap) {
-      idMap[id].push(obj);
-    } else {
-      idMap[id] = [obj];
-    }
-  }
-  return idMap;
 }
 
 function buildOneToManyIdentityMapWithOrigKeys(objs, idName) {

--- a/lib/include_utils.js
+++ b/lib/include_utils.js
@@ -29,7 +29,7 @@ function buildOneToOneIdentityMap(objs, idName) {
  * @param origKeyField filed name on value side to pick original key from.
  * @returns empty object to be filled with key-value pair and additional methods `keys` and `originalKeys`
  */
-function newIdMap(origKeyField) {
+function newIdMap(origKeyField, valueField) {
   //var idMap = Object.create(null); // not any single properties within our identity map
   var idMap = {};
   Object.defineProperty(idMap, "keys", {    // can ask for keys simply by idMap.keys
@@ -48,6 +48,17 @@ function newIdMap(origKeyField) {
     },
     enumerable: false // explicitly non-enumerable
   });
+  Object.defineProperty(idMap, "simplified",{
+    get: function(){
+      var keys = this.keys;
+      var simplified = {};
+      for(var i = 0; i < keys.length; i++) {
+        var key = keys[i];
+        simplified[key] = this[key][valueField];
+      }
+      return simplified;
+    }
+  });
   return idMap;
 }
 /**
@@ -59,7 +70,7 @@ function newIdMap(origKeyField) {
  * @returns {{}} object where keys are ids and values are objects itself
  */
 function buildOneToOneIdentityMapWithOrigKeys(objs, idName) {
-  var idMap = newIdMap("originalKey");
+  var idMap = newIdMap("originalKey", "value");
 
   for(var i = 0; i < objs.length; i++) {
     var obj = objs[i];

--- a/lib/include_utils.js
+++ b/lib/include_utils.js
@@ -32,6 +32,14 @@ function buildOneToOneIdentityMap(objs, idName) {
 function newIdMap(origKeyField, valueField) {
   //var idMap = Object.create(null); // not any single properties within our identity map
   var idMap = {};
+  Object.defineProperty(idMap, "set", {
+    value: function(origKey, value){
+      var key = origKey.toString();
+      this[key] = {};
+      this[key][origKeyField] = origKey;
+      this[key][valueField] = value;
+    }
+  });
   Object.defineProperty(idMap, "keys", {    // can ask for keys simply by idMap.keys
     get: function(){ return Object.keys(this); },
     enumerable: false // explicitly non-enumerable
@@ -75,10 +83,7 @@ function buildOneToOneIdentityMapWithOrigKeys(objs, idName) {
   for(var i = 0; i < objs.length; i++) {
     var obj = objs[i];
     var id = obj[idName];
-    idMap[id.toString()] = {
-      originalKey: id,
-      value: obj
-    };
+    idMap.set(id, obj);
   }
   return idMap;
 }
@@ -98,6 +103,21 @@ function buildOneToManyIdentityMap(objs, idName) {
       idMap[id].push(obj);
     } else {
       idMap[id] = [obj];
+    }
+  }
+  return idMap;
+}
+
+function buildOneToManyIdentityMapWithOrigKeys(objs, idName) {
+  var idMap = newIdMap("originalKey", "value");
+  for(var i = 0; i < objs.length; i++) {
+    var obj = objs[i];
+    var id = obj[idName];
+    var idString = id.toString();
+    if(idString in idMap) {
+      idMap[idString]["value"].push(obj);
+    } else {
+      idMap.set(id, [obj]);
     }
   }
   return idMap;

--- a/lib/include_utils.js
+++ b/lib/include_utils.js
@@ -1,8 +1,9 @@
 module.exports.buildOneToOneIdentityMap = buildOneToOneIdentityMap;
 module.exports.buildOneToManyIdentityMap = buildOneToManyIdentityMap;
+module.exports.buildOneToOneIdentityMapWithOrigKeys = buildOneToOneIdentityMapWithOrigKeys;
 module.exports.join = join;
 /**
- * Effectivly builds associative map on id -> object relation.
+ * Effectively builds associative map on id -> object relation.
  * Map returned in form of object with ids in keys and object as values.
  * @param objs array of objects to build from
  * @param idName name of property to be used as id. Such property considered to be unique across array.
@@ -15,6 +16,58 @@ function buildOneToOneIdentityMap(objs, idName) {
     var obj = objs[i];
     var id = obj[idName].toString();
     idMap[id] = obj;
+  }
+  return idMap;
+}
+
+/**
+ * Builds key -> value map on js object base. As js object keys can be only strings keys are stored on value side.
+ * So, each value should be an object like that:
+ * { origKey: 34, value: {...}}
+ * origKey field name should be passed as parameter to function.
+ *
+ * @param origKeyField filed name on value side to pick original key from.
+ * @returns empty object to be filled with key-value pair and additional methods `keys` and `originalKeys`
+ */
+function newIdMap(origKeyField) {
+  //var idMap = Object.create(null); // not any single properties within our identity map
+  var idMap = {};
+  Object.defineProperty(idMap, "keys", {    // can ask for keys simply by idMap.keys
+    get: function(){ return Object.keys(this); },
+    enumerable: false // explicitly non-enumerable
+  });
+  Object.defineProperty(idMap, "originalKeys", {  // can ask for all original keys by idMap.originalKeys
+    get: function(){
+      var keys = this.keys;
+      var origKeys = [];
+      for(var i = 0; i < keys.length; i++) {
+        var origKey = this[keys[i]][origKeyField];
+        origKeys.push(origKey);
+      }
+      return origKeys;
+    },
+    enumerable: false // explicitly non-enumerable
+  });
+  return idMap;
+}
+/**
+ * Effectively builds associative map on id -> object relation and stores original keys.
+ * Map returned in form of object with ids in keys and object as values.
+ * @param objs array of objects to build from
+ * @param idName name of property to be used as id. Such property considered to be unique across array.
+ * In case of collisions last wins. For non-unique ids use buildOneToManyIdentityMap()
+ * @returns {{}} object where keys are ids and values are objects itself
+ */
+function buildOneToOneIdentityMapWithOrigKeys(objs, idName) {
+  var idMap = newIdMap("originalKey");
+
+  for(var i = 0; i < objs.length; i++) {
+    var obj = objs[i];
+    var id = obj[idName];
+    idMap[id.toString()] = {
+      originalKey: id,
+      value: obj
+    };
   }
   return idMap;
 }

--- a/test/include.test.js
+++ b/test/include.test.js
@@ -56,6 +56,7 @@ describe('include', function () {
 
   it('should fetch Passport - Owner - Posts', function (done) {
     Passport.find({include: {owner: 'posts'}}, function (err, passports) {
+
       should.not.exist(err);
       should.exist(passports);
       passports.length.should.be.ok;

--- a/test/include_util.test.js
+++ b/test/include_util.test.js
@@ -4,16 +4,15 @@ var should = require("should");
 var includeUtils = require("../lib/include_utils");
 
 describe('include_util', function(){
-  describe('#buildOneToOneIdentityMap', function(){
+  describe('#buildOneToOneIdentityMapWithOrigKeys', function(){
     it('should return an object with keys', function(){
       var objs = [
           {id: 11, letter: "A"},
           {id: 22, letter: "B"}
       ];
-      var result = includeUtils.buildOneToOneIdentityMap(objs, "id");
-      result.should.be.an.instanceOf(Object);
-      result.should.have.property("11");
-      result.should.have.property("22");
+      var result = includeUtils.buildOneToOneIdentityMapWithOrigKeys(objs, "id");
+      result.get(11).should.be.ok;
+      result.get(22).should.be.ok;
     });
 
     it('should overwrite keys in case of collision', function(){
@@ -24,11 +23,12 @@ describe('include_util', function(){
             {id: 11, letter: "HA!"}
         ];
 
-        var result = includeUtils.buildOneToOneIdentityMap(objs, "id");
-        result.should.be.an.instanceOf(Object);
-        result.should.have.keys("11", "22", "33");
-        result["11"]["letter"].should.equal("HA!");
-        result["33"]["letter"].should.equal("C");
+        var result = includeUtils.buildOneToOneIdentityMapWithOrigKeys(objs, "id");
+        result.getKeys().should.containEql(11);
+        result.getKeys().should.containEql(22);
+        result.getKeys().should.containEql(33);
+        result.get(11)["letter"].should.equal("HA!");
+        result.get(33)["letter"].should.equal("C");
     });
   });
   describe('#buildOneToOneIdentityMapWithOrigKeys', function(){
@@ -49,9 +49,9 @@ describe('include_util', function(){
                 {id: 11, letter: "A"},
                 {id: 22, letter: "B"}
             ];
-            var result = includeUtils.buildOneToManyIdentityMap(objs, "id");
-            result.should.be.an.instanceOf(Object);
-            result.should.have.keys("11", "22");
+            var result = includeUtils.buildOneToManyIdentityMapWithOrigKeys(objs, "id");
+            result.exist(11).should.be.true;
+            result.exist(22).should.be.true;
         });
 
         it('should collect keys in case of collision', function(){
@@ -62,12 +62,10 @@ describe('include_util', function(){
                 {fk_id: 11, letter: "HA!"}
             ];
 
-            var result = includeUtils.buildOneToManyIdentityMap(objs, "fk_id");
-            result.should.be.an.instanceOf(Object);
-            result.should.have.keys("11", "22", "33");
-            result["11"][0]["letter"].should.equal("A");
-            result["11"][1]["letter"].should.equal("HA!");
-            result["33"][0]["letter"].should.equal("C");
+            var result = includeUtils.buildOneToManyIdentityMapWithOrigKeys(objs, "fk_id");
+            result.get(11)[0]["letter"].should.equal("A");
+            result.get(11)[1]["letter"].should.equal("HA!");
+            result.get(33)[0]["letter"].should.equal("C");
         });
     });
 });

--- a/test/include_util.test.js
+++ b/test/include_util.test.js
@@ -32,6 +32,54 @@ describe('include_util', function(){
     });
   });
 
+  describe('#buildOneToOneIdentityMapWithOrigKeys', function(){
+    it('should return an object with keys', function(){
+      var objs = [
+        {id: 11, letter: "A"},
+        {id: 22, letter: "B"}
+      ];
+      var result = includeUtils.buildOneToOneIdentityMapWithOrigKeys(objs, "id");
+      result.should.be.an.instanceOf(Object);
+      result.should.have.property("11");
+      result.should.have.property("22");
+      Object.keys(result).should.have.lengthOf(2);  // no additional properties
+    });
+    it('should return all stringized keys with .keys method', function(){
+      var objs = [
+        {id: 11, letter: "A"},
+        {id: 22, letter: "B"},
+        {id: "cc", letter: "C"}
+      ];
+      var result = includeUtils.buildOneToOneIdentityMapWithOrigKeys(objs, "id");
+      var keys = result.keys;
+      keys.should.be.instanceOf(Array);
+      keys.should.have.lengthOf(3);
+      keys.should.be.eql(['11', '22', 'cc']);
+    });
+    it("should return all original keys with .originalKeys method", function(){
+      var objs = [
+        {id: 11, letter: "A"},
+        {id: 22, letter: "B"},
+        {id: "vv", letter: "V"}
+      ];
+      var result = includeUtils.buildOneToOneIdentityMapWithOrigKeys(objs, "id");
+      var origKeys = result.originalKeys;
+      origKeys.should.be.instanceOf(Array);
+      origKeys.should.have.lengthOf(3);
+      origKeys.should.be.eql([11, 22, 'vv']);
+    });
+    it('should have .keys and .originalKeys in same order', function(){
+      var objs = [
+        {id: 11, letter: "A"},
+        {id: 22, letter: "B"},
+        {id: "vv", letter: "V"}
+      ];
+      var result = includeUtils.buildOneToOneIdentityMapWithOrigKeys(objs, "id");
+      var keys = result.keys;
+      var origKeys = result.originalKeys;
+      origKeys.map(function(a){return a.toString();}).should.be.eql(keys);
+    });
+  });
     describe('#buildOneToManyIdentityMap', function(){
         it('should return an object with keys', function(){
             var objs = [

--- a/test/include_util.test.js
+++ b/test/include_util.test.js
@@ -1,0 +1,62 @@
+var assert = require("assert");
+var should = require("should");
+
+var includeUtils = require("../lib/include_utils");
+
+describe('include_util', function(){
+  describe('#buildOneToOneIdentityMap', function(){
+    it('should return an object with keys', function(){
+      var objs = [
+          {id: 11, letter: "A"},
+          {id: 22, letter: "B"}
+      ];
+      var result = includeUtils.buildOneToOneIdentityMap(objs, "id");
+      result.should.be.an.instanceOf(Object);
+      result.should.have.property("11");
+      result.should.have.property("22");
+    });
+
+    it('should overwrite keys in case of collision', function(){
+        var objs = [
+            {id: 11, letter: "A"},
+            {id: 22, letter: "B"},
+            {id: 33, letter: "C"},
+            {id: 11, letter: "HA!"}
+        ];
+
+        var result = includeUtils.buildOneToOneIdentityMap(objs, "id");
+        result.should.be.an.instanceOf(Object);
+        result.should.have.keys("11", "22", "33");
+        result["11"]["letter"].should.equal("HA!");
+        result["33"]["letter"].should.equal("C");
+    });
+  });
+
+    describe('#buildOneToManyIdentityMap', function(){
+        it('should return an object with keys', function(){
+            var objs = [
+                {id: 11, letter: "A"},
+                {id: 22, letter: "B"}
+            ];
+            var result = includeUtils.buildOneToManyIdentityMap(objs, "id");
+            result.should.be.an.instanceOf(Object);
+            result.should.have.keys("11", "22");
+        });
+
+        it('should collect keys in case of collision', function(){
+            var objs = [
+                {fk_id: 11, letter: "A"},
+                {fk_id: 22, letter: "B"},
+                {fk_id: 33, letter: "C"},
+                {fk_id: 11, letter: "HA!"}
+            ];
+
+            var result = includeUtils.buildOneToManyIdentityMap(objs, "fk_id");
+            result.should.be.an.instanceOf(Object);
+            result.should.have.keys("11", "22", "33");
+            result["11"][0]["letter"].should.equal("A");
+            result["11"][1]["letter"].should.equal("HA!");
+            result["33"][0]["letter"].should.equal("C");
+        });
+    });
+});

--- a/test/include_util.test.js
+++ b/test/include_util.test.js
@@ -31,56 +31,19 @@ describe('include_util', function(){
         result["33"]["letter"].should.equal("C");
     });
   });
-
   describe('#buildOneToOneIdentityMapWithOrigKeys', function(){
     it('should return an object with keys', function(){
       var objs = [
         {id: 11, letter: "A"},
         {id: 22, letter: "B"}
       ];
-      var result = includeUtils.buildOneToOneIdentityMapWithOrigKeys(objs, "id");
-      result.should.be.an.instanceOf(Object);
-      result.should.have.property("11");
-      result.should.have.property("22");
-      Object.keys(result).should.have.lengthOf(2);  // no additional properties
-    });
-    it('should return all stringized keys with .keys method', function(){
-      var objs = [
-        {id: 11, letter: "A"},
-        {id: 22, letter: "B"},
-        {id: "cc", letter: "C"}
-      ];
-      var result = includeUtils.buildOneToOneIdentityMapWithOrigKeys(objs, "id");
-      var keys = result.keys;
-      keys.should.be.instanceOf(Array);
-      keys.should.have.lengthOf(3);
-      keys.should.be.eql(['11', '22', 'cc']);
-    });
-    it("should return all original keys with .originalKeys method", function(){
-      var objs = [
-        {id: 11, letter: "A"},
-        {id: 22, letter: "B"},
-        {id: "vv", letter: "V"}
-      ];
-      var result = includeUtils.buildOneToOneIdentityMapWithOrigKeys(objs, "id");
-      var origKeys = result.originalKeys;
-      origKeys.should.be.instanceOf(Array);
-      origKeys.should.have.lengthOf(3);
-      origKeys.should.be.eql([11, 22, 'vv']);
-    });
-    it('should have .keys and .originalKeys in same order', function(){
-      var objs = [
-        {id: 11, letter: "A"},
-        {id: 22, letter: "B"},
-        {id: "vv", letter: "V"}
-      ];
-      var result = includeUtils.buildOneToOneIdentityMapWithOrigKeys(objs, "id");
-      var keys = result.keys;
-      var origKeys = result.originalKeys;
-      origKeys.map(function(a){return a.toString();}).should.be.eql(keys);
+      var result = includeUtils.buildOneToOneIdentityMapWithOrigKeys(objs, 'id');
+      result.get(11).should.be.ok;
+      result.get(22).should.be.ok;
+      result.getKeys().should.have.lengthOf(2);  // no additional properties
     });
   });
-    describe('#buildOneToManyIdentityMap', function(){
+  describe('#buildOneToManyIdentityMap', function(){
         it('should return an object with keys', function(){
             var objs = [
                 {id: 11, letter: "A"},
@@ -107,4 +70,64 @@ describe('include_util', function(){
             result["33"][0]["letter"].should.equal("C");
         });
     });
+});
+
+
+describe('KVMap', function(){
+  it('should allow to set and get value with key string', function(){
+    var map = new includeUtils.KVMap();
+    map.set('name', 'Alex');
+    map.set('gender', true);
+    map.set('age', 25);
+    map.get('name').should.be.equal('Alex');
+    map.get('gender').should.be.equal(true);
+    map.get('age').should.be.equal(25);
+  });
+  it('should allow to set and get value with arbitrary key type', function(){
+    var map = new includeUtils.KVMap();
+    map.set('name', 'Alex');
+    map.set(true, 'male');
+    map.set(false, false);
+    map.set({isTrue: 'yes'}, 25);
+    map.get('name').should.be.equal('Alex');
+    map.get(true).should.be.equal('male');
+    map.get(false).should.be.equal(false);
+    map.get({isTrue: 'yes'}).should.be.equal(25);
+  });
+  it('should not allow to get values with [] operator', function(){
+    var map = new includeUtils.KVMap();
+    map.set('name', 'Alex');
+    (map['name'] === undefined).should.be.equal(true);
+  });
+  it('should provide .exist() method for checking if key presented', function(){
+    var map = new includeUtils.KVMap();
+    map.set('one', 1);
+    map.set(2, 'two');
+    map.set(true, 'true');
+    map.exist('one').should.be.true;
+    map.exist(2).should.be.true;
+    map.exist(true).should.be.true;
+    map.exist('two').should.be.false;
+  });
+  it('should return array of original keys with .getKeys()', function(){
+    var map = new includeUtils.KVMap();
+    map.set('one', 1);
+    map.set(2, 'two');
+    map.set(true, 'true');
+    var keys = map.getKeys();
+    keys.should.containEql('one');
+    keys.should.containEql(2);
+    keys.should.containEql(true);
+  });
+  it('should allow to store and fetch arrays', function(){
+    var map = new includeUtils.KVMap();
+    map.set(1, [1, 2, 3]);
+    map.set(2, [2, 3, 4]);
+    var valueOne = map.get(1);
+    valueOne.should.be.eql([1, 2, 3]);
+    valueOne.push(99);
+    map.set(1, valueOne);
+    var valueOneUpdated = map.get(1);
+    valueOneUpdated.should.be.eql([1, 2, 3, 99]);
+  });
 });


### PR DESCRIPTION
Hey guys, I'm not Loopback guru or even experienced user, but we were having some problems with performance of `hasMany` relation. 

It was affected cases when for ex. you have about 100 users (user hasMany permissions) and 100 permissions for them totally. As all join job done in app it was rather easy to trace whats going on. 

I introduced method `includeHasManySimple` which handles only simple cases of `hasMany` - without `subIncludes`. This is how it works: 
* building id -> obj1 map in object form to make by-id queries easy 
* collects ids to query from 2nd model
* builds and run query on 2nd model
* after that result of 2nd query collected to id -> [obj] map which make by-id queries easy and fast again
* for each object in 1st map cache filled and `processTargetObj` called 

This allow to do blazing fast joins. 

Second thing to pay attention is `processTargetObj` function

`var inst = (obj instanceof self) ? obj : new self(obj);`

moved down to place where it really used, and as in a lot of cases `inst` is used in `if(obj === inst)` clause `isInst` value introduced. So in most cases `inst` never used and it makes `processTargetObj` very fast. 


BTW, I still not sure, but in my case `new self(obj);` takes about 230ms which looks very poor.  I still not found the reason of such behaviour.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/strongloop/loopback-datasource-juggler/704)
<!-- Reviewable:end -->
