### PR TITLE
Give warning if PK is changed in hooks

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -2666,6 +2666,13 @@ DataAccessObject.replaceById = function(id, data, options, cb) {
   Model.notifyObserversOf('before save', context, function(err, ctx) {
     if (err) return cb(err);
 
+    if (ctx.instance[pkName] !== id && !Model._warned.cannotOverwritePKInBeforeSaveHook) {
+      Model._warned.cannotOverwritePKInBeforeSaveHook = true;
+      console.warn('WARNING: id property cannot be changed from ' +
+        id + ' to ' + inst[pkName] + ' for model:' + Model.modelName +
+        ' in \'before save\' operation hook');
+    }
+
     data = inst.toObject(false);
 
     if (strict) {
@@ -2717,7 +2724,15 @@ DataAccessObject.replaceById = function(id, data, options, cb) {
           Model.notifyObserversOf('loaded', ctx, function(err) {
             if (err) return cb(err);
 
+            if (ctx.data[pkName] !== id && !Model._warned.cannotOverwritePKInLoadedHook) {
+              Model._warned.cannotOverwritePKInLoadedHook = true;
+              console.warn('WARNING: id property cannot be changed from ' +
+                id + ' to ' + ctx.data[pkName] + ' for model:' + Model.modelName +
+                ' in \'loaded\' operation hook');
+            }
+
             inst.__persisted = true;
+            ctx.data[pkName] = id;
             inst.setAttributes(ctx.data);
 
             var context = {

--- a/lib/model-builder.js
+++ b/lib/model-builder.js
@@ -231,6 +231,7 @@ ModelBuilder.prototype.define = function defineClass(className, properties, sett
   hiddenProperty(ModelClass, 'http', { path: pathName });
   hiddenProperty(ModelClass, 'base', ModelBaseClass);
   hiddenProperty(ModelClass, '_observers', {});
+  hiddenProperty(ModelClass, '_warned', {});
 
   // inherit ModelBaseClass static methods
   for (var i in ModelBaseClass) {


### PR DESCRIPTION
* Give warning if PK is changed in `before save` and `loaded`
 operation hooks for replaceById

Connect to https://github.com/strongloop/loopback-datasource-juggler/pull/952