### PR TITLE
eslint config 2.0 + remove extra empty lines

### DIFF
--- a/examples/app-noschema.js
+++ b/examples/app-noschema.js
@@ -82,5 +82,3 @@ User.create(user, function(err, u1) {
     console.log('Found: ', u2.toObject());
   });
 });
-
-

--- a/examples/app.js
+++ b/examples/app.js
@@ -41,7 +41,3 @@ console.log(modelBuilder.definitions);
 User.mixin(Group);
 var user = new User({ name: 'Ray', group: 'Admin' });
 console.log(user);
-
-
-
-

--- a/lib/connectors/memory.js
+++ b/lib/connectors/memory.js
@@ -482,7 +482,6 @@ function applyFilter(filter) {
         });
       }
 
-
       if (test(where[key], value)) {
         return true;
       }

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -2998,7 +2998,6 @@ DataAccessObject.prototype.reload = function reload(cb) {
   return this.constructor.findById(getIdValue(this.constructor, this), cb);
 };
 
-
 /*
  * Define readonly property on object
  *

--- a/lib/include.js
+++ b/lib/include.js
@@ -785,7 +785,6 @@ Inclusion.include = function(objects, include, options, cb) {
       }
     }
 
-
     /**
      * Handle Inclusion of Polymorphic HasOne relation
      * @param callback
@@ -920,7 +919,6 @@ Inclusion.include = function(objects, include, options, cb) {
         execTasksWithInterLeave(tasks, callback);
       }
     }
-
 
     /**
      * Handle Inclusion of EmbedsMany/EmbedsManyWithBelongsTo/EmbedsOne

--- a/lib/include_utils.js
+++ b/lib/include_utils.js
@@ -38,7 +38,6 @@ function buildOneToManyIdentityMapWithOrigKeys(objs, idName) {
   return kvMap;
 }
 
-
 /**
  * Yeah, it joins. You need three things id -> obj1 map, id -> [obj2] map and merge function.
  * This functions will take each obj1, locate all data to join in map2 and call merge function.
@@ -55,7 +54,6 @@ function join(oneToOneIdMap, oneToManyIdMap, mergeF) {
     mergeF(obj, objectsToMergeIn);
   }
 }
-
 
 /**
  * Map with arbitrary keys and values. User .set() and .get() to work with values instead of []

--- a/lib/introspection.js
+++ b/lib/introspection.js
@@ -61,5 +61,3 @@ module.exports = function getIntrospector(ModelBuilder) {
   ModelBuilder.introspect = introspectType;
   return introspectType;
 };
-
-

--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -818,7 +818,6 @@ HasMany.prototype.exists = function(fkId, options, cb) {
   var modelInstance = this.modelInstance;
   cb = cb || utils.createPromiseCallback();
 
-
   this.findById(fkId, function(err, inst) {
     if (err) {
       return cb(err);
@@ -1054,8 +1053,6 @@ HasManyThrough.prototype.create = function create(data, options, cb) {
   return cb.promise;
 };
 
-
-
 /**
  * Add the target model instance to the 'hasMany' relation
  * @param {Object|ID} acInst The actual instance or id value
@@ -1190,7 +1187,6 @@ HasManyThrough.prototype.remove = function(acInst, options, cb) {
   });
   return cb.promise;
 };
-
 
 /**
  * Declare "belongsTo" relation that sets up a one-to-one connection with
@@ -1513,7 +1509,6 @@ BelongsTo.prototype.related = function(condOrRefresh, options, cb) {
   }
 };
 
-
 /**
  * Define a Promise-based method for the belongsTo relation itself
  * - order.customer.get(cb): Load the target model instance asynchronously
@@ -1531,7 +1526,6 @@ BelongsTo.prototype.getAsync = function(options, cb) {
   this.related(true, options, cb);
   return cb.promise;
 };
-
 
 /**
  * A hasAndBelongsToMany relation creates a direct many-to-many connection with
@@ -2442,7 +2436,6 @@ EmbedsMany.prototype.related = function(receiver, scopeParams, condOrRefresh, op
   if (typeof condOrRefresh === 'object') {
     actualCond = condOrRefresh;
   }
-
 
   var embeddedList = this.embeddedList(receiver);
 

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -182,5 +182,3 @@ if (Transaction) {
 }
 
 TransactionMixin.Transaction = Transaction;
-
-

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "debug": "^2.1.1",
     "depd": "^1.0.0",
     "eslint": "^2.5.3",
-    "eslint-config-loopback": "^1.0.0",
+    "eslint-config-loopback": "^2.0.0",
     "inflection": "^1.6.0",
     "loopback-connector": "^2.1.0",
     "node-uuid": "^1.4.2",

--- a/support/describe-operation-hooks.js
+++ b/support/describe-operation-hooks.js
@@ -112,7 +112,6 @@ operations.forEach(function(op) {
 
 p.then(report, function(err) { console.error(err.stack); });
 
-
 function createOptimizedDataSource() {
   var ds = new DataSource({ connector: Memory });
   ds.name = 'Optimized';

--- a/test/basic-querying.test.js
+++ b/test/basic-querying.test.js
@@ -447,7 +447,6 @@ describe('basic-querying', function() {
       });
     });
 
-
     it('should only include fields as specified', function(done) {
       var remaining = 0;
 

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -439,8 +439,6 @@ describe('hooks', function() {
   });
 });
 
-
-
 function addHooks(name, done) {
   var called = false, random = String(Math.floor(Math.random() * 1000));
   User['before' + name] = function(next, data) {

--- a/test/include.test.js
+++ b/test/include.test.js
@@ -721,7 +721,6 @@ describe('include', function() {
     });
   });
 
-
   // Not implemented correctly, see: loopback-datasource-juggler/issues/166
   // fixed by DB optimization
   it('should support include scope on hasAndBelongsToMany', function(done) {
@@ -881,7 +880,6 @@ describe('include', function() {
         done();
       });
     });
-
 
     it('should not make n+1 db calls in relation syntax',
       function(done) {

--- a/test/include_util.test.js
+++ b/test/include_util.test.js
@@ -75,7 +75,6 @@ describe('include_util', function() {
   });
 });
 
-
 describe('KVMap', function() {
   it('should allow to set and get value with key string', function() {
     var map = new includeUtils.KVMap();

--- a/test/loopback-dl.test.js
+++ b/test/loopback-dl.test.js
@@ -735,7 +735,6 @@ describe('Load models with base', function() {
     u.should.have.property('email', 'x@y.com');
   });
 
-
   it('should set up base class via parent arg', function() {
     var ds = new ModelBuilder();
 

--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -1448,7 +1448,6 @@ describe('manipulation', function() {
       });
     });
 
-
     describe('uuidv4 defaultFn', function() {
       var CustomModel;
 

--- a/test/memory.test.js
+++ b/test/memory.test.js
@@ -753,7 +753,6 @@ describe('Memory connector', function() {
     });
   });
 
-
   describe('automigrate when NO models are attached', function() {
     var ds;
     beforeEach(function() {
@@ -1011,5 +1010,3 @@ describe('Memory connector with observers', function() {
     });
   });
 });
-
-

--- a/test/optional-validation.test.js
+++ b/test/optional-validation.test.js
@@ -136,7 +136,6 @@ describe('optional-validation', function() {
     });
   });
 
-
   describe('no model setting', function() {
 
     describe('method create', function() {

--- a/test/persistence-hooks.suite.js
+++ b/test/persistence-hooks.suite.js
@@ -2361,8 +2361,6 @@ module.exports = function(dataSource, should, connectorCapabilities) {
                 },
               });
 
-
-
               if (dataSource.connector.replaceOrCreate) {
                 expectedContext.where = { id: 'new-id' };
               } else {
@@ -2979,7 +2977,6 @@ module.exports = function(dataSource, should, connectorCapabilities) {
       hookMonitor.install(TestModel, hookNames);
     }
   });
-
 
   function get(propertyName) {
     return function(obj) {

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -1271,7 +1271,6 @@ describe('relations', function() {
       db.automigrate(['User', 'Follow'], done);
     });
 
-
     it('should set foreignKeys of through model correctly in first relation',
       function(done) {
         var follower = new User({ id: 1 });
@@ -3194,7 +3193,6 @@ describe('relations', function() {
     });
   });
 
-
   describe('hasMany with primaryKey different from model PK', function() {
     var Employee, Boss;
     var COMPANY_ID = 'Company1';
@@ -3251,7 +3249,6 @@ describe('relations', function() {
       });
     });
   });
-
 
   describe('belongsTo with primaryKey different from model PK', function() {
     var Employee, Boss;
@@ -3427,7 +3424,6 @@ describe('relations', function() {
       })
       .catch(done);
     });
-
 
     it('should set targetClass on scope property', function() {
       should.equal(Article.prototype.tagNames._targetClass, 'TagName');
@@ -5109,8 +5105,6 @@ describe('relations', function() {
       }).catch(done);
     });
 
-
-
     it('should not allow duplicate record on scope with promises', function(done) {
       Category.findOne()
       .then(function(cat) {
@@ -5359,9 +5353,7 @@ describe('relations', function() {
       })
       .catch(done);
     });
-
   });
-
 
   describe('custom relation/scope methods', function() {
     var categoryId;

--- a/test/scope.test.js
+++ b/test/scope.test.js
@@ -329,9 +329,7 @@ describe('scope - filtered count, updateAll and destroyAll', function() {
 });
 
 describe('scope - dynamic target class', function() {
-
   var Collection, Media, Image, Video;
-
 
   before(function() {
     db = getSchema();


### PR DESCRIPTION
Upgrade eslint-config-loopback to ^2.0.0.

Remove extra empty lines to make `npm run lint` pass again.

@superkhau @Amir-61 PTAL