### PR TITLE
Correction of a regression introduced by commit 632898b

### DIFF
--- a/lib/connectors/memory.js
+++ b/lib/connectors/memory.js
@@ -421,6 +421,11 @@ function applyFilter(filter) {
       // Also support array types. Mongo, possibly PostgreSQL
       if (Array.isArray(value)) {
         var matcher  = where[key];
+        // The following condition is for the case where we are querying with
+        // a neq filter, and when the value is an empty array ([]).
+        if (matcher.neq !== undefined && value.length <= 0) {
+          return true;
+        }
         return value.some(function (v, i) {
           var filter = {where: {}};
           filter.where[i] = matcher;

--- a/test/memory.test.js
+++ b/test/memory.test.js
@@ -338,6 +338,19 @@ describe('Memory connector', function() {
       });
     });
 
+    it('should successfully extract 5 users matching a neq filter over array values', function (done) {
+      User.find({
+        where: {
+          'children': {neq: 'Dhani'}
+        }
+      }, function (err, users) {
+        should.not.exist(err);
+        console.log(users);
+        users.length.should.be.equal(5);
+        done();
+      });
+    });
+
     it('should count using date string', function(done) {
       User.count({birthday: {lt: new Date(1990,0).toISOString()}},
         function(err, count) {
@@ -546,7 +559,7 @@ describe('Memory connector', function() {
         },
         {seq: 2, name: 'George Harrison', order: 5, vip: false, children: ['Dhani']},
         {seq: 3, name: 'Ringo Starr', order: 6, vip: false},
-        {seq: 4, name: 'Pete Best', order: 4},
+        {seq: 4, name: 'Pete Best', order: 4, children: []},
         {seq: 5, name: 'Stuart Sutcliffe', order: 3, vip: true}
       ];
 


### PR DESCRIPTION
Correction of a regression introduced by commit 632898b: when querying an empty array ([]) with a 'neq' filter, there were no matching.

For example:

a filter like this one:

’children': {
	neq: 'barack'
}

On a set contain this object:

{
  children: [],
  id: 1
}

would not find any match.

Thanks to the correction I propose, the preceding situation leads to a match.
