### PR TITLE
Fix coercion

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1061,7 +1061,7 @@ DataAccessObject._normalize = function (filter) {
   var handleUndefined =  this._getSetting('normalizeUndefinedInQuery');
   // alter configuration of how removeUndefined handles undefined values
   filter = removeUndefined(filter, handleUndefined);
-  this._coerce(filter.where);
+  filter.where = this._coerce(filter.where);
   return filter;
 };
 
@@ -1119,16 +1119,17 @@ DataAccessObject._coerce = function (where) {
     // Handle logical operators
     if (p === 'and' || p === 'or' || p === 'nor') {
       var clauses = where[p];
+      where[p] = [];
       if (Array.isArray(clauses)) {
         for (var k = 0; k < clauses.length; k++) {
-          self._coerce(clauses[k]);
+          where[p][k] = self._coerce(clauses[k]);
         }
+        continue;
       } else {
         err = new Error(util.format('The %s operator has invalid clauses %j', p, clauses));
         err.statusCode = 400;
         throw err;
       }
-      return where;
     }
     var DataType = props[p] && props[p].type;
     if (!DataType) {

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1061,7 +1061,12 @@ DataAccessObject._normalize = function (filter) {
   var handleUndefined =  this._getSetting('normalizeUndefinedInQuery');
   // alter configuration of how removeUndefined handles undefined values
   filter = removeUndefined(filter, handleUndefined);
-  filter.where = this._coerce(filter.where);
+
+  var where = this._coerce(filter.where);
+  if (where !== undefined) {
+    filter.where = where;
+  }
+
   return filter;
 };
 

--- a/test/loopback-dl.test.js
+++ b/test/loopback-dl.test.js
@@ -1364,6 +1364,11 @@ describe('DataAccessObject', function () {
     assert.deepEqual(where, {or: [{age: 10}, {vip: true}]});
   });
 
+  it('should be able to coerce where clause with properties following a logical operation', function () {
+    where = model._coerce({and : [{scores: '0'}, {scores: '2'}], age: '10'});
+    assert.strictEqual(where.age, 10);
+  });
+
   it('should throw if the where property is not an object', function () {
     try {
       // The where clause has to be an object


### PR DESCRIPTION
The coercion function seemed to have some behaviours that didn't make sense:
- The way that the reference is used mutably is confusing in some situations.
- Coercion was abandoned after the use of a logical operator such as 'and', due to a return statement being used erroneously.

As a result of these inconsistencies, when I used a filter with an "and" in it on a query that also contained a foreign key, the `_coerce` function would be abandoned before the foreign key could be coerced to an ObjectId. This resulted in a query with a string, returning an empty result and breaking our queries!

This solution fixes that edge case, while also passing all tests. I'm not extremely happy with my efforts in 4f53ccf to meet tests, but I am at least content!
