### PR TITLE
support custom field settings under the connector's namespace

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -1343,8 +1343,6 @@ DataSource.prototype.discoverSchemas = function (modelName, options, cb) {
     };
 
     columns.forEach(function (item) {
-      var i = item;
-
       var propName = nameMapper('column', item.columnName);
       schema.properties[propName] = {
         type: item.type,
@@ -1358,14 +1356,20 @@ DataSource.prototype.discoverSchemas = function (modelName, options, cb) {
       if (pks[item.columnName]) {
         schema.properties[propName].id = pks[item.columnName];
       }
-      schema.properties[propName][dbType] = {
-        columnName: i.columnName,
-        dataType: i.dataType,
-        dataLength: i.dataLength,
+      var dbSpecific = schema.properties[propName][dbType] = {
+        columnName: item.columnName,
+        dataType: item.dataType,
+        dataLength: item.dataLength,
         dataPrecision: item.dataPrecision,
         dataScale: item.dataScale,
-        nullable: i.nullable
+        nullable: item.nullable
       };
+      // merge connector-specific properties
+      if (item[dbType]) {
+        for (var k in item[dbType]) {
+          dbSpecific[k] = item[dbType][k];
+        }
+      }
     });
 
     // Add current modelName to the visited tables

--- a/test/discovery.test.js
+++ b/test/discovery.test.js
@@ -602,3 +602,20 @@ describe('discoverExportedForeignKeys', function(){
       });
   });
 });
+
+describe('Mock connector', function() {
+  mockConnectors = require('./mock-connectors');
+  describe('customFieldSettings', function() {
+    ds = new DataSource(mockConnectors.customFieldSettings);
+
+    it('should be present in discoverSchemas', function(done) {
+      ds.discoverSchemas('person', function(err, schemas) {
+        should.not.exist(err);
+        schemas.should.be.an.Object;
+        schemas['public.person'].properties.name
+          .custom.storage.should.equal('quantum');
+        done();
+      });
+    });
+  });
+});

--- a/test/mock-connectors.js
+++ b/test/mock-connectors.js
@@ -1,0 +1,26 @@
+module.exports = {
+
+  // connector which uses custom field settings
+  customFieldSettings: {
+    initialize: function(ds, done) {
+      ds.connector = {
+        name: 'custom',
+        discoverModelProperties: function(resource, options, done) {
+          done(null, [
+            {
+              owner: 'public',
+              columnName: 'name',
+              type: 'String',
+              required: false,
+
+              // custom properties listed under a key matching the connector name
+              custom: {storage: 'quantum'}
+            }
+          ]);
+        }
+      };
+      ds.connector.dataSource = ds;
+    }
+  }
+
+};


### PR DESCRIPTION
Some database connectors need to have custom field settings.  E.g. Hbase has column families which could be different on a per field basis.  Reading/writing to Hbase is not possible without knowledge of the column families, so this is an important detail to be captured in schema discovery.

Right now, there is a namespace reserved for the connector, but it is hard coded to only populate certain properties.  I'd like to extend that to support any additional properties the connector may need.

A sample discoverModelProperties result for the 'custom' connector might look like this:

```javascript
[
    {
        owner: 'public',
        columnName: 'name',
        type: 'String',
        required: false,
        custom: {storage: 'quantum'}
    }
]
```

And discoverSchemas:

```javascript
{
    "public.person": {
        "name": "Person",
        "options": {
            "idInjection": false,
            "custom": {
                "schema": "public",
                "table": "person"
            }
        },
        "properties": {
            "name": {
                "type": "String",
                "required": false,
                "custom": {
                    "columnName": "name",
                    "storage": "quantum"
                }
            }
        }
    }
}
```

Code is implemented and tested.  I tried to support this in a way that seems idiomatic to the Loopback design.  Feedback welcome.