### PR TITLE
foreignKey dataLength fix

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -1815,9 +1815,14 @@ DataSource.prototype.defineForeignKey = function defineForeignKey(className, key
 
   var fkDef = {type: pkType};
   var foreignMeta = this.columnMetadata(foreignClassName, pkName);
-  if(foreignMeta && foreignMeta.dataType) {
+  if (foreignMeta && (foreignMeta.dataType || foreignMeta.dataLength)) {
     fkDef[this.connector.name] = {};
-    fkDef[this.connector.name].dataType = foreignMeta.dataType;
+    if (foreignMeta.dataType) {
+      fkDef[this.connector.name].dataType = foreignMeta.dataType;
+    }
+    if (foreingMeta.dataLength) {
+      fkDef[this.connector.name].dataLength = foreignMeta.dataLength;
+    }
   }
   if (this.connector.defineForeignKey) {
     var cb = function (err, keyType) {

--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -1820,7 +1820,7 @@ DataSource.prototype.defineForeignKey = function defineForeignKey(className, key
     if (foreignMeta.dataType) {
       fkDef[this.connector.name].dataType = foreignMeta.dataType;
     }
-    if (foreingMeta.dataLength) {
+    if (foreignMeta.dataLength) {
       fkDef[this.connector.name].dataLength = foreignMeta.dataLength;
     }
   }


### PR DESCRIPTION
If the PK has a definition like
```
      "mysql": {
        "dataType": "CHAR",
        "dataLength":36,
        "nullable":"N"
      }
```

dataLength is ignored when the PK is used as a foreignKey in other models