### PR TITLE
Return error if connector does not implement

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -2633,8 +2633,13 @@ DataAccessObject.replaceById = function(id, data, options, cb) {
   assert(typeof cb === 'function', 'The cb argument must be a function');
 
   var connector = this.getConnector();
-  assert(typeof connector.replaceById === 'function',
-          'replaceById() must be implemented by the connector');
+
+  if (typeof connector.replaceById !== 'function') {
+    var err = new Error('The connector ' + connector.name + ' does not support ' +
+      'replaceById operation. This is not a bug in LoopBack. ' +
+      'Please contact the authors of the connector, preferably via GitHub issues.');
+    return cb(err);
+  }
 
   var pkName = idName(this);
   if (!data[pkName]) data[pkName] = id;


### PR DESCRIPTION
* Return error if connector does not implement replaceById
* This patch is without globalization 

Backport https://github.com/strongloop/loopback-datasource-juggler/pull/1034
**Note:**
Please note this patch is without globalization because the globalization backport will go on top of that; the reason is after landing this PR, I got permission from @bajtos to release a new NPM version with `minor` changes and after releasing the NPM version, I will land [PR#1029](https://github.com/strongloop/loopback-datasource-juggler/pull/1029) to backport globalization, which we prefer to happen after releasing NPM version.

/to: @superkhau 

Thanks!
