### PR TITLE
Change "npm test" to call mocha directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "clean": "make clean",
     "help": "make help",
     "refresh": "make refresh",
-    "test": "make test"
+    "test": "NO_DEPRECATION=loopback-datasource-juggler mocha"
   },
   "engines": [
     "node >= 0.6"


### PR DESCRIPTION
Rework the test script to call directly mocha and skip Makefile. This allows CI enviroments to detect that this module is using Mocha as the test runner.

Related: 2cdc4ddcbf5 and #767

@jannyHou @rmg I noticed the "npm test" script was changed from `make test` to `mocha` and back, is there any reason why we cannot use the script proposed by this patch?