### PR TITLE
Fix error message

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -2672,7 +2672,7 @@ DataAccessObject.replaceById = function(id, data, options, cb) {
 
   if (id !== data[pkName]) {
     var err = new Error('id property (' + pkName + ') ' +
-            'cannot be updated from ' + inst[pkName] + ' to ' + data[pkName]);
+            'cannot be updated from ' + id + ' to ' + data[pkName]);
     err.statusCode = 400;
     process.nextTick(function() { cb(err); });
     return cb.promise;

--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -1024,6 +1024,18 @@ describe('manipulation', function() {
       .catch(done);
       });
 
+      it('should fail when changing id', function(done) {
+        Post.findById(postInstance.id, function(err, p) {
+          if (err) return done(err);
+          p.replaceAttributes({ title: 'b', id: 999 }, function(err, p) {
+            should.exist(err);
+            var expectedErrMsg = 'id property (id) cannot be updated from ' + postInstance.id + ' to 999';
+            err.message.should.equal(expectedErrMsg);
+            done();
+          });
+        });
+      });
+
       it('works without options(callback variant)', function(done) {
         Post.findById(postInstance.id, function(err, p) {
           if (err) return done(err);


### PR DESCRIPTION
* Fix error message when PK is changed in `replaceById` and test coverage

*Note: It needs to be back-ported to 2.x.*

To: @bajtos 