### PR TITLE
Add test to catch invalid date property

### DIFF
--- a/test/datatype.test.js
+++ b/test/datatype.test.js
@@ -52,6 +52,17 @@ describe('datatypes', function() {
       done();
     });
 
+  it('throws an error when property of type Date is set to an invalid value',
+    function() {
+      var myModel = db.define('myModel', {
+        date: { type: Date },
+      });
+
+      (function() {
+        myModel.create({ date: 'invalid' });
+      }).should.throw({ message: 'Invalid date: invalid' });
+    });
+
   it('should keep types when get read data from db', function(done) {
     var d = new Date, id;
 


### PR DESCRIPTION
Add a test in `datatype.test.js` to catch invalid date property (see strongloop/loopback#1035).