### PR TITLE
Fix tests for mysql

### DIFF
--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -767,8 +767,8 @@ describe('manipulation', function () {
               .then(function (p) {
                 p.should.not.have.property('_id');
                 p.title.should.equal('b');
-                p.should.have.property('content', undefined);
-                p.should.have.property('comments', undefined);
+                should.not.exist(p.content);
+                should.not.exist(p.comments);
                 done();
               });
             });
@@ -797,8 +797,8 @@ describe('manipulation', function () {
               .then(function (p) {
                 p.should.not.have.property('_id');
                 p.title.should.equal('b');
-                p.should.have.property('content', undefined);
-                p.should.have.property('comments', undefined);
+                should.not.exist(p.content);
+                should.not.exist(p.comments);
                 done();
               });
             });
@@ -826,8 +826,8 @@ describe('manipulation', function () {
                 p.id.should.eql(post.id);
                 p.should.not.have.property('_id');
                 p.title.should.equal('b');
-                p.should.have.property('content', undefined);
-                p.should.have.property('comments', undefined);
+                should.not.exist(p.content);
+                should.not.exist(p.comments);
                 done();
               });
             });
@@ -855,8 +855,8 @@ describe('manipulation', function () {
                 p.id.should.eql(post.id);
                 p.should.not.have.property('_id');
                 p.title.should.equal('b');
-                p.should.have.property('content', undefined);
-                p.should.have.property('comments', undefined);
+                should.not.exist(p.content);
+                should.not.exist(p.comments);
                 done();
               });
             });
@@ -939,7 +939,7 @@ describe('manipulation', function () {
           return Post.findById(postInstance.id)
           .then(function (p) {
             p.title.should.equal('b');
-            p.should.have.property('content', undefined);
+            should.not.exist(p.content);
             done();
           });
         });
@@ -959,7 +959,7 @@ describe('manipulation', function () {
           return Post.findById(postInstance.id)
           .then(function (p) {
             p.title.should.equal('b');
-            p.should.have.property('content', undefined);
+            should.not.exist(p.content);
             done();
           });
         });


### PR DESCRIPTION
##### Description:
If a field does not have any value in `MySQL` (Relational Databases) `findById` or `find` returns `null` for that field, whereas it is undefined in `memory` and `MongoDB` connectors (NoSQL DBs);  

```
Post.findById(post.id, function(err, p) {
   if (err) return done(err);
   p.should.have.property('content', undefined); // It fails for relational DBs (MySQL) because if a field is missing value it returns null
   should.not.exist(p.comments); // It passes
   ...
});
```

Actually I did this [PR#788](https://github.com/strongloop/loopback-datasource-juggler/pull/788) in `loopbakc-datasource-juggler` after finishing my [PR#139](https://github.com/strongloop/loopback-connector-mysql/pull/139) in `loopback-connector-mysql` and noticed these test cases in `loopback-datasource-juggler` will be breaking [PR#139](https://github.com/strongloop/loopback-connector-mysql/pull/139) in loopback-connetcor-mysql. The better practice was to finish my PR in `loopback-datasource-juggler` first and then other PRs in `loopback-connector`, `loopback-connector-mongodb` and `loopback-connector-mysql`.

@bajtos Please take a look. Thanks :-)

