### PR TITLE
test: extract context-test-helpers

### DIFF
--- a/test/helpers/context-test-helpers.js
+++ b/test/helpers/context-test-helpers.js
@@ -1,0 +1,71 @@
+// Copyright IBM Corp. 2016. All Rights Reserved.
+// Node module: loopback-datasource-juggler
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+var traverse = require('traverse');
+
+exports.ContextRecorder = ContextRecorder;
+exports.deepCloneToObject = deepCloneToObject;
+exports.aCtxForModel = aCtxForModel;
+
+function ContextRecorder(initialValue) {
+  if (!(this instanceof ContextRecorder)) {
+    return new ContextRecorder(initialValue);
+  }
+  this.records = initialValue;
+};
+
+ContextRecorder.prototype.recordAndNext = function(transformFm) {
+  var self = this;
+  return function(context, next) {
+    if (typeof transformFm === 'function') {
+      transformFm(context);
+    }
+
+    context = deepCloneToObject(context);
+    context.hookState.test = true;
+
+    if (typeof self.records === 'string') {
+      self.records = context;
+      return next();
+    }
+
+    if (!Array.isArray(self.records)) {
+      self.records = [self.records];
+    }
+
+    self.records.push(context);
+    next();
+  };
+};
+
+function deepCloneToObject(obj) {
+  return traverse(obj).map(function(x) {
+    if (x === undefined) {
+      // RDBMSs return null
+      return null;
+    }
+    if (x && x.toObject)
+      return x.toObject(true);
+    if (x && typeof x === 'function' && x.modelName)
+      return '[ModelCtor ' + x.modelName + ']';
+  });
+}
+
+function aCtxForModel(TestModel, ctx) {
+  ctx.Model = TestModel;
+
+  if (!ctx.hookState) {
+    ctx.hookState = {};
+  }
+
+  if (!('test' in ctx.hookState)) {
+    ctx.hookState.test = true;
+  }
+
+  if (!ctx.options) {
+    ctx.options = {};
+  }
+  return deepCloneToObject(ctx);
+}

--- a/test/helpers/hook-monitor.js
+++ b/test/helpers/hook-monitor.js
@@ -1,0 +1,30 @@
+// Copyright IBM Corp. 2016. All Rights Reserved.
+// Node module: loopback-datasource-juggler
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+module.exports = HookMonitor;
+
+function HookMonitor(opts) {
+  if (!(this instanceof HookMonitor)) {
+    return new HookMonitor();
+  }
+
+  this.options = opts || {};
+  this.names = [];
+};
+
+HookMonitor.prototype.install = function(ObservedModel, hookNames) {
+  var monitor = this;
+  this.names = [];
+  ObservedModel._notify = ObservedModel.notifyObserversOf;
+  ObservedModel.notifyObserversOf = function(operation, context, callback) {
+    if (!Array.isArray(hookNames) || hookNames.indexOf(operation) !== -1) {
+      var item = monitor.options.includeModelName ?
+        ObservedModel.modelName + ':' + operation :
+        operation;
+      monitor.names.push(item);
+    }
+    this._notify.apply(this, arguments);
+  };
+};

--- a/test/helpers/uid-generator.js
+++ b/test/helpers/uid-generator.js
@@ -1,0 +1,19 @@
+// Copyright IBM Corp. 2016. All Rights Reserved.
+// Node module: loopback-datasource-juggler
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+var lastId = 0;
+
+exports.next = function() {
+  lastId++;
+  return exports.last();
+};
+
+exports.last = function() {
+  return '' + lastId;
+};
+
+exports.reset = function() {
+  lastId = 0;
+};


### PR DESCRIPTION
This is a preparatory work for #497, where I would like to start a new source file for operations hooks for embedded relations. In order to do that, I need to share helper methods for recording and comparing context objects. In this patch, I am moving helpers to a file that can be loaded from multiple places.

The patch is quite large, as I was not able to preserve the current API which was relying on closures. Sorry for that :(

Connect to #497

/to @superkhau or @Amir-61 please review