### PR TITLE
kv-memory: fix crash in regular cleanup

### DIFF
--- a/lib/connectors/kv-memory.js
+++ b/lib/connectors/kv-memory.js
@@ -31,8 +31,15 @@ KeyValueMemoryConnector.prototype._setupRegularCleanup = function() {
   // key expiration too, the scheduled cleanup is merely a performance
   // optimization.
   var self = this;
-  this._cleanupTimer = setInterval(
-    function() { self._removeExpiredItems(); },
+  var timer = this._cleanupTimer = setInterval(
+    function() {
+      if (self && self._removeExpiredItems) {
+        self._removeExpiredItems();
+      } else {
+        // The datasource/connector was destroyed - cancel the timer
+        clearInterval(timer);
+      }
+    },
     1000);
   this._cleanupTimer.unref();
 };

--- a/test/kv-memory.js
+++ b/test/kv-memory.js
@@ -2,15 +2,9 @@ var kvMemory = require('../lib/connectors/kv-memory');
 var DataSource = require('..').DataSource;
 
 describe('KeyValue-Memory connector', function() {
-  var lastDataSource;
   var dataSourceFactory = function() {
-    lastDataSource = new DataSource({ connector: kvMemory });
-    return lastDataSource;
+    return new DataSource({ connector: kvMemory });
   };
-
-  afterEach(function disconnectKVMemoryConnector() {
-    if (lastDataSource) return lastDataSource.disconnect();
-  });
 
   require('./kvao.suite')(dataSourceFactory);
 });


### PR DESCRIPTION
Fix bug in "_setupRegularCleanup()" where the interval callback was trying to access an object that has been garbage-collected in the meantime.

Symptoms:

```
/Users/bajtos/src/loopback/loopback/node_modules/loopback-datasource-juggler/lib/connectors/kv-memory.js:35
    function() { self._removeExpiredItems(); },
                      ^

TypeError: self._removeExpiredItems is not a function
    at Timeout.<anonymous> (/Users/bajtos/src/loopback/loopback/node_modules/loopback-datasource-juggler/lib/connectors/kv-memory.js:35:23)
    at Timeout._repeat (/Users/bajtos/src/loopback/loopback/node_modules/continuation-local-storage/node_modules/async-listener/glue.js:188:31)
    at Timeout.wrapper [as _onTimeout] (timers.js:417:11)
    at Timer.unrefdHandle (timers.js:454:14)
```

@superkhau please review