### PR TITLE
Updated dao.js updateOrCreate() for issue #914

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -573,7 +573,7 @@ DataAccessObject.upsert = function(data, options, cb) {
             hookState: ctx.hookState,
             options: options,
           };
-          if(err){
+          if (err) {
             return cb(err);
           }
           Model.notifyObserversOf('loaded', context, function(err) {

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -573,6 +573,9 @@ DataAccessObject.upsert = function(data, options, cb) {
             hookState: ctx.hookState,
             options: options,
           };
+          if(err){
+            return cb(err);
+          }
           Model.notifyObserversOf('loaded', context, function(err) {
             if (err) return cb(err);
 


### PR DESCRIPTION
Whenever updateOrCreate() in connector returns an error, the method in DAO should mitigate it back to the calling source. Added the error check that was missing.