### PR TITLE
dao: should not convert the val type if object

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1494,7 +1494,8 @@ DataAccessObject._coerce = function(where) {
           operator = 'regexp';
         } else if (operator === 'regexp' && val instanceof RegExp) {
           // Do not coerce regex literals/objects
-        } else if (!((operator === 'like' || operator === 'nlike') && val instanceof RegExp)) {
+        } else if (!((operator === 'like' || operator === 'nlike') &&
+          (val instanceof RegExp || val instanceof Object))) {
           val = DataType(val);
         }
       }

--- a/test/basic-querying.test.js
+++ b/test/basic-querying.test.js
@@ -525,31 +525,31 @@ describe('basic-querying', function() {
 
     it('should find first record (default sort by id)', function(done) {
       User.all({ order: 'id' }, function(err, users) {
-        User.findOne(function(e, u) {
-          should.not.exist(e);
-          should.exist(u);
-          u.id.toString().should.equal(users[0].id.toString());
+        User.findOne(function(err, user) {
+          should.not.exist(err);
+          should.exist(user);
+          user.id.toString().should.equal(users[0].id.toString());
           done();
         });
       });
     });
 
     it('should find first record', function(done) {
-      User.findOne({ order: 'order' }, function(e, u) {
-        should.not.exist(e);
-        should.exist(u);
-        u.order.should.equal(1);
-        u.name.should.equal('Paul McCartney');
+      User.findOne({ order: 'order' }, function(err, user) {
+        should.not.exist(err);
+        should.exist(user);
+        user.order.should.equal(1);
+        user.name.should.equal('Paul McCartney');
         done();
       });
     });
 
     it('should find last record', function(done) {
-      User.findOne({ order: 'order DESC' }, function(e, u) {
-        should.not.exist(e);
-        should.exist(u);
-        u.order.should.equal(6);
-        u.name.should.equal('Ringo Starr');
+      User.findOne({ order: 'order DESC' }, function(err, user) {
+        should.not.exist(err);
+        should.exist(user);
+        user.order.should.equal(6);
+        user.name.should.equal('Ringo Starr');
         done();
       });
     });
@@ -574,6 +574,21 @@ describe('basic-querying', function() {
           should.exist(user);
           done();
         });
+      });
+    });
+
+    it('should query by using database operator', function(done) {
+      User.findOne({
+        where: {
+          role: {
+            '$exists': false,
+          },
+        },
+        order: 'order DESC',
+      }, function(err, user) {
+        should.not.exist(err);
+        should.not.exist(user);
+        done();
       });
     });
 


### PR DESCRIPTION
If the value is an object, maybe we should not convert it to corresponding type like supporting:

```
{ '$exists': true }
```

/cc @raymondfeng
