### PR TITLE
Fix incompatibility between different connectors for replace methods

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -2722,13 +2722,6 @@ DataAccessObject.replaceById = function(id, data, options, cb) {
       }
 
       function callConnector() {
-        var idNames = Model.definition.idNames();
-        var propKeys = Object.keys(Model.definition.properties);
-        var nonIdsPropKeys = propKeys.filter(function(i) { return idNames.indexOf(i) < 0; });
-        for (var i = 0; i < nonIdsPropKeys.length; i++) {
-          var p = nonIdsPropKeys[i];
-          inst[p] = null;
-        }
         copyData(data, inst);
         var typedData = convertSubsetOfPropertiesByType(inst, data);
         context.data = typedData;

--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -800,8 +800,8 @@ describe('manipulation', function() {
               p.id.should.equal(created.id);
               p.should.not.have.property('_id');
               p.title.should.equal('b');
-              p.should.not.have.property(p.content);
-              p.should.not.have.property(p.comments);
+              p.should.have.property('content', undefined);
+              p.should.have.property('comments', undefined);
               return Post.findById(created.id)
               .then(function(p) {
                 p.should.not.have.property('_id');
@@ -830,8 +830,8 @@ describe('manipulation', function() {
               p.id.should.equal(created.id);
               p.should.not.have.property('_id');
               p.title.should.equal('b');
-              p.should.not.have.property(p.content);
-              p.should.not.have.property(p.comments);
+              p.should.have.property('content', undefined);
+              p.should.have.property('comments', undefined);
               return Post.findById(created.id)
               .then(function(p) {
                 p.should.not.have.property('_id');
@@ -858,8 +858,8 @@ describe('manipulation', function() {
               p.id.should.equal(post.id);
               p.should.not.have.property('_id');
               p.title.should.equal('b');
-              p.should.not.have.property(p.content);
-              p.should.not.have.property(p.comments);
+              p.should.have.property('content', undefined);
+              p.should.have.property('comments', undefined);
               Post.findById(post.id, function(err, p) {
                 if (err) return done(err);
                 p.id.should.eql(post.id);
@@ -887,8 +887,8 @@ describe('manipulation', function() {
               p.id.should.equal(post.id);
               p.should.not.have.property('_id');
               p.title.should.equal('b');
-              p.should.not.have.property(p.content);
-              p.should.not.have.property(p.comments);
+              p.should.have.property('content', undefined);
+              p.should.have.property('comments', undefined);
               Post.findById(post.id, function(err, p) {
                 if (err) return done(err);
                 p.id.should.eql(post.id);
@@ -992,7 +992,7 @@ describe('manipulation', function() {
           should.exist(p);
           p.should.be.instanceOf(Post);
           p.title.should.equal('b');
-          p.should.not.have.property('content', undefined);
+          p.should.have.property('content', undefined);
           return Post.findById(postInstance.id)
           .then(function(p) {
             p.title.should.equal('b');
@@ -1012,7 +1012,7 @@ describe('manipulation', function() {
           should.exist(p);
           p.should.be.instanceOf(Post);
           p.title.should.equal('b');
-          p.should.not.have.property('content', undefined);
+          p.should.have.property('content', undefined);
           return Post.findById(postInstance.id)
           .then(function(p) {
             p.title.should.equal('b');
@@ -1029,7 +1029,7 @@ describe('manipulation', function() {
           if (err) return done(err);
           p.replaceAttributes({ title: 'b' }, function(err, p) {
             if (err) return done(err);
-            p.should.not.have.property('content', undefined);
+            p.should.have.property('content', undefined);
             p.title.should.equal('b');
             done();
           });
@@ -1041,7 +1041,7 @@ describe('manipulation', function() {
           if (err) return done(err);
           p.replaceAttributes({ title: 'b' }, { validate: false }, function(err, p) {
             if (err) return done(err);
-            p.should.not.have.property('content', undefined);
+            p.should.have.property('content', undefined);
             p.title.should.equal('b');
             done();
           });


### PR DESCRIPTION
* The goal is to to achieve the following behaviour for missing values:

db | replaceById / replaceAttributes | replaceOrCreate
--- | --- | ---
*NoDQL (MongoDB)* | undefined| undefined
*NoSQL (Memory)* | undefined   |  undefined
*SQL DBs (Mysql)* |  undefined|   undefined


###### There were some bad tests which got replaced now based on the goal.


#### Test statuses: 

dependencies' tests | status
--- | --- | ---
*Loopback-connector-Mysql* | Aborted! [1] 👎 
*Loopback-connector-MSsql* | passed 👍 
*Loopback-connector-Oracle* |  passed 👍 
*Loopback-connector-Postgressql* |  passed 👍 
*Loopback-connector-mongodb* |  passed 👍 
*Loopback-connector-redis* |  passed 👍 
*Loopback-datasource-juggler* |  passed 👍 
*Loopback-connector-sqllite* |  first time failed, but second time passed [2] 👎 

[1]:[Here](http://ci.strongloop.com/job/loopback-connector-mysql/label=ubuntu-0.12/1250/console), The tests for `loopback-connector-mysql` gets aborted and I don't know why! Hey @rmg did you abort the `loopback-connector-mysql` tests?

[2]: [Here](http://ci.strongloop.com/job/loopback-connector-sqlite3/label=amazon-5/572/console) I get this failure: `Deprecation warning: moment construction falls back to js Date. This is discouraged and will be removed in upcoming major release. Please refer to https://github.com/moment/moment/issues/1407 for more info.`; again I don't think if it is relevant to this PR... Also the final result in this repos says passing:
```
[sl-ci-run INFO  234.4 ]: *************** BUILD FRAMEWORK REPORT CARD ****************
[sl-ci-run INFO  234.4 ]: **  Sanity checks         : pass   [required]
[sl-ci-run INFO  234.4 ]: **  Install dependencies  : pass   [required]
[sl-ci-run INFO  234.4 ]: **  Linter                : pass   [optional]
[sl-ci-run INFO  234.4 ]: **  Generate artifacts    : pass   [required]
[sl-ci-run INFO  234.4 ]: **  Run tests             : pass   [required]
[sl-ci-run INFO  234.4 ]: **  Coverage report       : pass   [optional]
[sl-ci-run INFO  234.4 ]: *************** BUILD FRAMEWORK REPORT CARD ****************
```


Connect to https://github.com/strongloop-internal/scrum-loopback/issues/891