### PR TITLE
strict validation fails on invalid relations mixed with valid relations

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -198,7 +198,6 @@ ModelBaseClass.prototype._initProperties = function (data, options) {
         var typeName = multiple ? 'Array' : modelTo.modelName;
         var propType = multiple ? [modelTo] : modelTo;
         properties[p] = { name: typeName, type: propType };
-        this.setStrict(false);
       }
 
       // Relation


### PR DESCRIPTION
Fixes #780 

All test still pass after removing the offending line. Please review and suggest changes if this is undesired.
