### PR TITLE
Fix Mongo compatibility issue

### DIFF
--- a/test/memory.test.js
+++ b/test/memory.test.js
@@ -853,7 +853,7 @@ describe('Optimized connector', function() {
     }.bind(this));
   };
 
-  require('./persistence-hooks.suite')(ds, should);
+  require('./persistence-hooks.suite')(ds, should, {replaceOrCreateReportsNewInstance: true});
 });
 
 describe('Unoptimized connector', function() {
@@ -862,7 +862,7 @@ describe('Unoptimized connector', function() {
   ds.connector.updateOrCreate = false;
   ds.connector.findOrCreate = false;
 
-  require('./persistence-hooks.suite')(ds, should);
+  require('./persistence-hooks.suite')(ds, should, {replaceOrCreateReportsNewInstance: true});
 });
 
 describe('Memory connector with options', function() {

--- a/test/persistence-hooks.suite.js
+++ b/test/persistence-hooks.suite.js
@@ -1,7 +1,11 @@
 var ValidationError = require('../').ValidationError;
 var traverse = require('traverse');
 
-module.exports = function(dataSource, should) {
+module.exports = function(dataSource, should, connectorCapabilities) {
+  if (!connectorCapabilities) connectorCapabilities = {};
+  if (connectorCapabilities.replaceOrCreateReportsNewInstance === undefined) {
+    console.warn('The connector does not support a recently added feature: replaceOrCreateReportsNewInstance');
+  }
   describe('Persistence hooks', function() {
     var observedContexts, expectedError, observersCalled;
     var TestModel, existingInstance;
@@ -2403,13 +2407,19 @@ module.exports = function(dataSource, should) {
             { id: 'new-id', name: 'a name' },
             function(err, instance) {
               if (err) return done(err);
-              observedContexts.should.eql(aTestModelCtx({
+              
+              var expected = {
                 data: {
                   id: 'new-id',
                   name: 'a name'
-                },
-                isNewInstance: true
-              }));     
+                }
+              };
+              
+              expected.isNewInstance = 
+                connectorCapabilities.replaceOrCreateReportsNewInstance ?
+                true : undefined;            
+              
+              observedContexts.should.eql(aTestModelCtx(expected));     
               done();
             });
         });
@@ -2422,14 +2432,19 @@ module.exports = function(dataSource, should) {
             function(err, instance) {
               if (err) return done(err);
 
+              var expected = {
+                data: {
+                  id: existingInstance.id,
+                  name: 'replaced name'
+                }
+              };
+              
+              expected.isNewInstance = 
+                connectorCapabilities.replaceOrCreateReportsNewInstance ?
+                false : undefined;
+
               if (dataSource.connector.replaceOrCreate) {
-                observedContexts.should.eql(aTestModelCtx({
-                  data: {
-                    id: existingInstance.id,
-                    name: 'replaced name'
-                  },
-                  isNewInstance: false
-                }));
+                observedContexts.should.eql(aTestModelCtx(expected));
               } else {
                 // TODO: Please see loopback-datasource-juggler/issues#836
                 // 
@@ -2479,14 +2494,20 @@ module.exports = function(dataSource, should) {
             { id: existingInstance.id, name: 'replaced name' },
             function(err, instance) {
               if (err) return done(err);
-              observedContexts.should.eql(aTestModelCtx({
+              
+              var expected = {
                 instance: {
                   id: existingInstance.id,
                   name: 'replaced name',
                   extra: undefined
-                },
-                isNewInstance: false
-              }));
+                }
+              };
+              
+              expected.isNewInstance = 
+                connectorCapabilities.replaceOrCreateReportsNewInstance ?
+                false : undefined;
+
+              observedContexts.should.eql(aTestModelCtx(expected));
               done();
             });
         });
@@ -2498,14 +2519,19 @@ module.exports = function(dataSource, should) {
             { id: 'new-id', name: 'a name' },
             function(err, instance) {
               if (err) return done(err);
-              observedContexts.should.eql(aTestModelCtx({
+              
+              var expected = {
                 instance: {
                   id: instance.id,
                   name: 'a name',
                   extra: undefined
-                },
-                isNewInstance: true
-              }));
+                }
+              };
+              expected.isNewInstance = 
+                connectorCapabilities.replaceOrCreateReportsNewInstance ?
+                true : undefined;
+              
+              observedContexts.should.eql(aTestModelCtx(expected));
               done();
             });
         });


### PR DESCRIPTION
#### Fix Mongo compatibility issue for replaceOrCreate

##### Description: 
This patch takes care of compatibility issues for Mongodb v2.4 tests for PR: https://github.com/strongloop/loopback-connector-mongodb/pull/202

Please see the next comment for my conversation with Raymond.

@bajtos could you please review this patch.

Thanks  :-)