### PR TITLE
[SEMVER-MAJOR] Remove DataSource.registerType()

### DIFF
--- a/3.0-RELEASE-NOTES.md
+++ b/3.0-RELEASE-NOTES.md
@@ -83,3 +83,11 @@ for example, `customer.name: 'string'`, an error is thrown in 3.0 for
 enforcing use of valid model property names.
 
 See [related code change](https://github.com/strongloop/loopback-datasource-juggler/pull/947) for more details.
+
+## Remove wrapper `DataSource.registerType()`
+
+`DataSource.registerType() method is removed as it was a wrapper for
+`ModelBuilder.registerType()` and was deprecated.
+
+See [related code change](https://github.com/strongloop/loopback-datasource-juggler/pull/976)
+for more details.

--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -2192,11 +2192,3 @@ function defineReadonlyProp(obj, key, value) {
 DataSource.Text = ModelBuilder.Text;
 DataSource.JSON = ModelBuilder.JSON;
 DataSource.Any = ModelBuilder.Any;
-
-/*!
- * @deprecated Use ModelBuilder.registerType instead
- * @param type
- */
-DataSource.registerType = function(type) {
-  ModelBuilder.registerType(type);
-};


### PR DESCRIPTION
Result of compat flag cleanup.
- Current implementation has a wrapper
DataSource.registerType() for
ModelBuilder.registerType(). This removes
the wrapper to encourage use of original
method.

Connect to https://github.com/strongloop-internal/scrum-loopback/issues/766