### PR TITLE
Ability to define normalization of undefined query

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -934,6 +934,27 @@ DataAccessObject.all = function () {
   return DataAccessObject.find.apply(this, arguments);
 };
 
+/**
+ * Get settings via hiarchical determiniation
+ *
+ * @param {String} key The setting key
+ */
+DataAccessObject._getSetting = function(key) {
+  // Check for settings in model
+  var m = this.definition;
+  if(m && m.settings && m.settings[key]) {
+    return m.settings[key]
+  }
+
+  // Check for settings in connector
+  var ds = this.getDataSource();
+  if(ds && ds.settings && ds.settings[key]) {
+    return ds.settings[key];
+  }
+
+  return;
+};
+
 var operators = {
   gt: '>',
   gte: '>=',
@@ -955,6 +976,7 @@ var operators = {
  * @private
  */
 DataAccessObject._normalize = function (filter) {
+
   if (!filter) {
     return undefined;
   }
@@ -1032,9 +1054,8 @@ DataAccessObject._normalize = function (filter) {
       Object.keys(this.definition.properties), this.settings.strict);
   }
 
-  var handleUndefined = this.getConnector().settings.normalizeUndefinedInQuery;
+  var handleUndefined =  this._getSetting('normalizeUndefinedInQuery');
   // alter configuration of how removeUndefined handles undefined values
-  // @TODO should refactor `removeUndefined` to something like `handleUndefined`
   filter = removeUndefined(filter, handleUndefined);
   this._coerce(filter.where);
   return filter;

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1032,7 +1032,10 @@ DataAccessObject._normalize = function (filter) {
       Object.keys(this.definition.properties), this.settings.strict);
   }
 
-  filter = removeUndefined(filter);
+  var handleUndefined = this.getConnector().settings.normalizeUndefinedInQuery;
+  // alter configuration of how removeUndefined handles undefined values
+  // @TODO should refactor `removeUndefined` to something like `handleUndefined`
+  filter = removeUndefined(filter, handleUndefined);
   this._coerce(filter.where);
   return filter;
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -292,9 +292,10 @@ function selectFields(fields) {
 /**
  * Remove undefined values from the queury object
  * @param query
+ * @param handleUndefined {String} either "setNull", "throwError" or "strip" (default: "strip")
  * @returns {exports.map|*}
  */
-function removeUndefined(query) {
+function removeUndefined(query, handleUndefined) {
   if (typeof query !== 'object' || query === null) {
     return query;
   }
@@ -302,7 +303,17 @@ function removeUndefined(query) {
   // as traverse doesn't transform the ObjectId correctly
   return traverse(query).forEach(function (x) {
     if (x === undefined) {
-      this.remove();
+      switch (handleUndefined) {
+        case 'setNull':
+          this.update(null);
+          break;
+        case 'throwError':
+          throw new Error('Unexpected `undefined` in query');
+          break;
+        case 'strip':
+        default:
+          this.remove();
+      }
     }
 
     if (!Array.isArray(x) && (typeof x === 'object' && x !== null
@@ -389,7 +400,7 @@ function mergeSettings(target, src) {
           // The source item value is an object
           if (target == null || typeof target !== 'object' ||
             target[key] == null) {
-            // If target is not an object or target item value 
+            // If target is not an object or target item value
             dst[key] = srcValue;
           } else {
             dst[key] = mergeSettings(target[key], src[key]);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -292,7 +292,7 @@ function selectFields(fields) {
 /**
  * Remove undefined values from the queury object
  * @param query
- * @param handleUndefined {String} either "setNull", "throwError" or "strip" (default: "strip")
+ * @param handleUndefined {String} either "nullify", "throw" or "ignore" (default: "ignore")
  * @returns {exports.map|*}
  */
 function removeUndefined(query, handleUndefined) {
@@ -304,13 +304,13 @@ function removeUndefined(query, handleUndefined) {
   return traverse(query).forEach(function (x) {
     if (x === undefined) {
       switch (handleUndefined) {
-        case 'setNull':
+        case 'nullify':
           this.update(null);
           break;
-        case 'throwError':
+        case 'throw':
           throw new Error('Unexpected `undefined` in query');
           break;
-        case 'strip':
+        case 'ignore':
         default:
           this.remove();
       }

--- a/test/loopback-dl.test.js
+++ b/test/loopback-dl.test.js
@@ -1487,6 +1487,23 @@ describe('DataAccessObject', function () {
     assert.deepEqual(filter, {limit: 100, offset: 5, skip: 5});
   });
 
+  it('should apply settings for handling undefined', function () {
+    filter = model._normalize({filter: { x: undefined }});
+    assert.deepEqual(filter, {filter: {}});
+
+    ds.settings.normalizeUndefinedInQuery = 'setNull';
+    filter = model._normalize({filter: { x: undefined }});
+    assert.deepEqual(filter, {filter: { x: null }});
+
+    ds.settings.normalizeUndefinedInQuery = 'throwError';
+    try {
+      filter = model._normalize({filter: { x: undefined }});
+    }
+    catch(err) {
+      assert.ok(err instanceof Error);
+    }
+  });
+
   it('should skip GeoPoint', function () {
     where = model._coerce({location: {near: {lng: 10, lat: 20}, maxDistance: 20}});
     assert.deepEqual(where, {location: {near: {lng: 10, lat: 20}, maxDistance: 20}});
@@ -1796,4 +1813,3 @@ describe('ModelBuilder options.models', function () {
     });
 
 });
-

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -68,15 +68,10 @@ describe('util.removeUndefined', function () {
 
     // test handling of undefined
     var q5 = {where: {x: 1, y: undefined}};
-    should.deepEqual(removeUndefined(q5, 'setNull'), {where: {x: 1, y: null}});
+    should.deepEqual(removeUndefined(q5, 'nullify'), {where: {x: 1, y: null}});
 
     var q6 = {where: {x: 1, y: undefined}};
-    try {
-      removeUndefined(q6, 'throwError');
-    }
-    catch(err) {
-      err.should.be.instanceof(Error);
-    }
+    (function(){ removeUndefined(q6, 'throw') }).should.throw(/`undefined` in query/);
 
   });
 });

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -66,6 +66,18 @@ describe('util.removeUndefined', function () {
     var q4 = {where: {x: 1, y: date}};
     should.deepEqual(removeUndefined(q4), {where: {x: 1, y: date}});
 
+    // test handling of undefined
+    var q5 = {where: {x: 1, y: undefined}};
+    should.deepEqual(removeUndefined(q5, 'setNull'), {where: {x: 1, y: null}});
+
+    var q6 = {where: {x: 1, y: undefined}};
+    try {
+      removeUndefined(q6, 'throwError');
+    }
+    catch(err) {
+      err.should.be.instanceof(Error);
+    }
+
   });
 });
 


### PR DESCRIPTION
Add setting to datasource `normalizeUndefinedInQuery` to determine how
it will handle undefined values. Options:

- setNull : converts undefined to null
- throwError : throw an error on undefined value
- strip : strip the key where undefined value is found

Defualt operation is to strip the key.