### PR TITLE
Fix missing connector error msg for db2, cloudant

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -198,7 +198,7 @@ function connectorModuleNames(name) {
     }
   }
   // Only try the short name if the connector is not from StrongLoop
-  if (['mongodb', 'oracle', 'mysql', 'postgresql', 'mssql', 'rest', 'soap']
+  if (['mongodb', 'oracle', 'mysql', 'postgresql', 'mssql', 'rest', 'soap', 'db2', 'cloudant']
       .indexOf(name) === -1) {
     names.push(name);
   }


### PR DESCRIPTION
WARNING: LoopBack connector "cloudant" is not installed as any of the following modules:

./connectors/cloudant
loopback-connector-cloudant
cloudant

To fix, run:

`npm install cloudant`


to

WARNING: LoopBack connector "cloudant" is not installed as any of the following modules:

./connectors/cloudant
loopback-connector-cloudant

To fix, run:

`npm install loopback-connector-cloudant`