### PR TITLE
Add parameter caseInsensitive to validatesUniquenessOf validator

### DIFF
--- a/lib/validations.js
+++ b/lib/validations.js
@@ -225,6 +225,7 @@ Validatable.validateAsync = getConfigurator('custom', {async: true});
  * @property {RegExp} with Regular expression to validate format.
  * @property {Array.<String>} scopedTo List of properties defining the scope.
  * @property {String} message Optional error message if property is not valid.  Default error message: "is not unique".
+ * @property {String} caseInsensitive Make the validation case insensitive
  */
 Validatable.validatesUniquenessOf = getConfigurator('uniqueness', {async: true});
 
@@ -332,7 +333,12 @@ function validateUniqueness(attr, conf, err, done) {
     return process.nextTick(done);
   }
   var cond = {where: {}};
-  cond.where[attr] = this[attr];
+
+  if(conf && conf.caseInsensitive) {
+    cond.where[attr] = new RegExp(this[attr], 'i');
+  } else {
+    cond.where[attr] = this[attr];
+  }
 
   if (conf && conf.scopedTo) {
     conf.scopedTo.forEach(function(k) {

--- a/test/validations.test.js
+++ b/test/validations.test.js
@@ -462,6 +462,22 @@ describe('validations', function () {
         })).should.be.false;
       });
     });
+
+    it('should validate uniqueness c-i', function (done) {
+      User.validatesUniquenessOf('email', { caseInsensitive: true });
+      var u = new User({email: 'hey'});
+      Boolean(u.isValid(function (valid) {
+        valid.should.be.true;
+        u.save(function () {
+          var u2 = new User({email: 'HEY'});
+          u2.isValid(function (valid) {
+            valid.should.be.false;
+            done();
+          });
+        });
+      })).should.be.false;
+    });
+
   });
 
   describe('format', function () {


### PR DESCRIPTION
This patch adds an option to check the uniqueness of a value in a case insensitive way. 

Should fix #607, though I'm not sure if I overlooked any edge cases.