### PR TITLE
Document promise support for DAO::find

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1568,7 +1568,8 @@ DataAccessObject._coerce = function(where) {
  *  - `{foo: true}` - include only foo
  * - `{bat: false}` - include all properties, exclude bat
  *
- * @param {Function} cb Required callback function.  Call this function with two arguments: `err` (null or Error) and an array of instances.
+ * @param {Function} cb Optional callback function.  Call this function with two arguments: `err` (null or Error) and an array of instances.
+ * @return {Promise} results If no callback function is provided, a promise (which resolves to an array of instances) is returned
  */
 
 DataAccessObject.find = function find(query, options, cb) {


### PR DESCRIPTION
It was previously completely undocumented. There are additional methods that add promises but I figure accurately documenting some is better than none. 😸 