### PR TITLE
Declare definition[2.x]

### DIFF
--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -1364,9 +1364,10 @@ BelongsTo.prototype.destroy = function(options, cb) {
     cb = options;
     options = {};
   }
-  var modelTo = this.definition.modelTo;
+
+  var definition = this.definition;
   var modelInstance = this.modelInstance;
-  var fk = this.definition.keyFrom;
+  var fk = definition.keyFrom;
 
   cb = cb || utils.createPromiseCallback();
 


### PR DESCRIPTION
* Declare `definition` in `BelongsTo.prototype.destroy`
Backport https://github.com/strongloop/loopback-datasource-juggler/pull/1009

CC: @jannyHou