### PR TITLE
`Validatable.validatesDateOf()` replacing exception thrown for invalid dates.

### DIFF
--- a/lib/model-builder.js
+++ b/lib/model-builder.js
@@ -425,6 +425,9 @@ ModelBuilder.prototype.define = function defineClass(className, properties, sett
       var requiredOptions = typeof prop.required === 'object' ? prop.required : undefined;
       ModelClass.validatesPresenceOf(propertyName, requiredOptions);
     }
+    if (DataType === Date) {
+      ModelClass.validatesDateOf(propertyName);
+    }
 
     Object.defineProperty(ModelClass.prototype, propertyName, {
       get: function () {
@@ -526,10 +529,10 @@ ModelBuilder.prototype.define = function defineClass(className, properties, sett
 
 // DataType for Date
 function DateType(arg) {
-  var d = new Date(arg);
-  if (isNaN(d.getTime())) {
-    throw new Error('Invalid date: ' + arg);
+  if (arg === null) {
+    return null;
   }
+  var d = new Date(arg);
   return d;
 }
 

--- a/lib/validations.js
+++ b/lib/validations.js
@@ -228,6 +228,8 @@ Validatable.validateAsync = getConfigurator('custom', {async: true});
  */
 Validatable.validatesUniquenessOf = getConfigurator('uniqueness', {async: true});
 
+Validatable.validatesDateOf = getConfigurator('date');
+
 // implementation of validators
 
 /*!
@@ -358,6 +360,18 @@ function validateUniqueness(attr, conf, err, done) {
   }.bind(this));
 }
 
+/*!
+ * Date validator
+ */
+function validateDate(attr, conf, err) {
+  if (this[attr] === null || this[attr] === undefined) return;
+
+  var date = new Date(this[attr]);
+  if (isNaN(date.getTime())) {
+    return err();
+  }
+}
+
 var validators = {
   presence: validatePresence,
   absence: validateAbsence,
@@ -367,7 +381,8 @@ var validators = {
   exclusion: validateExclusion,
   format: validateFormat,
   custom: validateCustom,
-  uniqueness: validateUniqueness
+  uniqueness: validateUniqueness,
+  date: validateDate
 };
 
 function getConfigurator(name, opts) {
@@ -441,7 +456,6 @@ Validatable.prototype.isValid = function (callback, data) {
       asyncFail = false;
 
     var attrs = Object.keys(validations || {});
-
     attrs.forEach(function(attr) {
       var attrValidations = validations[attr] || [];
       attrValidations.forEach(function(v) {
@@ -600,7 +614,8 @@ var defaultMessages = {
   },
   inclusion: 'is not included in the list',
   exclusion: 'is reserved',
-  uniqueness: 'is not unique'
+  uniqueness: 'is not unique',
+  date: 'is not a valid date'
 };
 
 function nullCheck(attr, conf, err) {
@@ -801,7 +816,7 @@ function formatPropertyError(propertyName, propertyValue, errorMessage) {
   if (valueType === 'string') {
     formattedValue = JSON.stringify(truncatePropertyString(propertyValue));
   } else if (propertyValue instanceof Date) {
-    formattedValue = propertyValue.toISOString();
+    formattedValue = isNaN(propertyValue.getTime()) ? propertyValue.toString() : propertyValue.toISOString();
   } else if (valueType === 'object') {
     // objects and arrays
     formattedValue = util.inspect(propertyValue, {

--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -1159,12 +1159,9 @@ describe('manipulation', function () {
       p1 = new Person({name: 'John', dob: undefined});
       p1.should.have.property('dob', undefined);
 
-      try {
-        p1 = new Person({name: 'John', dob: 'X'});
-        throw new Error('new Person() should have thrown');
-      } catch (e) {
-        e.should.be.eql(new Error('Invalid date: X'));
-      }
+      p1 = new Person({name: 'John', dob: 'X'});
+      p1.should.have.property('dob');
+      p1.dob.toString().should.be.eql('Invalid Date');
     });
   });
 

--- a/test/validations.test.js
+++ b/test/validations.test.js
@@ -615,4 +615,80 @@ describe('validations', function () {
       return err.message.replace(/^.*Details: /, '');
     }
   });
+
+  describe('date', function () {
+    it('should validate a date object', function() {
+      User.validatesDateOf('updatedAt');
+      var u = new User({updatedAt: new Date()});
+      u.isValid().should.be.true;
+    });
+
+    it('should validate a date string', function() {
+      User.validatesDateOf('updatedAt');
+      var u = new User({updatedAt: '2000-01-01'});
+      u.isValid().should.be.true;
+    });
+
+    it('should validate a null date', function() {
+      User.validatesDateOf('updatedAt');
+      var u = new User({updatedAt: null});
+      u.isValid().should.be.true;
+    });
+
+    it('should validate an undefined date', function() {
+      User.validatesDateOf('updatedAt');
+      var u = new User({updatedAt: undefined});
+      u.isValid().should.be.true;
+    });
+
+    it('should validate an invalid date string', function() {
+      User.validatesDateOf('updatedAt');
+      var u = new User({updatedAt: 'invalid date string'});
+      u.isValid().should.not.be.true;
+      u.errors.should.eql({ 
+        updatedAt: [ 'is not a valid date' ],
+        codes: {
+          updatedAt: ['date']
+        }
+      });
+    });
+
+    it('should attach validation by default to all date properties', function() {
+      var AnotherUser = db.define('User', {
+        email: String,
+        name: String,
+        password: String,
+        state: String,
+        age: Number,
+        gender: String,
+        domain: String,
+        pendingPeriod: Number,
+        createdByAdmin: Boolean,
+        createdByScript: Boolean,
+        updatedAt: Date
+      });
+      var u = new AnotherUser({updatedAt: 'invalid date string'});
+      u.isValid().should.not.be.true;
+      u.errors.should.eql({ 
+        updatedAt: [ 'is not a valid date' ],
+        codes: {
+          updatedAt: ['date']
+        }
+      });
+    });
+
+    it('should overwrite default blank message with custom format message', function() {
+      var CUSTOM_MESSAGE = 'custom validation message';
+      User.validatesDateOf('updatedAt', {message: CUSTOM_MESSAGE});
+      var u = new User({updatedAt: 'invalid date string'});
+      u.isValid().should.not.be.true;
+      u.errors.should.eql({ 
+        updatedAt: [ CUSTOM_MESSAGE ],
+        codes: {
+          updatedAt: ['date']
+        }
+      });
+    });
+  });
+
 });


### PR DESCRIPTION
Please review this PR that fixes issue #592, but also takes a broader approach on how loopback handles invalid dates. 
- _Current behavior_ - Making a `POST` request or instantiating a model with the following data throws an exception:

```
{
  "createdAt": "2015-13-13"
}
```

I would like to propose changing this behavior since it allows any client to crash the server with invalid data. Unfortunately, trying to catch the error on the server is not possible by adding custom validation methods, since parsing the data into a model (and throwing the exception) happens before any validation method is called. The only feasible solution I see for this problem is to implement a `before save` hook on _every_ model that contains a date field or maybe implement some middleware to handle date field errors (? not tested).
- _Proposed behavior_ - Providing a `validatesDateOf()` method which is added to any date field by default could be the cleaner solution. Making a request to the REST API with an invalid date field triggers a proper validation error as a client would expect it. Instantiating a model with an invalid date would not throw an exception, but calling `isValid()` on it would return false, without having to add the validation method explicitly. Removing the default validation method can easily be done if so desired.