### PR TITLE
Allow the default scope to be overridden

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -180,7 +180,7 @@ function mergeQuery(base, update, spec) {
       else{
         //default behaviour of inclusion merge - merge inclusions at the same
         //level. - https://github.com/strongloop/loopback-datasource-juggler/pull/569#issuecomment-95310874
-        base.include = mergeIncludes(base.include, update.include);
+        base.include = mergeIncludes(update.include, base.include);
       }
     }
   }


### PR DESCRIPTION
When working with scopes + default scope I realized a behavior that does not seem to be intended: Whenever you define a default scope, every `include` in this scope will be immutable in every request.
It will also shadow any call to the scope-remote-method.

In my opinion, this problem was introduced in #569 . Think of the following configuration:
##### modelA.json:
```
{
    ...
    "scope": {
        "include": ["modelB"]
    },
    "scopes": {
        "modelBFiltered": {
            "include": [{
                "relation": "modelB",
                "scope": {
                    "where": {
                        "active": true
                    }
                }
            }]
        }
    }
}
```

##### test.js
````
ModelA.find() 
// -> ModelA-Instances, with *all* modelB-relations (as expected)

ModelA.find({
    include: {
        relation: 'modelB',
        scope: {
            where: {
                active: true
            }
        }
    }
})
// -> ModelA-Instances, with *all* modelB-relations 
// (you'd expect only the active ones, but that doesn't work)

ModelA.modelBFiltered() 
// -> ModelA-Instances, with *all* modelB-relations
// (you'd expect only the active ones, but that doesn't work)
```

So basically, if you define an `include` in your default scope, you **cannot** filter on that relation.

This PR **does** have security-implications, because with the change one might override an include that was intended to be restricted (think my example, but the other way around). I don't see any solution to this but to be honest, that must not be a task the `scope` should solve, because any relation not explicitly specified in the default scope can be included either way.