### PR TITLE
ds.discoverSchema hangs when provided an invalid table name

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -1225,7 +1225,7 @@ DataSource.prototype.discoverSchema = function (modelName, options, cb) {
   cb = cb || utils.createPromiseCallback();
 
   this.discoverSchemas(modelName, options, function (err, schemas) {
-    if (err) {
+    if (err || !schemas) {
       cb && cb(err, schemas);
       return;
     }
@@ -1305,7 +1305,7 @@ DataSource.prototype.discoverSchemas = function (modelName, options, cb) {
 
     var columns = results[0];
     if (!columns || columns.length === 0) {
-      cb();
+      cb(new Error('Table \''+modelName+'\' does not exist.'));
       return cb.promise;
     }
 

--- a/test/discovery.test.js
+++ b/test/discovery.test.js
@@ -602,3 +602,27 @@ describe('discoverExportedForeignKeys', function(){
       });
   });
 });
+
+describe('Default memory connector', function() {
+  var ds, nonExistantError = 'Table \'NONEXISTENT\' does not exist.';
+
+  before(function() {
+    ds = new DataSource({connector: 'memory'});
+  });
+
+  it('discoverSchema should return an error when table does not exist', function(done) {
+    ds.discoverSchema('NONEXISTENT', {}, function(err, schemas) {
+      should.exist(err);
+      err.message.should.eql(nonExistantError);
+      done();
+    });
+  });
+
+  it('discoverSchemas should return an error when table does not exist', function(done) {
+    ds.discoverSchemas('NONEXISTENT', {}, function(err, schemas) {
+      should.exist(err);
+      err.message.should.eql(nonExistantError);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
When I run `ds.discoverSchema` with the Postgres adapter and I provide a table that does not exist, the method hangs.  I would expect it to return an error.

Here is what's happening in the code.  `ds.discoverSchema` calls `ds.discoverSchemas`.  When the latter runs, it [detects that there are no columns returned, so it calls its callback](https://github.com/strongloop/loopback-datasource-juggler/blob/486c1de1ba4572f810606be1aa148db4d272e52c/lib/datasource.js#L1306-L1310).  When `ds.discoverSchema` [receives the value undefined for `schemas`, it tries to iterate through it](https://github.com/strongloop/loopback-datasource-juggler/blob/486c1de1ba4572f810606be1aa148db4d272e52c/lib/datasource.js#L1227-L1236).  Because of whacky not-as-you-would-expect Javascript behavior, this doesn't throw any errors, but instead passes over the loop with no action.  Therefore, the callback is never called and the method hangs from the consumer's perspective.

A workaround is to call `ds.discoverSchema` directly, and interpret the empty result sets yourself.

I wrote a failing test case, and have included code that resolves the issue by explicitly returning an error when the table cannot be found.