### PR TITLE
Fix _coerce after logic operators

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1391,7 +1391,7 @@ DataAccessObject._coerce = function (where) {
         err.statusCode = 400;
         throw err;
       }
-      return where;
+      continue;
     }
     var DataType = props[p] && props[p].type;
     if (!DataType) {


### PR DESCRIPTION
_coerce goes over all properties of a query. When it gets to one of the logic operators (and, or, nor) it uses recursion but instead of iterating to next property of the query, it returns.

```js
{
  name: "myName",
  and: [...],
  title: "myTitle"
}
```

In this example the title's value won't be coerced because _coerce will return after handling "and".