### PR TITLE
Declare `definition`

### DIFF
--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -1366,9 +1366,10 @@ BelongsTo.prototype.destroy = function(options, cb) {
     cb = options;
     options = {};
   }
-  var modelTo = this.definition.modelTo;
+
+  var definition = this.definition; 
   var modelInstance = this.modelInstance;
-  var fk = this.definition.keyFrom;
+  var fk = definition.keyFrom;
 
   cb = cb || utils.createPromiseCallback();
 


### PR DESCRIPTION
Due to undefined `definition` the following line was broken; this is a fix to declare `definition` which is used in the following error message:

```
cb(new Error('BelongsTo relation ' + definition.name + ' is empty'));
```

/to: @jannyHou
/CC: @bajtos 