### PR TITLE
Capture includeHasMany() as a find()'s caller by findCaller option

### DIFF
--- a/lib/include.js
+++ b/lib/include.js
@@ -507,7 +507,7 @@ Inclusion.include = function (objects, include, options, cb) {
         inq: uniq(sourceIds)
       };
       relation.applyScope(null, filter);
-      options.findCaller = 'includeHasMany';
+      options.partitionBy = relation.keyTo;
       relation.modelTo.find(filter, options, targetFetchHandler);
       /**
        * Process fetched related objects

--- a/lib/include.js
+++ b/lib/include.js
@@ -507,6 +507,7 @@ Inclusion.include = function (objects, include, options, cb) {
         inq: uniq(sourceIds)
       };
       relation.applyScope(null, filter);
+      options.findCaller = 'includeHasMany';
       relation.modelTo.find(filter, options, targetFetchHandler);
       /**
        * Process fetched related objects


### PR DESCRIPTION
To replace incorrect location of capturing this condition in find() in
loopback-connector/lib/sql.js  proposed earlier in
https://github.com/strongloop/loopback-connector/pull/34.

Being set to 'includeHasMany', findCaller option triggers injection of
PARTITION BY clause in buildColumnNames() in
loopback-connector-mssql/lib/mssql.js only when find() function is
called to process include filter with 'has many' relation.