### PR TITLE
Return error if the connector does not implement

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -2638,8 +2638,14 @@ DataAccessObject.replaceById = function(id, data, options, cb) {
   assert(typeof cb === 'function', 'The cb argument must be a function');
 
   var connector = this.getConnector();
-  assert(typeof connector.replaceById === 'function',
-          'replaceById() must be implemented by the connector');
+
+  if (typeof connector.replaceById !== 'function') {
+    var err = new Error(g.f(
+      'The connector %s does not support {{replaceById}} operation. This is not a bug in LoopBack. ' +
+      'Please contact the authors of the connector, preferably via GitHub issues.',
+      connector.name));
+    return cb(err);
+  }
 
   var pkName = idName(this);
   if (!data[pkName]) data[pkName] = id;


### PR DESCRIPTION
* Return error if the connector does not implement `replaceById`

While QA was testing replace* methods for Cloudantdb where we do not have support, they got the following error:
```
lavens-mbp:replaceDemo laven$ node .
assert.js:90
  throw new assert.AssertionError({
  ^
AssertionError: replaceById() must be implemented by the connector
    at Function.DataAccessObject.replaceById (/Users/laven/Desktop/replaceDemo/node_modules/loopback-datasource-juggler/lib/dao.js:2640:3)
    at /Users/laven/Desktop/replaceDemo/node_modules/loopback-datasource-juggler/lib/dao.js:807:16
    at /Users/laven/Desktop/replaceDemo/node_modules/loopback-datasource-juggler/lib/dao.js:1824:5
    at /Users/laven/Desktop/replaceDemo/node_modules/loopback-datasource-juggler/lib/dao.js:1752:9
    at /Users/laven/Desktop/replaceDemo/node_modules/loopback-datasource-juggler/node_modules/async/lib/async.js:396:17
    at done (/Users/laven/Desktop/replaceDemo/node_modules/loopback-datasource-juggler/node_modules/async/lib/async.js:167:19)
    at /Users/laven/Desktop/replaceDemo/node_modules/loopback-datasource-juggler/node_modules/async/lib/async.js:40:16
    at /Users/laven/Desktop/replaceDemo/node_modules/loopback-datasource-juggler/node_modules/async/lib/async.js:393:21
    at /Users/laven/Desktop/replaceDemo/node_modules/loopback-datasource-juggler/lib/dao.js:1730:13
    at doNotify (/Users/laven/Desktop/replaceDemo/node_modules/loopback-datasource-juggler/lib/observer.js:98:49)
```

This PR avoids dumping stack trace and it reports the error accordingly.

@superkhau Please review. Thanks!

/to: @superkhau 
/CC: @laven26 @bajtos 