### PR TITLE
Added missing callback when results are filtered

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1464,6 +1464,8 @@ DataAccessObject.find = function find(query, options, cb) {
             results.push(obj);
             callback();
           });
+        } else {
+          callback();
         }
       },
       function(err) {


### PR DESCRIPTION
`allCb`, the helper function used in `find` wasn't calling a callback in certain cases.

That caused the server to hang in certain scenarios (eg. when filtering results in resources accessed by a hasManyThrough relationship).
This PR fixes bug https://github.com/strongloop/loopback/issues/1737
You can test the problem here: https://github.com/framp/loopback-bug-1737 (reverting the last commit which contains the solution).

The data provided to `allCb` was
```
[ { customerId: 1, itemId: 1, id: 1, item: { name: 'a', id: 1 } },
  { customerId: 1, itemId: 2, id: 2 } ]
```
The second item wasn't calling `callback`.