### PR TITLE
Fix test case typo

### DIFF
--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -1644,7 +1644,7 @@ describe('manipulation', function() {
 
     });
 
-    it('should coerce boolean types properly', function() {
+    it('should coerce date types properly', function() {
       var p1 = new Person({ name: 'John', dob: '2/1/2015' });
       p1.dob.should.eql(new Date('2/1/2015'));
 


### PR DESCRIPTION
Fix a test case that coerces date types but it is incorrectly described to boolean types.

Signed-off-by: Supasate Choochaisri <supasate.c@gmail.com>