### PR TITLE
Improve error message on connector init error

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -327,13 +327,22 @@ DataSource.prototype.setup = function (name, settings) {
 
     }.bind(this);
 
-    if ('function' === typeof connector.initialize) {
-      // Call the async initialize method
-      connector.initialize(this, postInit);
-    } else if ('function' === typeof connector) {
-      // Use the connector constructor directly
-      this.connector = new connector(this.settings);
-      postInit();
+    try {
+      if ('function' === typeof connector.initialize) {
+        // Call the async initialize method
+        connector.initialize(this, postInit);
+      } else if ('function' === typeof connector) {
+        // Use the connector constructor directly
+        this.connector = new connector(this.settings);
+        postInit();
+      }
+    } catch(err) {
+      if (err.message) {
+        err.message = 'Cannot initialize connector ' +
+          JSON.stringify(connector.name || name)  + ': ' +
+          err.message;
+      }
+      throw err;
     }
   }
 


### PR DESCRIPTION
Before this change, after adding a Cloudant-backed datasource to an app, `node .` will fail with
```
AssertionError: url is not valid
  (...stack trace...)
```

Now:

```
AssertionError: Cannot initialize connector "cloudant": url is not valid
  (...stack trace...)
```

/to @ritch please review