### PR TITLE
Ignored Error

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -2449,6 +2449,7 @@ DataAccessObject.prototype.updateAttributes = function updateAttributes(data, op
           context.data = typedData;
 
           function updateAttributesCallback(err) {
+            if (err) return cb(err);
             var ctx = {
               Model: Model,
               data: context.data,


### PR DESCRIPTION
I came across this bug when an update attribute call was violating a database restriction. In this case the api call returned 200 and didn't update the database.

Since I don't know what the Strongloop/Loopback standards are for protecting database information in error messages.  I just propagated the database error out the the frontend. 

This is my first time putting in a Pull request for opensource software so guidance about if I'm doing it right or not is appreciated.


Thanks for loopback. It's great
-Abe Barth-Werb