### PR TITLE
Add support for matching array values à la mongo.

### DIFF
--- a/lib/connectors/memory.js
+++ b/lib/connectors/memory.js
@@ -416,7 +416,20 @@ function applyFilter(filter) {
         }
       }
 
-      if (test(where[key], getValue(obj, key))) {
+      var value = getValue(obj, key);
+      // Support referencesMany and other embedded relations
+      // Also support array types. Mongo, possibly PostgreSQL
+      if (Array.isArray(value)) {
+        var matcher  = where[key];
+        return value.some(function (v, i) {
+          var filter = {where: {}};
+          filter.where[i] = matcher;
+          return applyFilter(filter)(value);
+        });
+      }
+
+
+      if (test(where[key], value)) {
         return true;
       }
 
@@ -428,7 +441,7 @@ function applyFilter(filter) {
         var subFilter = {where: {}};
         var subKey = key.substring(dotIndex+1);
         subFilter.where[subKey] = where[key];
-        return !!subValue.filter(applyFilter(subFilter)).length
+        return subValue.some(applyFilter(subFilter));
       }
 
       return false;

--- a/test/memory.test.js
+++ b/test/memory.test.js
@@ -134,7 +134,6 @@ describe('Memory connector', function() {
     });
   });
 
-  // describe.only('Query for memory connector', function() {
   describe('Query for memory connector', function() {
     var ds = new DataSource({
       connector: 'memory'
@@ -306,6 +305,22 @@ describe('Memory connector', function() {
       User.find({where: {birthday: {between: [new Date(1990,0), Date.now()]}}},
                 function(err, users) {
         should(users.length).be.equal(0);
+        done();
+      });
+    });
+
+    it('should successfully extract 2 users matching array values', function (done) {
+      User.find({
+        where: {
+          'children': {
+            regexp: /an/
+          }
+        }
+      }, function (err, users) {
+        should.not.exist(err);
+        users.length.should.be.equal(2);
+        users[0].name.should.be.equal('John Lennon');
+        users[1].name.should.be.equal('George Harrison');
         done();
       });
     });
@@ -492,7 +507,8 @@ describe('Memory connector', function() {
             { name: 'Paul McCartney' },
             { name: 'George Harrison' },
             { name: 'Ringo Starr' },
-          ]
+          ],
+          children: ['Sean', 'Julian']
         },
         {
           seq: 1,
@@ -512,9 +528,10 @@ describe('Memory connector', function() {
             { name: 'John Lennon' },
             { name: 'George Harrison' },
             { name: 'Ringo Starr' },
-          ]
+          ],
+          children: ['Stella', 'Mary', 'Heather', 'Beatrice', 'James']
         },
-        {seq: 2, name: 'George Harrison', order: 5, vip: false},
+        {seq: 2, name: 'George Harrison', order: 5, vip: false, children: ['Dhani']},
         {seq: 3, name: 'Ringo Starr', order: 6, vip: false},
         {seq: 4, name: 'Pete Best', order: 4},
         {seq: 5, name: 'Stuart Sutcliffe', order: 3, vip: true}

--- a/test/memory.test.js
+++ b/test/memory.test.js
@@ -309,10 +309,10 @@ describe('Memory connector', function() {
       });
     });
 
-    it('should successfully extract 2 users matching array values', function (done) {
+    it('should successfully extract 2 users matching over array values', function (done) {
       User.find({
         where: {
-          'children': {
+          children: {
             regexp: /an/
           }
         }
@@ -321,6 +321,19 @@ describe('Memory connector', function() {
         users.length.should.be.equal(2);
         users[0].name.should.be.equal('John Lennon');
         users[1].name.should.be.equal('George Harrison');
+        done();
+      });
+    });
+
+    it('should successfully extract 1 users matching over array values', function (done) {
+      User.find({
+        where: {
+          children: 'Dhani'
+        }
+      }, function (err, users) {
+        should.not.exist(err);
+        users.length.should.be.equal(1);
+        users[0].name.should.be.equal('George Harrison');
         done();
       });
     });


### PR DESCRIPTION
Support mongo style matcher in where clause. 

embedsMany, referencesMany all have type array properties that can be filtered with when using loopback-mongo-connector. These don't have counterparts in relational dbs but precluding the use of the filters in the memory connectors complicates tests for mongo based apps.

Fixes the memory connector support mentionned in strongloop/loopback#953, strongloop/loopback#517.

Provides a baseline for the memory connector support of #625. At least for unit tests of a mongo based app.

Other issues related to this: #147 