### PR TITLE
Ensure stable order of items in DAO.find() [2.x]

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1680,12 +1680,10 @@ DataAccessObject.find = function find(query, options, cb) {
   }
 
   var allCb = function(err, data) {
-    var results = [];
     if (!err && Array.isArray(data)) {
-      async.each(data, function(item, callback) {
-        var d = item;//data[i];
-        var Model = self.lookupModel(d);
-        var obj = new Model(d, { fields: query.fields, applySetters: false, persisted: true });
+      async.map(data, function(item, next) {
+        var Model = self.lookupModel(item);
+        var obj = new Model(item, { fields: query.fields, applySetters: false, persisted: true });
 
         if (query && query.include) {
           if (query.collect) {
@@ -1727,17 +1725,22 @@ DataAccessObject.find = function find(query, options, cb) {
           };
 
           Model.notifyObserversOf('loaded', context, function(err) {
-            if (err) return callback(err);
+            if (err) return next(err);
 
-            results.push(obj);
-            callback();
+            next(null, obj);
           });
         } else {
-          callback();
+          next();
         }
       },
-      function(err) {
+      function(err, results) {
         if (err) return cb(err);
+
+        // When applying query.collect, some root items may not have
+        // any related/linked item. We store `undefined` in the results
+        // array in such case, which is not desirable from API consumer's
+        // point of view.
+        results = results.filter(isDefined);
 
         if (data && data.countBeforeLimit) {
           results.countBeforeLimit = data.countBeforeLimit;
@@ -1776,6 +1779,10 @@ DataAccessObject.find = function find(query, options, cb) {
   }
   return cb.promise;
 };
+
+function isDefined(value) {
+  return value !== undefined;
+}
 
 /**
  * Find one record, same as `find`, but limited to one result. This function returns an object, not a collection.

--- a/test/basic-querying.test.js
+++ b/test/basic-querying.test.js
@@ -123,6 +123,14 @@ describe('basic-querying', function() {
   describe('find', function() {
     before(seed);
 
+    before(function setupDelayingLoadedHook() {
+      User.observe('loaded', nextAfterDelay);
+    });
+
+    after(function removeDelayingLoadHook() {
+      User.removeObserver('loaded', nextAfterDelay);
+    });
+
     it('should query collection', function(done) {
       User.find(function(err, users) {
         should.exists(users);
@@ -210,6 +218,18 @@ describe('basic-querying', function() {
         users.pop().name.should.equal('George Harrison');
         users.pop().name.should.equal('John Lennon');
         users.shift().name.should.equal('Stuart Sutcliffe');
+        done();
+      });
+    });
+
+    it('should query sorted desc by order integer field even though there' +
+        'is an async model loaded hook', function(done) {
+      User.find({ order: 'order DESC' }, function(err, users) {
+        if (err) return done(err);
+
+        should.exists(users);
+        var order = users.map(function(u) { return u.order; });
+        order.should.eql([6, 5, 4, 3, 2, 1]);
         done();
       });
     });
@@ -812,4 +832,9 @@ function seed(done) {
       async.each(beatles, User.create.bind(User), cb);
     },
   ], done);
+}
+
+function nextAfterDelay(ctx, next) {
+  var randomTimeoutTrigger = Math.floor(Math.random() * 100);
+  setTimeout(function() { process.nextTick(next); }, randomTimeoutTrigger);
 }


### PR DESCRIPTION
When post-processing result of find operation, use "async.map" instead of "async.each + array.push" to ensure the order of items is preserved.

This is a back-port of #996.

The code has diverged between 2.x and master, the merge leave too many conflicts, so I had to re-do the change again.

/to @Amir-61 please review
/cc @jannyHou @MichaelKohler