### PR TITLE
polymorphic discriminator type is hard coded as 'string'

### DIFF
--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -602,7 +602,7 @@ RelationDefinition.hasMany = function hasMany(modelFrom, modelTo, params) {
       fk = polymorphic.foreignKey;
     }
     if (!params.through) {
-      modelTo.dataSource.defineProperty(modelTo.modelName, discriminator, { type: 'string', index: true });
+      modelTo.dataSource.defineProperty(modelTo.modelName, discriminator, { type: 'string', length:30, index: true });
     }
   }
 
@@ -1240,7 +1240,7 @@ RelationDefinition.belongsTo = function (modelFrom, modelTo, params) {
       modelFrom.dataSource.defineForeignKey(modelFrom.modelName, fk, modelFrom.modelName, pkName);
     }
 
-    modelFrom.dataSource.defineProperty(modelFrom.modelName, discriminator, { type: 'string', index: true });
+    modelFrom.dataSource.defineProperty(modelFrom.modelName, discriminator, { type: 'string', length:30, index: true });
   } else {
     pkName = params.primaryKey || modelTo.dataSource.idName(modelTo.modelName) || 'id';
     relationName = params.as || i8n.camelize(modelTo.modelName, true);
@@ -1611,7 +1611,7 @@ RelationDefinition.hasOne = function (modelFrom, modelTo, params) {
     fk = polymorphic.foreignKey;
     discriminator = polymorphic.discriminator;
     if (!params.through) {
-      modelTo.dataSource.defineProperty(modelTo.modelName, discriminator, { type: 'string', index: true });
+      modelTo.dataSource.defineProperty(modelTo.modelName, discriminator, { type: 'string', length:30, index: true });
     }
   }
 


### PR DESCRIPTION
MySQL throws `ER_TOO_LONG_KEY: Specified key was too long; max key length is 767 bytes`

I needed to hack this with a reasonable length to get MySql CREATE TABLE working.

Probably need to make this configurable (Something like idType) for both type and length. 

```javascript
polymorphic: {
    discriminatorType: { "type": "string", length: 30, "index": true },
    foreignKey: 'imageableId',
    discriminator: 'imageableType'
}
```

Anyone else had this issue? Is there another solution? Thoughts?