### PR TITLE
Optimize related model queries

### DIFF
--- a/lib/include.js
+++ b/lib/include.js
@@ -212,6 +212,9 @@ Inclusion.include = function(objects, include, options, cb) {
         }
       }
     }
+    if (!foreignKeys.length) {
+      return cb(null, []);
+    }
     if (filter.limit || filter.skip || filter.offset) {
       // Force the find to be performed per FK to honor the pagination
       pageSize = 1;
@@ -235,6 +238,10 @@ Inclusion.include = function(objects, include, options, cb) {
     }
 
     var items = [];
+    // Optimization: no need to resolve keys that are an empty array
+    listOfFKs = listOfFKs.filter(function(keys) {
+      return keys.length > 0;
+    });
     async.each(listOfFKs, function(foreignKeys, done) {
       var newFilter = {};
       for (var f in filter) {


### PR DESCRIPTION
Optimise related model queries

No longer query for the related/included model when no results are obtained in the first query

fix: https://github.com/strongloop/loopback-datasource-juggler/issues/1006