### PR TITLE
Fix `forceId` check for `replaceById`

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -2657,7 +2657,7 @@ DataAccessObject.replaceById = function(id, data, options, cb) {
   if (!data[pkName]) data[pkName] = id;
 
   var Model = this;
-  var inst = new Model(data);
+  var inst = new Model(data, { persisted: true });
   var enforced = {};
   this.applyProperties(enforced, inst);
   inst.setAttributes(enforced);

--- a/test/optional-validation.test.js
+++ b/test/optional-validation.test.js
@@ -4,8 +4,9 @@
 // License text available at https://opensource.org/licenses/MIT
 
 // This test written in mocha+should.js
+var async = require('async');
 var should = require('./init.js');
-var db, User, options, whereCount = 0;
+var db, User, options, ModelWithForceId, whereCount = 0;
 var j = require('../');
 var ValidationError = j.ValidationError;
 
@@ -18,6 +19,10 @@ describe('optional-validation', function() {
 
   before(function(done) {
     db = getSchema();
+    ModelWithForceId = db.createModel(
+    'ModelWithForceId',
+    { name: String },
+    { forceId: true });
     User = db.define('User', {
       seq: { type: Number, index: true },
       name: { type: String, index: true, sort: true },
@@ -27,9 +32,7 @@ describe('optional-validation', function() {
       order: { type: Number, index: true, sort: true },
       vip: { type: Boolean },
     }, { forceId: true, strict: true });
-
-    db.automigrate(['User'], done);
-
+    db.automigrate(['ModelWithForceId', 'User'], done);
   });
 
   beforeEach(function(done) {
@@ -106,6 +109,33 @@ describe('optional-validation', function() {
   function getNewWhere() {
     return { name: 'DoesNotExist' + (whereCount++) };
   }
+
+  describe('forceId', function() {
+    context('replaceAttributes', function() {
+      it('should not fail if you do not pass the Primary key in data object',
+      function(done) {
+        ModelWithForceId.create({ name: 'foo' }, function(err, created) {
+          if (err) return done(err);
+          created.replaceAttributes({ name: 'bar' }, function(err, data) {
+            done(err);
+          });
+        });
+      });
+
+      it('should fail if you pass the Primary key in data object',
+      function(done) {
+        ModelWithForceId.create({ name: 'foo' }, function(err, created) {
+          if (err) return done(err);
+          created.replaceAttributes({ name: 'bar', id: 999 },
+          function(err, data) {
+            should.exist(err);
+            done();
+          });
+        });
+      });
+    });
+  });
+
 
   describe('no model setting', function() {
 


### PR DESCRIPTION
This patch fixes `forceId` check for `replaceById` method:

##### Problem:
Validation fails if you pass `{ forceId: true }` for `replaceById` even though you don't pass the primary key in data object.

##### Connect to https://github.com/strongloop/loopback-datasource-juggler/issues/897

#### Notes: 
Relate to https://github.com/strongloop/loopback-datasource-juggler/pull/893
This ptach (PR#896) needs to be landed before https://github.com/strongloop/loopback-datasource-juggler/pull/893