### PR TITLE
Prevent constructor to be property name

### DIFF
--- a/lib/model-builder.js
+++ b/lib/model-builder.js
@@ -257,6 +257,12 @@ ModelBuilder.prototype.define = function defineClass(className, properties, sett
       deprecated('Property names containing a dot are not supported. ' +
         'Model: ' + className + ', property: ' + p);
     }
+    
+    // Warn if property name is 'constructor'
+    if (p === "constructor") {
+      deprecated('Property name should not be "constructor" in Model: ' +
+        className);
+    }
   }
 
   var modelDefinition = new ModelDefinition(this, className, properties, settings);

--- a/lib/model.js
+++ b/lib/model.js
@@ -63,6 +63,11 @@ ModelBaseClass.prototype._initProperties = function (data, options) {
   var self = this;
   var ctor = this.constructor;
 
+  if (typeof data !== 'undefined' && 
+      typeof (data.constructor) !== 'function') {
+    throw new Error('Property name "constructor" is not allowed in ' + ctor.modelName +' data');
+  }
+
   if(data instanceof ctor) {
     // Convert the data to be plain object to avoid pollutions
     data = data.toObject(false);

--- a/test/model-definition.test.js
+++ b/test/model-definition.test.js
@@ -379,6 +379,15 @@ describe('ModelDefinition class', function () {
     message.should.match(/Dotted.*dot\.name/);
   });
 
+  it('should report deprecation warning for property named constructor', function() {
+    var message = 'deprecation not reported';
+    process.once('deprecation', function(err) { message = err.message; });
+
+    memory.createModel('Ctor', { 'constructor': String });
+
+    message.should.match(/Property name should not be "constructor" in Model: Ctor/);
+  });
+
   it('should report deprecation warning for dynamic property names containing dot', function(done) {
     var message = 'deprecation not reported';
     process.once('deprecation', function(err) { message = err.message; });
@@ -387,6 +396,14 @@ describe('ModelDefinition class', function () {
     Model.create({ 'dot.name': 'dot.value' }, function(err) {
       if (err) return done(err);
       message.should.match(/Dotted.*dot\.name/);
+      done();
+    });
+  });
+
+  it('should throw error for dynamic property named constructor', function(done) {
+    var Model = memory.createModel('DynamicCtor');
+    Model.create({ 'constructor': 'myCtor' }, function(err) {
+      assert.equal(err.message, 'Property name "constructor" is not allowed in DynamicCtor data');
       done();
     });
   });


### PR DESCRIPTION
Connect to strongloop-internal/scrum-loopback#642

Hey @bajtos this pr is created for handling `constructor` in two places:
1) Throw error in `/lib/model-builder.js` if model has a property named `constructor`.
2) Give warning in `/lib/model.js` if user assigns property named `constructor` in instance.

Could you review it? Thanks!
Move to this pr since the previous one keep failing even I commented all of my changes. Thanks for your understanding.