### PR TITLE
Updata datasource.js 2.x

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -2150,7 +2150,7 @@ DataSource.prototype.ping = function(cb) {
     self.discoverModelProperties('dummy', {}, cb);
   } else {
     process.nextTick(function() {
-      var err = self.connected ? null : 'Not connected';
+      var err = self.connected ? null : new Error('Not connected');
       cb(err);
     });
   }


### PR DESCRIPTION
Return a real Error message for the default ping() method.

Connect to https://github.com/strongloop/loopback-datasource-juggler/pull/960

Talked to @ritch and since [his PR](https://github.com/strongloop/loopback-datasource-juggler/pull/960) on master got LGTM, now I'm back-porting to `2.x`.