### PR TITLE
2.x - Save on embedded model (from embedsOne relation) persist to parent

### DIFF
--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -2066,7 +2066,7 @@ EmbedsOne.prototype.related = function(condOrRefresh, options, cb) {
     return;
   }
 
-  var embeddedInstance = modelInstance[propertyName];
+  var embeddedInstance = this.embeddedValue();
 
   if (embeddedInstance) {
     embeddedInstance.__persisted = true;
@@ -2081,9 +2081,50 @@ EmbedsOne.prototype.related = function(condOrRefresh, options, cb) {
   }
 };
 
+EmbedsOne.prototype.prepareEmbeddedInstance = function(inst) {
+  if (inst && inst.triggerParent !== 'function') {
+    var self = this;
+    var propertyName = this.definition.keyFrom;
+    var modelInstance = this.modelInstance;
+    if (this.definition.options.persistent) {
+      var pk = this.definition.keyTo;
+      inst.__persisted = !!inst[pk];
+    } else {
+      inst.__persisted = true;
+    }
+    inst.triggerParent = function(actionName, callback) {
+      if (actionName === 'save' || actionName === 'destroy') {
+        var embeddedValue = self.embeddedValue();
+        modelInstance.updateAttribute(propertyName,
+          embeddedValue, function(err, modelInst) {
+            callback(err, err ? null : modelInst);
+          });
+      } else {
+        process.nextTick(callback);
+      }
+    };
+    var originalTrigger = inst.trigger;
+    inst.trigger = function(actionName, work, data, callback) {
+      if (typeof work === 'function') {
+        var originalWork = work;
+        work = function(next) {
+          originalWork.call(this, function(done) {
+            inst.triggerParent(actionName, function(err, inst) {
+              next(done); // TODO [fabien] - error handling?
+            });
+          });
+        };
+      }
+      originalTrigger.call(this, actionName, work, data, callback);
+    };
+  }
+};
+
 EmbedsOne.prototype.embeddedValue = function(modelInstance) {
   modelInstance = modelInstance || this.modelInstance;
-  return modelInstance[this.definition.keyFrom];
+  var embeddedValue = modelInstance[this.definition.keyFrom];
+  this.prepareEmbeddedInstance(embeddedValue);
+  return embeddedValue;
 };
 
 EmbedsOne.prototype.create = function(targetModelData, options, cb) {
@@ -2184,6 +2225,8 @@ EmbedsOne.prototype.build = function(targetModelData) {
   var embeddedInstance = new modelTo(targetModelData);
   modelInstance[propertyName] = embeddedInstance;
 
+  this.prepareEmbeddedInstance(embeddedInstance);
+
   return embeddedInstance;
 };
 
@@ -2201,7 +2244,7 @@ EmbedsOne.prototype.update = function(targetModelData, options, cb) {
   var isInst = targetModelData instanceof ModelBaseClass;
   var data = isInst ? targetModelData.toObject() : targetModelData;
 
-  var embeddedInstance = modelInstance[propertyName];
+  var embeddedInstance = this.embeddedValue();
   if (embeddedInstance instanceof modelTo) {
     cb = cb || utils.createPromiseCallback();
     var hookState = {};

--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -2093,12 +2093,18 @@ EmbedsOne.prototype.prepareEmbeddedInstance = function(inst) {
       inst.__persisted = true;
     }
     inst.triggerParent = function(actionName, callback) {
-      if (actionName === 'save' || actionName === 'destroy') {
+      if (actionName === 'save') {
         var embeddedValue = self.embeddedValue();
         modelInstance.updateAttribute(propertyName,
           embeddedValue, function(err, modelInst) {
             callback(err, err ? null : modelInst);
           });
+      } else if (actionName === 'destroy') {
+        modelInstance.unsetAttribute(propertyName, true);
+        // cannot delete property completely the way save works. operator $unset needed like mongo
+        modelInstance.save(function(err, modelInst) {
+          callback(err, modelInst);
+        });
       } else {
         process.nextTick(callback);
       }

--- a/test/persistence-hooks.suite.js
+++ b/test/persistence-hooks.suite.js
@@ -3006,10 +3006,10 @@ module.exports = function(dataSource, should, connectorCapabilities) {
     function monitorHookExecution(hookNames) {
       hookMonitor.install(TestModel, hookNames);
     }
-
+    
     require('./operation-hooks.suite')(dataSource, should, connectorCapabilities);
   });
-
+  
   function get(propertyName) {
     return function(obj) {
       return obj[propertyName];

--- a/test/persistence-hooks.suite.js
+++ b/test/persistence-hooks.suite.js
@@ -3006,11 +3006,10 @@ module.exports = function(dataSource, should, connectorCapabilities) {
     function monitorHookExecution(hookNames) {
       hookMonitor.install(TestModel, hookNames);
     }
-    
+
     require('./operation-hooks.suite')(dataSource, should, connectorCapabilities);
   });
-  
-  
+
   function get(propertyName) {
     return function(obj) {
       return obj[propertyName];

--- a/test/persistence-hooks.suite.js
+++ b/test/persistence-hooks.suite.js
@@ -3010,6 +3010,7 @@ module.exports = function(dataSource, should, connectorCapabilities) {
     require('./operation-hooks.suite')(dataSource, should, connectorCapabilities);
   });
   
+  
   function get(propertyName) {
     return function(obj) {
       return obj[propertyName];

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -3836,6 +3836,7 @@ describe('relations', function() {
       tmp = getTransientDataSource();
       // db = getSchema();
       Person = db.define('Person', { name: String });
+      // mark name required
       Passport = tmp.define('Passport',
         {
           id: { type: 'string', id: true, generated: true },

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -3797,7 +3797,10 @@ describe('relations', function() {
           Passport.definition.hasPK = originalHasPK;
           done();
         })
-        .catch(done);
+        .catch(function(err) {
+          Passport.definition.hasPK = originalHasPK;
+          done(err);
+        });
     });
   });
 

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -3779,12 +3779,12 @@ describe('relations', function() {
     it('should also save changes when directly saving the embedded model', function(done) {
       // Passport should normally have an id for the direct save to work. For now override the check
       var originalHasPK = Passport.definition.hasPK;
-      Passport.definition.hasPK = function(){ return true };
+      Passport.definition.hasPK = function() { return true; };
       Person.findById(personId)
         .then(function(p) {
           return p.passportItem.create({ name: 'Mitsos' });
         })
-        .then(function (passport) {
+        .then(function(passport) {
           passport.name = 'Jim';
           return passport.save();
         })

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -3802,6 +3802,26 @@ describe('relations', function() {
           done(err);
         });
     });
+
+    it('should delete the embedded document and also update parent', function(done) {
+      var originalHasPK = Passport.definition.hasPK;
+      Passport.definition.hasPK = function() { return true; };
+      Person.findById(personId)
+        .then(function(p) {
+          return p.passportItem().destroy();
+        })
+        .then(function() {
+          return Person.findById(personId);
+        })
+        .then(function(person) {
+          person.should.have.property('passport', null);
+          done();
+        })
+        .catch(function(err) {
+          Passport.definition.hasPK = originalHasPK;
+          done(err);
+        });
+    });
   });
 
   describe('embedsOne - persisted model', function() {

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -3775,6 +3775,30 @@ describe('relations', function() {
         done();
       }).catch(done);
     });
+
+    it('should also save changes when directly saving the embedded model', function(done) {
+      // Passport should normally have an id for the direct save to work. For now override the check
+      var originalHasPK = Passport.definition.hasPK;
+      Passport.definition.hasPK = function(){ return true };
+      Person.findById(personId)
+        .then(function(p) {
+          return p.passportItem.create({ name: 'Mitsos' });
+        })
+        .then(function (passport) {
+          passport.name = 'Jim';
+          return passport.save();
+        })
+        .then(function() {
+          return Person.findById(personId);
+        })
+        .then(function(person) {
+          person.passportItem().toObject().should.eql({ name: 'Jim' });
+          // restore original hasPk
+          Passport.definition.hasPK = originalHasPK;
+          done();
+        })
+        .catch(done);
+    });
   });
 
   describe('embedsOne - persisted model', function() {


### PR DESCRIPTION
Implemented override of trigger for embedsOne relationship embedded document, to allow direct save of changes on embedded model to be persisted on parent document.

ex:
```
Person.embedsOne(Address);
Person.findById(someId)
  .then(function(p){
    var address = p.addressItem();
    address.street = 'new street'
    return address.save(); // This will now persist changes on parent p documentt
  })
```

**Note:** Commit Linter tests fail for some reason, but when I click on details nothing shows up.... on the repository running npm test or npm run lint, completes succesfully...