### PR TITLE
[RFR][MINOR] Use Env Variable to configure Max Listeners at runtime

### DIFF
--- a/lib/model-builder.js
+++ b/lib/model-builder.js
@@ -185,7 +185,7 @@ ModelBuilder.prototype.define = function defineClass(className, properties, sett
     var events = new EventEmitter();
     // The model can have more than 10 listeners for lazy relationship setup
     // See https://github.com/strongloop/loopback/issues/404
-    events.setMaxListeners(32);
+    events.setMaxListeners(Number(process.env.MAX_LISTENERS) || 32);
     for (var f in EventEmitter.prototype) {
       if (typeof EventEmitter.prototype[f] === 'function') {
         if (f !== 'on') {


### PR DESCRIPTION
@bajtos @raymondfeng please review, simple configuration option to solve, (keeps your hard coded limits, but if I want to push the limits in test scenarios or architecture I should be able to ): 
- https://github.com/strongloop/loopback/issues/404
- https://github.com/strongloop/generator-loopback/issues/89
- https://github.com/strongloop/loopback-datasource-juggler/issues/805