### PR TITLE
silence a warning that introduced in bluebird 3.0.x

### DIFF
--- a/lib/observer.js
+++ b/lib/observer.js
@@ -98,7 +98,7 @@ ObserverMixin.notifyObserversOf = function(operation, context, callback) {
         var retval = fn(context, next);
         if (retval && typeof retval.then === 'function') {
           retval.then(
-            function() { next(); },
+            function() { next(); return null; },
             next // error handler
           );
         }


### PR DESCRIPTION
see http://bluebirdjs.com/docs/warning-explanations.html#warning-a-promise-was-created-in-a-handler-but-none-were-returned-from-it

Signed-off-by: Clark Wang <clark.wangs@gmail.com>