### PR TITLE
[SEMVER-MAJOR] Always use bluebird as the Promise implementation

### DIFF
--- a/3.0-RELEASE-NOTES.md
+++ b/3.0-RELEASE-NOTES.md
@@ -5,3 +5,17 @@ always describe the impact on users and instructions for upgrading
 applications from 2.x to 3.0.
 
 See also https://github.com/strongloop/loopback/blob/master/3.0-DEVELOPING.md
+
+## Always use bluebird as promise library
+
+In version 3.0, we always use bluebird as our promise library
+instead of `global.Promise`.
+We consider Bluebird API a part of LoopBack API from now on,
+you are welcome to use any Bluebird-specific methods in your applications.
+
+If you are using LoopBack with a custom promise implementation provided
+via `global.Promise`,
+you will have to check all places where you are using non-standard promise API
+and update them to use Bluebird API instead.
+
+Please see [Related code change](https://github.com/strongloop/loopback-datasource-juggler/pull/790) here.

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -407,7 +407,7 @@ function defineScope(cls, targetClass, name, params, methods, options) {
         }
       }
     }
-    
+
     options = options || {};
     filter = filter || {};
     var targetModel = definition.targetModel(this._receiver);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -19,6 +19,7 @@ exports.findIndexOf = findIndexOf;
 
 var traverse = require('traverse');
 var assert = require('assert');
+var Promise = require('bluebird');
 
 function safeRequire(module) {
   try {
@@ -478,15 +479,6 @@ function sortObjectsByIds(idName, ids, objects, strict) {
 
 function createPromiseCallback() {
   var cb;
-
-  if (!global.Promise) {
-    cb = function(){};
-    cb.promise = {};
-    Object.defineProperty(cb.promise, 'then', { get: throwPromiseNotDefined });
-    Object.defineProperty(cb.promise, 'catch', { get: throwPromiseNotDefined });
-    return cb;
-  }
-
   var promise = new Promise(function (resolve, reject) {
     cb = function (err, data) {
       if (err) return reject(err);
@@ -495,12 +487,6 @@ function createPromiseCallback() {
   });
   cb.promise = promise;
   return cb;
-}
-
-function throwPromiseNotDefined() {
-  throw new Error(
-    'Your Node runtime does support ES6 Promises. ' +
-    'Set "global.Promise" to your preferred implementation of promises.');
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
     "node >= 0.6"
   ],
   "devDependencies": {
-    "bluebird": "^2.9.9",
     "mocha": "^2.1.0",
     "should": "^8.0.2"
   },
   "dependencies": {
     "async": "~1.0.0",
+    "bluebird": "^3.1.1",
     "debug": "^2.1.1",
     "depd": "^1.0.0",
     "inflection": "^1.6.0",

--- a/test/async-observer.test.js
+++ b/test/async-observer.test.js
@@ -1,5 +1,6 @@
 var ModelBuilder = require('../').ModelBuilder;
 var should = require('./init');
+var Promise = require('bluebird');
 
 describe('async observer', function() {
   var TestModel;

--- a/test/init.js
+++ b/test/init.js
@@ -26,7 +26,3 @@ if (!('getModelBuilder' in global)) {
     return new ModelBuilder();
   };
 }
-
-if (!('Promise' in global)) {
-  global.Promise = require('bluebird');
-}


### PR DESCRIPTION
This pr is created for updating files to use `bluebird` as promise library.
Details see here:
Connect to strongloop-internal/scrum-loopback#615

Related: https://github.com/strongloop/loopback/pull/1896
