### PR TITLE
[SEMVER-MAJOR] Throw Error for property names with dots

### DIFF
--- a/3.0-RELEASE-NOTES.md
+++ b/3.0-RELEASE-NOTES.md
@@ -75,3 +75,11 @@ Model events
 
 See [related code change](https://github.com/strongloop/loopback-datasource-juggler/pull/965)
 for more details.
+
+## Model property names with dot(s) generates an error
+
+Instead of showing a deprecation warning for model property names with dots,
+for example, `customer.name: 'string'`, an error is thrown in 3.0 for
+enforcing use of valid model property names.
+
+See [related code change](https://github.com/strongloop/loopback-datasource-juggler/pull/947) for more details.

--- a/lib/model-builder.js
+++ b/lib/model-builder.js
@@ -246,9 +246,9 @@ ModelBuilder.prototype.define = function defineClass(className, properties, sett
       delete properties[p];
     }
 
-    // Warn about properties with unsupported names
+    // Throw error for properties with unsupported names
     if (/\./.test(p)) {
-      deprecated('Property names containing a dot are not supported. ' +
+      throw new Error('Property names containing dot(s) are not supported. ' +
         'Model: ' + className + ', property: ' + p);
     }
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -232,11 +232,12 @@ ModelBaseClass.prototype._initProperties = function(data, options) {
         self[p] = self.__data[p] =
           (propVal !== undefined) ? propVal : self.__cachedRelations[p];
 
-        // Warn about properties with unsupported names
+        // Throw error for properties with unsupported names
         if (/\./.test(p)) {
-          deprecated('Property names containing a dot are not supported. ' +
-            'Model: ' + this.constructor.modelName +
-            ', dynamic property: ' + p);
+          throw new Error(
+            'Property names containing dot(s) are not supported. ' +
+            'Model: ' + this.constructor.modelName + ', dynamic property: ' +
+            p);
         }
       } else if (strict === 'throw') {
         throw new Error('Unknown property: ' + p);

--- a/test/model-definition.test.js
+++ b/test/model-definition.test.js
@@ -375,13 +375,10 @@ describe('ModelDefinition class', function() {
     });
   });
 
-  it('should report deprecation warning for property names containing dot', function() {
-    var message = 'deprecation not reported';
-    process.once('deprecation', function(err) { message = err.message; });
-
-    memory.createModel('Dotted', { 'dot.name': String });
-
-    message.should.match(/Dotted.*dot\.name/);
+  it('should throw error for property names containing dot', function() {
+    (function() { memory.createModel('Dotted', { 'dot.name': String }); })
+      .should
+      .throw(/dot\(s\).*Dotted.*dot\.name/);
   });
 
   it('should report deprecation warning for property named constructor', function() {
@@ -393,17 +390,15 @@ describe('ModelDefinition class', function() {
     message.should.match(/Property name should not be "constructor" in Model: Ctor/);
   });
 
-  it('should report deprecation warning for dynamic property names containing dot', function(done) {
-    var message = 'deprecation not reported';
-    process.once('deprecation', function(err) { message = err.message; });
-
-    var Model = memory.createModel('DynamicDotted');
-    Model.create({ 'dot.name': 'dot.value' }, function(err) {
-      if (err) return done(err);
-      message.should.match(/Dotted.*dot\.name/);
-      done();
+  it('should throw error for dynamic property names containing dot',
+    function(done) {
+      var Model = memory.createModel('DynamicDotted');
+      Model.create({ 'dot.name': 'dot.value' }, function(err) {
+        err.should.be.instanceOf(Error);
+        err.message.should.match(/dot\(s\).*DynamicDotted.*dot\.name/);
+        done();
+      });
     });
-  });
 
   it('should throw error for dynamic property named constructor', function(done) {
     var Model = memory.createModel('DynamicCtor');


### PR DESCRIPTION
Result of Compat Flags Clenup.
Throws an error for property names with dots, instead of a deprecation warning.

Connect to https://github.com/strongloop-internal/scrum-loopback/issues/765