### PR TITLE
change the test script for package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "depd": "./lib/browser.depd.js"
   },
   "scripts": {
-    "test": "make test"
+    "test": "NO_DEPRECATION=loopback-datasource-juggler mocha --growl"
   },
   "engines": [
     "node >= 0.6"


### PR DESCRIPTION
In order to generate the mocha test report, our automation script will invoke "npm test" and it needs to detect that mocha is a command in the test script so we move the command in the test case in the Makefile to here.