### PR TITLE
Removed DataType condition that breaks $exists lookups in mongoDB

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1207,7 +1207,9 @@ DataAccessObject._coerce = function (where) {
         } else if (operator === 'regexp' && val instanceof RegExp) {
           // Do not coerce regex literals/objects
         } else if (!((operator === 'like' || operator === 'nlike') && val instanceof RegExp)) {
-          //val = DataType(val);
+            if(DataType(val)!="[object Object]") {
+                val = DataType(val);      
+            }
         }
       }
     }

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1207,7 +1207,7 @@ DataAccessObject._coerce = function (where) {
         } else if (operator === 'regexp' && val instanceof RegExp) {
           // Do not coerce regex literals/objects
         } else if (!((operator === 'like' || operator === 'nlike') && val instanceof RegExp)) {
-          val = DataType(val);
+          //val = DataType(val);
         }
       }
     }


### PR DESCRIPTION
I'm not entirely sure what this DataType(val) check is even needed for.

But in a query like this: 

```
http://localhost:4001/api/products?filter[where][tags][exists]=true
```

This method will return: "[object, Object]" instead of using the actual object {exists: true} which will get converted later in the buildWhere in mongoDB to {$exists: true}
