### PR TITLE
Feature/all loaded hook + access callback in context

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -266,7 +266,7 @@ DataAccessObject.create = function (data, options, cb) {
     if (options.validate === undefined && Model.settings.automaticValidation === false) {
       return create();
     }
-    
+
     // validation required
     obj.isValid(function (valid) {
       if (valid) {
@@ -1516,7 +1516,18 @@ DataAccessObject.find = function find(query, options, cb) {
           results = geo.filter(results, near);
         }
 
-        cb(err, results);
+        if (options.notify === false || !(results && results.length > 0)) return cb(err, results);
+
+        context = {
+          Model: self,
+          hookState: hookState,
+          results: results,
+          options: options
+        };
+
+        self.notifyObserversOf('allLoaded', context, function(err) {
+          cb(err, results);
+        });
       });
     }
     else {

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -435,7 +435,8 @@ DataAccessObject.updateOrCreate = DataAccessObject.upsert = function upsert(data
     Model: Model,
     query: byIdQuery(Model, id),
     hookState: hookState,
-    options: options
+    options: options,
+    end: cb
   };
   Model.notifyObserversOf('access', context, doUpdateOrCreate);
 
@@ -1406,7 +1407,8 @@ DataAccessObject.find = function find(query, options, cb) {
         Model: self,
         query: query,
         hookState: hookState,
-        options: options
+        options: options,
+        end: cb
       };
       self.notifyObserversOf('access', context, function(err, ctx) {
         if (err) return cb(err);
@@ -1546,7 +1548,8 @@ DataAccessObject.find = function find(query, options, cb) {
       Model: this,
       query: query,
       hookState: hookState,
-      options: options
+      options: options,
+      end: cb
     };
     this.notifyObserversOf('access', context, function(err, ctx) {
       if (err) return cb(err);
@@ -1668,7 +1671,8 @@ DataAccessObject.remove = DataAccessObject.deleteAll = DataAccessObject.destroyA
       Model: Model,
       query: query,
       hookState: hookState,
-      options: options
+      options: options,
+      end: cb
     };
     Model.notifyObserversOf('access', context, function(err, ctx) {
         if (err) return cb(err);
@@ -1866,7 +1870,8 @@ DataAccessObject.count = function (where, options, cb) {
     Model: Model,
     query: { where: where },
     hookState: hookState,
-    options: options
+    options: options,
+    end: cb
   };
   this.notifyObserversOf('access', context, function(err, ctx) {
     if (err) return cb(err);
@@ -2109,7 +2114,8 @@ DataAccessObject.updateAll = function (where, data, options, cb) {
     Model: Model,
     query: { where: where },
     hookState: hookState,
-    options: options
+    options: options,
+    end: cb
   };
   Model.notifyObserversOf('access', context, function(err, ctx) {
     if (err) return cb(err);
@@ -2227,7 +2233,8 @@ DataAccessObject.prototype.remove =
         Model: Model,
         query: byIdQuery(Model, id),
         hookState: hookState,
-        options: options
+        options: options,
+        end: cb
       };
 
       Model.notifyObserversOf('access', context, function(err, ctx) {

--- a/test/persistence-hooks.suite.js
+++ b/test/persistence-hooks.suite.js
@@ -62,7 +62,8 @@ module.exports = function(dataSource, should) {
 
             triggered.should.eql([
               'access',
-              'loaded'
+              'loaded',
+              'allLoaded'
             ]);
             done();
           });
@@ -537,6 +538,7 @@ module.exports = function(dataSource, should) {
           { name: 'new-record' },
           function(err, record, created) {
             if (err) return done(err);
+            console.log(triggered);
             triggered.should.eql([
               'access',
               'before save',
@@ -567,7 +569,8 @@ module.exports = function(dataSource, should) {
             } else {
               triggered.should.eql([
                 'access',
-                'loaded'
+                'loaded',
+                'allLoaded'
               ]);
             }
             done();

--- a/test/persistence-hooks.suite.js
+++ b/test/persistence-hooks.suite.js
@@ -467,6 +467,8 @@ module.exports = function(dataSource, should) {
 
         var cb = function(err, record, created) {
           if (err) return done(err);
+          // Workaround to fix unoptimized...
+          if (observedContexts.end) delete observedContexts.end;
           observedContexts.should.eql(aTestModelCtx({
             query: {
               where: { name: 'new-record' },

--- a/test/persistence-hooks.suite.js
+++ b/test/persistence-hooks.suite.js
@@ -72,13 +72,16 @@ module.exports = function(dataSource, should) {
       it('triggers `access` hook', function(done) {
         TestModel.observe('access', pushContextAndNext());
 
-        TestModel.find({ where: { id: '1' } }, function(err, list) {
+        var cb = function(err, list) {
           if (err) return done(err);
           observedContexts.should.eql(aTestModelCtx({
-            query: { where: { id: '1' } }
+            query: { where: { id: '1' } },
+            end: cb
           }));
           done();
-        });
+        };
+
+        TestModel.find({ where: { id: '1' } }, cb);
       });
 
       it('aborts when `access` hook fails', function(done) {
@@ -106,13 +109,16 @@ module.exports = function(dataSource, should) {
       it('triggers `access` hook for geo queries', function(done) {
         TestModel.observe('access', pushContextAndNext());
 
-        TestModel.find({ where: { geo: { near: '10,20' }}}, function(err, list) {
+        var cb = function(err, list) {
           if (err) return done(err);
           observedContexts.should.eql(aTestModelCtx({
-            query: { where: { geo: { near: '10,20' } } }
+            query: { where: { geo: { near: '10,20' } } },
+            end: cb
           }));
           done();
-        });
+        };
+
+        TestModel.find({ where: { geo: { near: '10,20' }}}, cb);
       });
 
       it('applies updates from `access` hook for geo queries', function(done) {
@@ -459,19 +465,23 @@ module.exports = function(dataSource, should) {
       it('triggers `access` hook', function(done) {
         TestModel.observe('access', pushContextAndNext());
 
-        TestModel.findOrCreate(
-          { where: { name: 'new-record' } },
-          { name: 'new-record' },
-          function(err, record, created) {
-            if (err) return done(err);
-            observedContexts.should.eql(aTestModelCtx({ query: {
+        var cb = function(err, record, created) {
+          if (err) return done(err);
+          observedContexts.should.eql(aTestModelCtx({
+            query: {
               where: { name: 'new-record' },
               limit: 1,
               offset: 0,
               skip: 0
-            }}));
-            done();
-          });
+            }
+          }));
+          done();
+        };
+
+        TestModel.findOrCreate(
+          { where: { name: 'new-record' } },
+          { name: 'new-record' },
+          cb);
       });
 
       if (dataSource.connector.findOrCreate) {
@@ -889,13 +899,15 @@ module.exports = function(dataSource, should) {
       it('triggers `access` hook', function(done) {
         TestModel.observe('access', pushContextAndNext());
 
-        TestModel.count({ id: existingInstance.id }, function(err, count) {
+        var cb = function(err, count) {
           if (err) return done(err);
           observedContexts.should.eql(aTestModelCtx({ query: {
             where: { id: existingInstance.id }
-          }}));
+          }, end: cb }));
           done();
-        });
+        };
+
+        TestModel.count({ id: existingInstance.id }, cb);
       });
 
       it('applies updates from `access` hook', function(done) {
@@ -1426,29 +1438,32 @@ module.exports = function(dataSource, should) {
       it('triggers `access` hook on create', function(done) {
         TestModel.observe('access', pushContextAndNext());
 
+        var cb = function(err, instance) {
+          if (err) return done(err);
+          observedContexts.should.eql(aTestModelCtx({ query: {
+            where: { id: 'not-found' }
+          }, end: cb }));
+          done();
+        };
+
         TestModel.updateOrCreate(
-          { id: 'not-found', name: 'not found' },
-          function(err, instance) {
-            if (err) return done(err);
-            observedContexts.should.eql(aTestModelCtx({ query: {
-              where: { id: 'not-found' }
-            }}));
-            done();
-          });
+          { id: 'not-found', name: 'not found' }, cb);
       });
 
       it('triggers `access` hook on update', function(done) {
         TestModel.observe('access', pushContextAndNext());
 
+        var cb = function(err, instance) {
+          if (err) return done(err);
+          observedContexts.should.eql(aTestModelCtx({ query: {
+            where: { id: existingInstance.id }
+          }, end: cb }));
+          done();
+        }
+
         TestModel.updateOrCreate(
           { id: existingInstance.id, name: 'new name' },
-          function(err, instance) {
-            if (err) return done(err);
-            observedContexts.should.eql(aTestModelCtx({ query: {
-              where: { id: existingInstance.id }
-            }}));
-            done();
-          });
+          cb);
       });
 
       it('does not trigger `access` on missing id', function(done) {
@@ -1823,23 +1838,28 @@ module.exports = function(dataSource, should) {
       it('triggers `access` hook with query', function(done) {
         TestModel.observe('access', pushContextAndNext());
 
-        TestModel.deleteAll({ name: existingInstance.name }, function(err) {
+        var cb = function(err) {
           if (err) return done(err);
           observedContexts.should.eql(aTestModelCtx({
-             query: { where: { name: existingInstance.name } }
+             query: { where: { name: existingInstance.name } },
+             end: cb
           }));
           done();
-        });
+        };
+
+        TestModel.deleteAll({ name: existingInstance.name }, cb);
       });
 
       it('triggers `access` hook without query', function(done) {
         TestModel.observe('access', pushContextAndNext());
 
-        TestModel.deleteAll(function(err) {
+        var cb = function(err) {
           if (err) return done(err);
-          observedContexts.should.eql(aTestModelCtx({ query: { where: {} } }));
+          observedContexts.should.eql(aTestModelCtx({ query: { where: {} }, end: cb }));
           done();
-        });
+        }
+
+        TestModel.deleteAll(cb);
       });
 
       it('applies updates from `access` hook', function(done) {
@@ -1946,13 +1966,16 @@ module.exports = function(dataSource, should) {
       it('triggers `access` hook', function(done) {
         TestModel.observe('access', pushContextAndNext());
 
-        existingInstance.delete(function(err) {
+        var cb = function(err) {
           if (err) return done(err);
           observedContexts.should.eql(aTestModelCtx({
-             query: { where: { id: existingInstance.id } }
+             query: { where: { id: existingInstance.id } },
+             end: cb
           }));
           done();
-        });
+        }
+
+        existingInstance.delete(cb);
       });
 
       it('applies updated from `access` hook', function(done) {
@@ -2095,16 +2118,18 @@ module.exports = function(dataSource, should) {
       it('triggers `access` hook', function(done) {
         TestModel.observe('access', pushContextAndNext());
 
+        var cb = function(err, instance) {
+          if (err) return done(err);
+          observedContexts.should.eql(aTestModelCtx({ query: {
+            where: { name: 'searched' }
+          }, end: cb }));
+          done();
+        };
+
         TestModel.updateAll(
           { name: 'searched' },
           { name: 'updated' },
-          function(err, instance) {
-            if (err) return done(err);
-            observedContexts.should.eql(aTestModelCtx({ query: {
-              where: { name: 'searched' }
-            }}));
-            done();
-          });
+          cb);
       });
 
       it('applies updates from `access` hook', function(done) {

--- a/test/persistence-hooks.suite.js
+++ b/test/persistence-hooks.suite.js
@@ -548,7 +548,6 @@ module.exports = function(dataSource, should) {
           { name: 'new-record' },
           function(err, record, created) {
             if (err) return done(err);
-            console.log(triggered);
             triggered.should.eql([
               'access',
               'before save',


### PR DESCRIPTION
Hi, 

I would like to have a new operation hook triggered after a find query with the full results.

I did an enhancement for the access operation hook, it's providing the end callback in the context to be able to stop the flow without an error.

One test failed for this change, I didn't found a way to fix the Optimize or the Unoptimize test of findOrCreate.
Do you have any idea to fix them both ?


The purpose the these changes is to be able to plug a cache system between the 'access' and 'allLoaded' operation hooks.