### PR TITLE
"Near" fix for Where clauses that contain and/or

### DIFF
--- a/lib/geo.js
+++ b/lib/geo.js
@@ -9,80 +9,145 @@ var assert = require('assert');
 
 /*!
  * Get a near filter from a given where object. For connector use only.
+ * NB: This only supports one near parameter per where object.  eg, this:
+ * {where: {or: [{location: {near: "29,-90"}},{location: {near: "50,-72"}}]}}
+ * would throw an error.
  */
 
 exports.nearFilter = function nearFilter(where) {
-  var result = false;
+  function nearSearch(clause) {
+    if (typeof clause !== 'object') {
+      return false;
+    }
 
-  if (where && typeof where === 'object') {
-    Object.keys(where).forEach(function(key) {
-      var ex = where[key];
-
-      if (ex && ex.near) {
-        result = {
-          near: ex.near,
-          maxDistance: ex.maxDistance,
-          unit: ex.unit,
-          key: key,
-        };
+    Object.keys(clause).forEach(function(clauseKey) {
+      if (Array.isArray(clause[clauseKey])) {
+        clause[clauseKey].forEach(function(el) {
+          var ret = nearSearch(el);
+          if (ret) return ret;
+        });
+      } else {
+        if (clause[clauseKey].hasOwnProperty('near')) {
+          var result = clause[clauseKey];
+          nearResults.push({
+            near: result.near,
+            maxDistance: result.maxDistance,
+            unit: result.unit,
+            key: clauseKey,
+          });
+        }
       }
     });
   }
+  var nearResults = [];
+  nearSearch(where);
 
-  return result;
+  if (nearResults.length === 0) {
+    return false;
+  }
+  return nearResults;
 };
 
 /*!
- * Filter a set of objects using the given `nearFilter`.
+ * Filter a set of objects using the given `nearFilter`.  Can support multiple
+ * locations, but will include results from all of them.
+ *
+ * WARNING: "or" operator with GeoPoint does not work as expected, eg:
+ * {where: {or: [{location: {near: (29,-90)}},{name:'Sean'}]}}
+ * Will actually work as if you had used "and".  This is because geo filtering
+ * takes place outside of the SQL query, so the result set of "name = Sean" is
+ * returned by the database, and then the location filtering happens in the app
+ * logic.  So the "near" operator is always an "and" of the SQL filters, and "or"
+ * of other GeoPoint filters.
+ *
+ * Additionally, since this step occurs after the SQL result set is returned,
+ * if using GeoPoints with pagination the result set may be smaller than the
+ * page size.  The page size is enforced at the DB level, and then we may
+ * remove results at the Geo-app level.  If we "limit: 25", but 4 of those results
+ * do not have a matching geopoint field, the request will only return 21 results.
+ * This may make it erroneously look like a given page is the end of the result set.
  */
 
-exports.filter = function(arr, filter) {
-  var origin = filter.near;
-  var max = filter.maxDistance > 0 ? filter.maxDistance : false;
-  var unit = filter.unit;
-  var key = filter.key;
-
-  // create distance index
+exports.filter = function(arr, filters) {
   var distances = {};
   var result = [];
 
-  arr.forEach(function(obj) {
-    var loc = obj[key];
+  filters.forEach(function(filter) {
+    var origin = filter.near;
+    var max = filter.maxDistance > 0 ? filter.maxDistance : false;
+    var unit = filter.unit;
+    var key = filter.key;
 
-    // filter out objects without locations
-    if (!loc) return;
+    // create distance index
+    arr.forEach(function(obj) {
+      var loc = obj[key];
 
-    if (!(loc instanceof GeoPoint)) {
-      loc = GeoPoint(loc);
-    }
+      // filter out objects without locations
+      if (!loc) return;
 
-    if (typeof loc.lat !== 'number') return;
-    if (typeof loc.lng !== 'number') return;
+      if (!(loc instanceof GeoPoint)) {
+        loc = GeoPoint(loc);
+      }
 
-    var d = GeoPoint.distanceBetween(origin, loc, {type: unit});
+      var d = GeoPoint.distanceBetween(origin, loc, {
+        type: unit
+      });
+      if (typeof loc.lat !== 'number') return;
+      if (typeof loc.lng !== 'number') return;
 
-    if (max && d > max) {
-      // dont add
-    } else {
-      distances[obj.id] = d;
-      result.push(obj);
-    }
+      var d = GeoPoint.distanceBetween(origin, loc, {
+        type: unit
+      });
+
+      if (max && d > max) {
+        // dont add
+      } else {
+        distances[obj.id] = d;
+        result.push(obj);
+      }
+    });
+
+    result.sort(function(objA, objB) {
+      var a = objA[key];
+      var b = objB[key];
+
+      if (a && b) {
+        var da = distances[objA.id];
+        var db = distances[objB.id];
+
+        if (typeof loc.lat !== 'number') return;
+        if (typeof loc.lng !== 'number') return;
+
+        var d = GeoPoint.distanceBetween(origin, loc, {
+          type: unit
+        });
+
+        if (max && d > max) {
+          // dont add
+        } else {
+          distances[obj.id] = d;
+          result.push(obj);
+        }
+      }
+    });
+
+    result.sort(function(objA, objB) {
+      var a = objA[key];
+      var b = objB[key];
+
+      if (a && b) {
+        var da = distances[objA.id];
+        var db = distances[objB.id];
+
+        if (db === da) return 0;
+        return da > db ? 1 : -1;
+      } else {
+        return 0;
+      }
+    });
   });
 
-  return result.sort(function(objA, objB) {
-    var a = objA[key];
-    var b = objB[key];
-
-    if (a && b) {
-      var da = distances[objA.id];
-      var db = distances[objB.id];
-
-      if (db === da) return 0;
-      return da > db ? 1 : -1;
-    } else {
-      return 0;
-    }
-  });
+  return result;
 };
 
 exports.GeoPoint = GeoPoint;
@@ -243,7 +308,7 @@ GeoPoint.prototype.toString = function() {
  * @property {Number} DEG2RAD - Factor to convert degrees to radians.
  * @property {Number} RAD2DEG - Factor to convert radians to degrees.
  * @property {Object} EARTH_RADIUS - Radius of the earth.
-*/
+ */
 
 // factor to convert degrees to radians
 var DEG2RAD = 0.01745329252;
@@ -280,4 +345,3 @@ function geoDistance(x1, y1, x2, y2, options) {
 
   return 2 * Math.asin(f) * EARTH_RADIUS[type];
 }
-

--- a/test/basic-querying.test.js
+++ b/test/basic-querying.test.js
@@ -15,13 +15,38 @@ describe('basic-querying', function() {
   before(function(done) {
     db = getSchema();
     User = db.define('User', {
-      seq: {type: Number, index: true},
-      name: {type: String, index: true, sort: true},
-      email: {type: String, index: true},
-      birthday: {type: Date, index: true},
-      role: {type: String, index: true},
-      order: {type: Number, index: true, sort: true},
-      vip: {type: Boolean},
+      seq: {
+        type: Number,
+        index: true
+      },
+      name: {
+        type: String,
+        index: true,
+        sort: true
+      },
+      email: {
+        type: String,
+        index: true
+      },
+      birthday: {
+        type: Date,
+        index: true
+      },
+      role: {
+        type: String,
+        index: true
+      },
+      order: {
+        type: Number,
+        index: true,
+        sort: true
+      },
+      vip: {
+        type: Boolean
+      },
+      addressLoc: {
+        type: 'GeoPoint'
+      },
     });
 
     db.automigrate(done);
@@ -66,14 +91,21 @@ describe('basic-querying', function() {
   describe('findByIds', function() {
     var createdUsers;
     before(function(done) {
-      var people = [
-        {name: 'a', vip: true},
-        {name: 'b'},
-        {name: 'c'},
-        {name: 'd', vip: true},
-        {name: 'e'},
-        {name: 'f'},
-      ];
+      var people = [{
+        name: 'a',
+        vip: true
+      }, {
+        name: 'b'
+      }, {
+        name: 'c'
+      }, {
+        name: 'd',
+        vip: true
+      }, {
+        name: 'e'
+      }, {
+        name: 'f'
+      }, ];
       db.automigrate(['User'], function(err) {
         User.create(people, function(err, users) {
           should.not.exist(err);
@@ -105,21 +137,24 @@ describe('basic-querying', function() {
         createdUsers[0].id,
         createdUsers[1].id,
         createdUsers[2].id,
-        createdUsers[3].id],
-        {where: {vip: true}}, function(err, users) {
-          should.exist(users);
-          should.not.exist(err);
-          var names = users.map(function(u) {
-            return u.name;
-          });
-          names.should.eql(createdUsers.slice(0, 4).
-            filter(function(u) {
-              return u.vip;
-            }).map(function(u) {
-              return u.name;
-            }));
-          done();
+        createdUsers[3].id
+      ], {
+        where: {
+          vip: true
+        }
+      }, function(err, users) {
+        should.exist(users);
+        should.not.exist(err);
+        var names = users.map(function(u) {
+          return u.name;
         });
+        names.should.eql(createdUsers.slice(0, 4).filter(function(u) {
+          return u.vip;
+        }).map(function(u) {
+          return u.name;
+        }));
+        done();
+      });
     });
   });
 
@@ -144,7 +179,9 @@ describe('basic-querying', function() {
     });
 
     it('should query limited collection', function(done) {
-      User.find({limit: 3}, function(err, users) {
+      User.find({
+        limit: 3
+      }, function(err, users) {
         should.exists(users);
         should.not.exists(err);
         users.should.have.lengthOf(3);
@@ -152,8 +189,81 @@ describe('basic-querying', function() {
       });
     });
 
+    it('should support nested GeoPoint near queries', function(done) {
+      User.find({
+        where: {
+          and: [{
+            addressLoc: {
+              near: '29.9,-90.07'
+            }
+          }, {
+            vip: true
+          }]
+        },
+      }, function(err, users) {
+        if (err) return done(err);
+        users.should.have.property('length', 2);
+        users[0].addressLoc.should.not.equal(null);
+        done();
+      });
+    });
+
+    it('should support very nested GeoPoint near queries', function(done) {
+      User.find({
+        where: {
+          and: [{
+            and: [{
+              addressLoc: {
+                near: '29.9,-90.07'
+              }
+            }, {
+              order: 2
+            }]
+          }, {
+            vip: true
+          }, ]
+        },
+      }, function(err, users) {
+        if (err) return done(err);
+        users.should.have.property('length', 1);
+        users[0].addressLoc.should.not.equal(null);
+        done();
+      });
+    });
+
+    it('should support multiple GeoPoint near queries', function(done) {
+      User.find({
+        where: {
+          and: [{
+            or: [{
+              addressLoc: {
+                near: '29.9,-90.04',
+                maxDistance: 300
+              }
+            }, {
+              addressLoc: {
+                near: '22.97, -88.03',
+                maxDistance: 300
+              }
+            }, ]
+          }, {
+            vip: true
+          }, ]
+        },
+      }, function(err, users) {
+        if (err) return done(err);
+        users.should.have.property('length', 2);
+        users[0].addressLoc.should.not.equal(null);
+        done();
+      });
+    });
+
     it('should query collection with skip & limit', function(done) {
-      User.find({skip: 1, limit: 4, order: 'seq'}, function(err, users) {
+      User.find({
+        skip: 1,
+        limit: 4,
+        order: 'seq'
+      }, function(err, users) {
         should.exists(users);
         should.not.exists(err);
         users[0].seq.should.be.eql(1);
@@ -163,7 +273,11 @@ describe('basic-querying', function() {
     });
 
     it('should query collection with offset & limit', function(done) {
-      User.find({offset: 2, limit: 3, order: 'seq'}, function(err, users) {
+      User.find({
+        offset: 2,
+        limit: 3,
+        order: 'seq'
+      }, function(err, users) {
         should.exists(users);
         should.not.exists(err);
         users[0].seq.should.be.eql(2);
@@ -173,7 +287,11 @@ describe('basic-querying', function() {
     });
 
     it('should query filtered collection', function(done) {
-      User.find({where: {role: 'lead'}}, function(err, users) {
+      User.find({
+        where: {
+          role: 'lead'
+        }
+      }, function(err, users) {
         should.exists(users);
         should.not.exists(err);
         users.should.have.lengthOf(2);
@@ -182,7 +300,9 @@ describe('basic-querying', function() {
     });
 
     it('should query collection sorted by numeric field', function(done) {
-      User.find({order: 'order'}, function(err, users) {
+      User.find({
+        order: 'order'
+      }, function(err, users) {
         should.exists(users);
         should.not.exists(err);
         users.forEach(function(u, i) {
@@ -193,7 +313,9 @@ describe('basic-querying', function() {
     });
 
     it('should query collection desc sorted by numeric field', function(done) {
-      User.find({order: 'order DESC'}, function(err, users) {
+      User.find({
+        order: 'order DESC'
+      }, function(err, users) {
         should.exists(users);
         should.not.exists(err);
         users.forEach(function(u, i) {
@@ -204,7 +326,9 @@ describe('basic-querying', function() {
     });
 
     it('should query collection sorted by string field', function(done) {
-      User.find({order: 'name'}, function(err, users) {
+      User.find({
+        order: 'name'
+      }, function(err, users) {
         should.exists(users);
         should.not.exists(err);
         users.shift().name.should.equal('George Harrison');
@@ -215,7 +339,9 @@ describe('basic-querying', function() {
     });
 
     it('should query collection desc sorted by string field', function(done) {
-      User.find({order: 'name DESC'}, function(err, users) {
+      User.find({
+        order: 'name DESC'
+      }, function(err, users) {
         should.exists(users);
         should.not.exists(err);
         users.pop().name.should.equal('George Harrison');
@@ -226,22 +352,32 @@ describe('basic-querying', function() {
     });
 
     it('should query sorted desc by order integer field even though there' +
-        'is an async model loaded hook', function(done) {
-      User.find({order: 'order DESC'}, function(err, users) {
-        if (err) return done(err);
+      'is an async model loaded hook',
+      function(done) {
+        User.find({
+          order: 'order DESC'
+        }, function(err, users) {
+          if (err) return done(err);
 
-        should.exists(users);
-        var order = users.map(function(u) { return u.order; });
-        order.should.eql([6, 5, 4, 3, 2, 1]);
-        done();
+          should.exists(users);
+          var order = users.map(function(u) {
+            return u.order;
+          });
+          order.should.eql([6, 5, 4, 3, 2, 1]);
+          done();
+        });
       });
-    });
 
     it('should support "and" operator that is satisfied', function(done) {
-      User.find({where: {and: [
-        {name: 'John Lennon'},
-        {role: 'lead'},
-      ]}}, function(err, users) {
+      User.find({
+        where: {
+          and: [{
+            name: 'John Lennon'
+          }, {
+            role: 'lead'
+          }, ]
+        }
+      }, function(err, users) {
         should.not.exist(err);
         users.should.have.property('length', 1);
         done();
@@ -249,10 +385,15 @@ describe('basic-querying', function() {
     });
 
     it('should support "and" operator that is not satisfied', function(done) {
-      User.find({where: {and: [
-        {name: 'John Lennon'},
-        {role: 'member'},
-      ]}}, function(err, users) {
+      User.find({
+        where: {
+          and: [{
+            name: 'John Lennon'
+          }, {
+            role: 'member'
+          }, ]
+        }
+      }, function(err, users) {
         should.not.exist(err);
         users.should.have.property('length', 0);
         done();
@@ -260,10 +401,15 @@ describe('basic-querying', function() {
     });
 
     it('should support "or" that is satisfied', function(done) {
-      User.find({where: {or: [
-        {name: 'John Lennon'},
-        {role: 'lead'},
-      ]}}, function(err, users) {
+      User.find({
+        where: {
+          or: [{
+            name: 'John Lennon'
+          }, {
+            role: 'lead'
+          }, ]
+        }
+      }, function(err, users) {
         should.not.exist(err);
         users.should.have.property('length', 2);
         done();
@@ -271,10 +417,15 @@ describe('basic-querying', function() {
     });
 
     it('should support "or" operator that is not satisfied', function(done) {
-      User.find({where: {or: [
-        {name: 'XYZ'},
-        {role: 'Hello1'},
-      ]}}, function(err, users) {
+      User.find({
+        where: {
+          or: [{
+            name: 'XYZ'
+          }, {
+            role: 'Hello1'
+          }, ]
+        }
+      }, function(err, users) {
         should.not.exist(err);
         users.should.have.property('length', 0);
         done();
@@ -282,8 +433,14 @@ describe('basic-querying', function() {
     });
 
     it('should support date "gte" that is satisfied', function(done) {
-      User.find({order: 'seq', where: {birthday: {'gte': new Date('1980-12-08')},
-      }}, function(err, users) {
+      User.find({
+        order: 'seq',
+        where: {
+          birthday: {
+            'gte': new Date('1980-12-08')
+          },
+        }
+      }, function(err, users) {
         should.not.exist(err);
         users.should.have.property('length', 1);
         users[0].name.should.equal('John Lennon');
@@ -292,8 +449,14 @@ describe('basic-querying', function() {
     });
 
     it('should support date "gt" that is not satisfied', function(done) {
-      User.find({order: 'seq', where: {birthday: {'gt': new Date('1980-12-08')},
-      }}, function(err, users) {
+      User.find({
+        order: 'seq',
+        where: {
+          birthday: {
+            'gt': new Date('1980-12-08')
+          },
+        }
+      }, function(err, users) {
         should.not.exist(err);
         users.should.have.property('length', 0);
         done();
@@ -301,8 +464,14 @@ describe('basic-querying', function() {
     });
 
     it('should support date "gt" that is satisfied', function(done) {
-      User.find({order: 'seq', where: {birthday: {'gt': new Date('1980-12-07')},
-      }}, function(err, users) {
+      User.find({
+        order: 'seq',
+        where: {
+          birthday: {
+            'gt': new Date('1980-12-07')
+          },
+        }
+      }, function(err, users) {
         should.not.exist(err);
         users.should.have.property('length', 1);
         users[0].name.should.equal('John Lennon');
@@ -311,8 +480,14 @@ describe('basic-querying', function() {
     });
 
     it('should support date "lt" that is satisfied', function(done) {
-      User.find({order: 'seq', where: {birthday: {'lt': new Date('1980-12-07')},
-      }}, function(err, users) {
+      User.find({
+        order: 'seq',
+        where: {
+          birthday: {
+            'lt': new Date('1980-12-07')
+          },
+        }
+      }, function(err, users) {
         should.not.exist(err);
         users.should.have.property('length', 1);
         users[0].name.should.equal('Paul McCartney');
@@ -321,8 +496,14 @@ describe('basic-querying', function() {
     });
 
     it('should support number "gte" that is satisfied', function(done) {
-      User.find({order: 'seq', where: {order: {'gte': 3},
-      }}, function(err, users) {
+      User.find({
+        order: 'seq',
+        where: {
+          order: {
+            'gte': 3
+          },
+        }
+      }, function(err, users) {
         should.not.exist(err);
         users.should.have.property('length', 4);
         users[0].name.should.equal('George Harrison');
@@ -331,8 +512,14 @@ describe('basic-querying', function() {
     });
 
     it('should support number "gt" that is not satisfied', function(done) {
-      User.find({order: 'seq', where: {order: {'gt': 6},
-      }}, function(err, users) {
+      User.find({
+        order: 'seq',
+        where: {
+          order: {
+            'gt': 6
+          },
+        }
+      }, function(err, users) {
         should.not.exist(err);
         users.should.have.property('length', 0);
         done();
@@ -340,8 +527,14 @@ describe('basic-querying', function() {
     });
 
     it('should support number "gt" that is satisfied', function(done) {
-      User.find({order: 'seq', where: {order: {'gt': 5},
-      }}, function(err, users) {
+      User.find({
+        order: 'seq',
+        where: {
+          order: {
+            'gt': 5
+          },
+        }
+      }, function(err, users) {
         should.not.exist(err);
         users.should.have.property('length', 1);
         users[0].name.should.equal('Ringo Starr');
@@ -350,8 +543,14 @@ describe('basic-querying', function() {
     });
 
     it('should support number "lt" that is satisfied', function(done) {
-      User.find({order: 'seq', where: {order: {'lt': 2},
-      }}, function(err, users) {
+      User.find({
+        order: 'seq',
+        where: {
+          order: {
+            'lt': 2
+          },
+        }
+      }, function(err, users) {
         should.not.exist(err);
         users.should.have.property('length', 1);
         users[0].name.should.equal('Paul McCartney');
@@ -360,8 +559,14 @@ describe('basic-querying', function() {
     });
 
     it('should support number "gt" that is satisfied by null value', function(done) {
-      User.find({order: 'seq', where: {order: {'gt': null},
-      }}, function(err, users) {
+      User.find({
+        order: 'seq',
+        where: {
+          order: {
+            'gt': null
+          },
+        }
+      }, function(err, users) {
         should.not.exist(err);
         users.should.have.property('length', 0);
         done();
@@ -369,8 +574,14 @@ describe('basic-querying', function() {
     });
 
     it('should support number "lt" that is not satisfied by null value', function(done) {
-      User.find({order: 'seq', where: {order: {'lt': null},
-      }}, function(err, users) {
+      User.find({
+        order: 'seq',
+        where: {
+          order: {
+            'lt': null
+          },
+        }
+      }, function(err, users) {
         should.not.exist(err);
         users.should.have.property('length', 0);
         done();
@@ -378,8 +589,14 @@ describe('basic-querying', function() {
     });
 
     it('should support string "gte" that is satisfied by null value', function(done) {
-      User.find({order: 'seq', where: {name: {'gte': null},
-      }}, function(err, users) {
+      User.find({
+        order: 'seq',
+        where: {
+          name: {
+            'gte': null
+          },
+        }
+      }, function(err, users) {
         should.not.exist(err);
         users.should.have.property('length', 0);
         done();
@@ -387,8 +604,14 @@ describe('basic-querying', function() {
     });
 
     it('should support string "gte" that is satisfied', function(done) {
-      User.find({order: 'seq', where: {name: {'gte': 'Paul McCartney'},
-      }}, function(err, users) {
+      User.find({
+        order: 'seq',
+        where: {
+          name: {
+            'gte': 'Paul McCartney'
+          },
+        }
+      }, function(err, users) {
         should.not.exist(err);
         users.should.have.property('length', 4);
         users[0].name.should.equal('Paul McCartney');
@@ -397,8 +620,14 @@ describe('basic-querying', function() {
     });
 
     it('should support string "gt" that is not satisfied', function(done) {
-      User.find({order: 'seq', where: {name: {'gt': 'xyz'},
-      }}, function(err, users) {
+      User.find({
+        order: 'seq',
+        where: {
+          name: {
+            'gt': 'xyz'
+          },
+        }
+      }, function(err, users) {
         should.not.exist(err);
         users.should.have.property('length', 0);
         done();
@@ -406,8 +635,14 @@ describe('basic-querying', function() {
     });
 
     it('should support string "gt" that is satisfied', function(done) {
-      User.find({order: 'seq', where: {name: {'gt': 'Paul McCartney'},
-      }}, function(err, users) {
+      User.find({
+        order: 'seq',
+        where: {
+          name: {
+            'gt': 'Paul McCartney'
+          },
+        }
+      }, function(err, users) {
         should.not.exist(err);
         users.should.have.property('length', 3);
         users[0].name.should.equal('Ringo Starr');
@@ -416,8 +651,14 @@ describe('basic-querying', function() {
     });
 
     it('should support string "lt" that is satisfied', function(done) {
-      User.find({order: 'seq', where: {name: {'lt': 'Paul McCartney'},
-      }}, function(err, users) {
+      User.find({
+        order: 'seq',
+        where: {
+          name: {
+            'lt': 'Paul McCartney'
+          },
+        }
+      }, function(err, users) {
         should.not.exist(err);
         users.should.have.property('length', 2);
         users[0].name.should.equal('John Lennon');
@@ -426,8 +667,14 @@ describe('basic-querying', function() {
     });
 
     it('should support boolean "gte" that is satisfied', function(done) {
-      User.find({order: 'seq', where: {vip: {'gte': true},
-      }}, function(err, users) {
+      User.find({
+        order: 'seq',
+        where: {
+          vip: {
+            'gte': true
+          },
+        }
+      }, function(err, users) {
         should.not.exist(err);
         users.should.have.property('length', 3);
         users[0].name.should.equal('John Lennon');
@@ -436,8 +683,14 @@ describe('basic-querying', function() {
     });
 
     it('should support boolean "gt" that is not satisfied', function(done) {
-      User.find({order: 'seq', where: {vip: {'gt': true},
-      }}, function(err, users) {
+      User.find({
+        order: 'seq',
+        where: {
+          vip: {
+            'gt': true
+          },
+        }
+      }, function(err, users) {
         should.not.exist(err);
         users.should.have.property('length', 0);
         done();
@@ -445,8 +698,14 @@ describe('basic-querying', function() {
     });
 
     it('should support boolean "gt" that is satisfied', function(done) {
-      User.find({order: 'seq', where: {vip: {'gt': false},
-      }}, function(err, users) {
+      User.find({
+        order: 'seq',
+        where: {
+          vip: {
+            'gt': false
+          },
+        }
+      }, function(err, users) {
         should.not.exist(err);
         users.should.have.property('length', 3);
         users[0].name.should.equal('John Lennon');
@@ -455,8 +714,14 @@ describe('basic-querying', function() {
     });
 
     it('should support boolean "lt" that is satisfied', function(done) {
-      User.find({order: 'seq', where: {vip: {'lt': true},
-      }}, function(err, users) {
+      User.find({
+        order: 'seq',
+        where: {
+          vip: {
+            'lt': true
+          },
+        }
+      }, function(err, users) {
         should.not.exist(err);
         users.should.have.property('length', 2);
         users[0].name.should.equal('George Harrison');
@@ -467,7 +732,13 @@ describe('basic-querying', function() {
     var itWhenIlikeSupported = connectorCapabilities.ilike ? it : it.skip.bind(it);
 
     itWhenIlikeSupported('should support "like" that is satisfied', function(done) {
-      User.find({where: {name: {like: 'John'}}}, function(err, users) {
+      User.find({
+        where: {
+          name: {
+            like: 'John'
+          }
+        }
+      }, function(err, users) {
         if (err) return done(err);
         users.length.should.equal(1);
         users[0].name.should.equal('John Lennon');
@@ -476,7 +747,13 @@ describe('basic-querying', function() {
     });
 
     itWhenIlikeSupported('should support "like" that is not satisfied', function(done) {
-      User.find({where: {name: {like: 'Bob'}}}, function(err, users) {
+      User.find({
+        where: {
+          name: {
+            like: 'Bob'
+          }
+        }
+      }, function(err, users) {
         if (err) return done(err);
         users.length.should.equal(0);
         done();
@@ -486,7 +763,13 @@ describe('basic-querying', function() {
     var itWhenNilikeSupported = connectorCapabilities.nilike ? it : it.skip.bind(it);
 
     itWhenNilikeSupported('should support "nlike" that is satisfied', function(done) {
-      User.find({where: {name: {nlike: 'John'}}}, function(err, users) {
+      User.find({
+        where: {
+          name: {
+            nlike: 'John'
+          }
+        }
+      }, function(err, users) {
         if (err) return done(err);
         users.length.should.equal(5);
         users[0].name.should.equal('Paul McCartney');
@@ -495,28 +778,109 @@ describe('basic-querying', function() {
     });
 
     itWhenIlikeSupported('should support "ilike" that is satisfied', function(done) {
-      User.find({where: {name: {ilike: 'john'}}}, function(err, users) {
+      User.find({
+        where: {
+          name: {
+            ilike: 'john'
+          }
+        }
+      }, function(err, users) {
         if (err) return done(err);
         users.length.should.equal(1);
         users[0].name.should.equal('John Lennon');
-        done();
+        it('should support nested GeoPoint near queries', function(done) {
+          User.find({
+            where: {
+              and: [{
+                addressLoc: {
+                  near: '29.9,-90.07'
+                }
+              }, {
+                vip: true
+              }]
+            },
+          }, function(err, users) {
+            if (err) return done(err);
+            users.should.have.property('length', 2);
+            users[0].addressLoc.should.not.equal(null);
+            done();
+          });
+        });
       });
     });
 
     itWhenIlikeSupported('should support "ilike" that is not satisfied', function(done) {
-      User.find({where: {name: {ilike: 'bob'}}}, function(err, users) {
+      User.find({
+        where: {
+          name: {
+            ilike: 'bob'
+          }
+        }
+      }, function(err, users) {
         if (err) return done(err);
         users.length.should.equal(0);
-        done();
+        it('should support very nested GeoPoint near queries', function(done) {
+          User.find({
+            where: {
+              and: [{
+                and: [{
+                  addressLoc: {
+                    near: '29.9,-90.07'
+                  }
+                }, {
+                  order: 2
+                }]
+              }, {
+                vip: true
+              }, ]
+            },
+          }, function(err, users) {
+            if (err) return done(err);
+            users.should.have.property('length', 1);
+            users[0].addressLoc.should.not.equal(null);
+            done();
+          });
+        });
       });
     });
 
     itWhenNilikeSupported('should support "nilike" that is satisfied', function(done) {
-      User.find({where: {name: {nilike: 'john'}}}, function(err, users) {
+      User.find({
+        where: {
+          name: {
+            nilike: 'john'
+          }
+        }
+      }, function(err, users) {
         if (err) return done(err);
         users.length.should.equal(5);
         users[0].name.should.equal('Paul McCartney');
-        done();
+        it('should support multiple GeoPoint near queries', function(done) {
+          User.find({
+            where: {
+              and: [{
+                or: [{
+                  addressLoc: {
+                    near: '29.9,-90.04',
+                    maxDistance: 300
+                  }
+                }, {
+                  addressLoc: {
+                    near: '22.97, -88.03',
+                    maxDistance: 300
+                  }
+                }, ]
+              }, {
+                vip: true
+              }, ]
+            },
+          }, function(err, users) {
+            if (err) return done(err);
+            users.should.have.property('length', 2);
+            users[0].addressLoc.should.not.equal(null);
+            done();
+          });
+        });
       });
     });
 
@@ -527,7 +891,9 @@ describe('basic-querying', function() {
         return {
           expect: function(arr) {
             remaining++;
-            User.find({fields: fields}, function(err, users) {
+            User.find({
+              fields: fields
+            }, function(err, users) {
               remaining--;
               if (err) return done(err);
 
@@ -556,10 +922,21 @@ describe('basic-querying', function() {
         };
       }
 
-      sample({name: true}).expect(['name']);
-      sample({name: false}).expect(['id', 'seq', 'email', 'role', 'order', 'birthday', 'vip']);
-      sample({name: false, id: true}).expect(['id']);
-      sample({id: true}).expect(['id']);
+      sample({
+        name: true
+      }).expect(['name']);
+      sample({
+        name: false
+      }).expect([
+        'id', 'seq', 'email', 'role', 'order', 'birthday', 'vip', 'addressLoc',
+      ]);
+      sample({
+        name: false,
+        id: true
+      }).expect(['id']);
+      sample({
+        id: true
+      }).expect(['id']);
       sample('id').expect(['id']);
       sample(['id']).expect(['id']);
       sample(['email']).expect(['email']);
@@ -567,6 +944,7 @@ describe('basic-querying', function() {
   });
 
   describe('count', function() {
+
     before(seed);
 
     it('should query total count', function(done) {
@@ -579,7 +957,9 @@ describe('basic-querying', function() {
     });
 
     it('should query filtered count', function(done) {
-      User.count({role: 'lead'}, function(err, n) {
+      User.count({
+        role: 'lead'
+      }, function(err, n) {
         should.not.exist(err);
         should.exist(n);
         n.should.equal(2);
@@ -592,7 +972,9 @@ describe('basic-querying', function() {
     before(seed);
 
     it('should find first record (default sort by id)', function(done) {
-      User.all({order: 'id'}, function(err, users) {
+      User.all({
+        order: 'id'
+      }, function(err, users) {
         User.findOne(function(e, u) {
           should.not.exist(e);
           should.exist(u);
@@ -603,7 +985,9 @@ describe('basic-querying', function() {
     });
 
     it('should find first record', function(done) {
-      User.findOne({order: 'order'}, function(e, u) {
+      User.findOne({
+        order: 'order'
+      }, function(e, u) {
         should.not.exist(e);
         should.exist(u);
         u.order.should.equal(1);
@@ -613,7 +997,9 @@ describe('basic-querying', function() {
     });
 
     it('should find last record', function(done) {
-      User.findOne({order: 'order DESC'}, function(e, u) {
+      User.findOne({
+        order: 'order DESC'
+      }, function(e, u) {
         should.not.exist(e);
         should.exist(u);
         u.order.should.equal(6);
@@ -624,7 +1010,9 @@ describe('basic-querying', function() {
 
     it('should find last record in filtered set', function(done) {
       User.findOne({
-        where: {role: 'lead'},
+        where: {
+          role: 'lead'
+        },
         order: 'order DESC',
       }, function(e, u) {
         should.not.exist(e);
@@ -637,7 +1025,11 @@ describe('basic-querying', function() {
 
     it('should work even when find by id', function(done) {
       User.findOne(function(e, u) {
-        User.findOne({where: {id: u.id}}, function(err, user) {
+        User.findOne({
+          where: {
+            id: u.id
+          }
+        }, function(err, user) {
           should.not.exist(err);
           should.exist(user);
           done();
@@ -672,7 +1064,9 @@ describe('basic-querying', function() {
   });
 
   context('regexp operator', function() {
-    var invalidDataTypes = [0, true, {}, [], Function, null];
+    var invalidDataTypes = [0, true, {},
+      [], Function, null
+    ];
 
     before(seed);
 
@@ -680,8 +1074,14 @@ describe('basic-querying', function() {
       // `undefined` is not tested because the `removeUndefined` function
       // in `lib/dao.js` removes it before coercion
       invalidDataTypes.forEach(function(invalidDataType) {
-        User.find({where: {name: {regexp: invalidDataType}}}, function(err,
-            users) {
+        User.find({
+          where: {
+            name: {
+              regexp: invalidDataType
+            }
+          }
+        }, function(err,
+          users) {
           should.exist(err);
         });
       });
@@ -697,7 +1097,9 @@ describe.skip('queries', function() {
     var db = getSchema();
     Todo = db.define('Todo', {
       id: false,
-      content: {type: 'string'},
+      content: {
+        type: 'string'
+      },
     }, {
       idInjection: false,
     });
@@ -705,17 +1107,21 @@ describe.skip('queries', function() {
   });
   beforeEach(function resetFixtures(done) {
     Todo.destroyAll(function() {
-      Todo.create([
-        {content: 'Buy eggs'},
-        {content: 'Buy milk'},
-        {content: 'Buy sausages'},
-      ], done);
+      Todo.create([{
+        content: 'Buy eggs'
+      }, {
+        content: 'Buy milk'
+      }, {
+        content: 'Buy sausages'
+      }, ], done);
     });
   });
 
   context('that do not require an id', function() {
     it('should work for create', function(done) {
-      Todo.create({content: 'Buy ham'}, function(err) {
+      Todo.create({
+        content: 'Buy ham'
+      }, function(err) {
         should.not.exist(err);
         done();
       });
@@ -724,7 +1130,9 @@ describe.skip('queries', function() {
     it('should work for updateOrCreate/upsert', function(done) {
       var aliases = ['updateOrCreate', 'upsert'];
       async.each(aliases, function(alias, cb) {
-        Todo[alias]({content: 'Buy ham'}, function(err) {
+        Todo[alias]({
+          content: 'Buy ham'
+        }, function(err) {
           should.not.exist(err);
           cb();
         });
@@ -732,14 +1140,18 @@ describe.skip('queries', function() {
     });
 
     it('should work for findOrCreate', function(done) {
-      Todo.findOrCreate({content: 'Buy ham'}, function(err) {
+      Todo.findOrCreate({
+        content: 'Buy ham'
+      }, function(err) {
         should.not.exist(err);
         done();
       });
     });
 
     it('should work for exists', function(done) {
-      Todo.exists({content: 'Buy ham'}, function(err) {
+      Todo.exists({
+        content: 'Buy ham'
+      }, function(err) {
         should.not.exist(err);
         done();
       });
@@ -772,14 +1184,18 @@ describe.skip('queries', function() {
     });
 
     it('should work for update/updateAll', function(done) {
-      Todo.update({content: 'Buy ham'}, function(err) {
+      Todo.update({
+        content: 'Buy ham'
+      }, function(err) {
         should.not.exist(err);
         done();
       });
     });
 
     it('should work for count', function(done) {
-      Todo.count({content: 'Buy eggs'}, function(err) {
+      Todo.count({
+        content: 'Buy eggs'
+      }, function(err) {
         should.not.exist(err);
         done();
       });
@@ -806,16 +1222,16 @@ describe.skip('queries', function() {
     });
 
     it('should return an error for deleteById/destroyById/removeById',
-    function(done) {
-      var aliases = ['deleteById', 'destroyById', 'removeById'];
-      async.each(aliases, function(alias, cb) {
-        Todo[alias](1, function(err) {
-          should.exist(err);
-          err.message.should.equal(expectedErrMsg);
-          cb();
-        });
-      }, done);
-    });
+      function(done) {
+        var aliases = ['deleteById', 'destroyById', 'removeById'];
+        async.each(aliases, function(alias, cb) {
+          Todo[alias](1, function(err) {
+            should.exist(err);
+            err.message.should.equal(expectedErrMsg);
+            cb();
+          });
+        }, done);
+      });
 
     it('should return an error for instance.save', function(done) {
       var todo = new Todo();
@@ -849,7 +1265,9 @@ describe.skip('queries', function() {
 
     it('should return an error for instance.updateAttributes', function(done) {
       Todo.findOne(function(err, todo) {
-        todo.updateAttributes({content: 'Buy ham'}, function(err) {
+        todo.updateAttributes({
+          content: 'Buy ham'
+        }, function(err) {
           should.exist(err);
           err.message.should.equal(expectedErrMsg);
           done();
@@ -860,30 +1278,73 @@ describe.skip('queries', function() {
 });
 
 function seed(done) {
-  var beatles = [
-    {
-      seq: 0,
-      name: 'John Lennon',
-      email: 'john@b3atl3s.co.uk',
-      role: 'lead',
-      birthday: new Date('1980-12-08'),
-      order: 2,
-      vip: true,
+  var beatles = [{
+    seq: 0,
+    name: 'John Lennon',
+    email: 'john@b3atl3s.co.uk',
+    role: 'lead',
+    birthday: new Date('1980-12-08'),
+    order: 2,
+    vip: true,
+    addressLoc: {
+      lat: 29.97,
+      lng: -90.03
     },
-    {
-      seq: 1,
-      name: 'Paul McCartney',
-      email: 'paul@b3atl3s.co.uk',
-      role: 'lead',
-      birthday: new Date('1942-06-18'),
-      order: 1,
-      vip: true,
+  }, {
+    seq: 1,
+    name: 'Paul McCartney',
+    email: 'paul@b3atl3s.co.uk',
+    role: 'lead',
+    birthday: new Date('1942-06-18'),
+    order: 1,
+    vip: true,
+    addressLoc: {
+      lat: 22.97,
+      lng: -88.03
     },
-    {seq: 2, name: 'George Harrison', order: 5, vip: false},
-    {seq: 3, name: 'Ringo Starr', order: 6, vip: false},
-    {seq: 4, name: 'Pete Best', order: 4},
-    {seq: 5, name: 'Stuart Sutcliffe', order: 3, vip: true},
-  ];
+  }, {
+    seq: 2,
+    name: 'George Harrison',
+    order: 5,
+    vip: false,
+    addressLoc: {
+      lat: 22.7,
+      lng: -89.03
+    },
+  }, {
+    seq: 2,
+    name: 'George Harrison',
+    order: 5,
+    vip: false
+  }, {
+    seq: 3,
+    name: 'Ringo Starr',
+    order: 6,
+    vip: false
+  }, {
+    seq: 4,
+    name: 'Pete Best',
+    order: 4
+  }, {
+    seq: 5,
+    name: 'Stuart Sutcliffe',
+    order: 3,
+    vip: true
+  }, {
+    seq: 3,
+    name: 'Ringo Starr',
+    order: 6,
+    vip: false
+  }, {
+    seq: 4,
+    name: 'Pete Best',
+    order: 4
+  }, {
+    seq: 5,
+    name: 'Stuart Sutcliffe',
+    order: 3,
+    vip: true
+  }, ];
 
   async.series([
     User.destroyAll.bind(User),
@@ -895,5 +1356,7 @@ function seed(done) {
 
 function nextAfterDelay(ctx, next) {
   var randomTimeoutTrigger = Math.floor(Math.random() * 100);
-  setTimeout(function() { process.nextTick(next); }, randomTimeoutTrigger);
+  setTimeout(function() {
+    process.nextTick(next);
+  }, randomTimeoutTrigger);
 }


### PR DESCRIPTION
The near filter on geo searches currently only searches a first level
object, eg { "where": { "location": {"near": "30,-90"}}}.  For clauses
that contain an "and" or an "or" clause, the geo filter does not pick up
the operator, and you tend to get a SQL error back.  For instance, Postgres
forms this abomination:  WHERE ("location"point($1,$2)) AND ("name" ~\* $3).

This fix allows for queries with a format such as:
"where":{"and":[{"location":{"near":"29,-90"}},{"name":{"regexp":"/sean/i"}}]}

Additionally adds support for specifying multiple "near" filters.  If a geopoint is
within maxDistance of any of the near geopoints, it will be included in
the return result set.

NB:  This changes none of the actual distance searching functionality; that code has only been touched if necessary for linting.

This is a cleaned up re-submit of PR #876 
