### PR TITLE
Fix search statements becomes "[object Object]"

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1179,7 +1179,7 @@ DataAccessObject._coerce = function (where) {
     // Check there is an operator
     var operator = null;
     var exp = val;
-    if (val.constructor === Object) {
+    if (typeof val==='object') {
       for (var op in operators) {
         if (op in val) {
           val = val[op];


### PR DESCRIPTION
fix issues nlike,inq,nin,between,regexp VALUE becomes "[object object]"
