### PR TITLE
findByIds would fail when an array of 0 length was passed as its first argument

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -909,7 +909,7 @@ DataAccessObject.findByIds = function(ids, query, options, cb) {
   if (isPKMissing(this, cb)) {
     return cb.promise;
   } else if (ids.length === 0) {
-    process.nextTick(cb(null, []));
+    process.nextTick(function(){cb(null, []);});
     return cb.promise;
   }
 


### PR DESCRIPTION
This is a regression introduced in 2.39.0.
process.nextTick expects a function as its argument however in this case it was being given undefined with the result of a warning 'TypeError: callback is not a function'.