### PR TITLE
kv-memory: fix crash in regular cleanup [2.x]

### DIFF
--- a/lib/connectors/kv-memory.js
+++ b/lib/connectors/kv-memory.js
@@ -31,8 +31,15 @@ KeyValueMemoryConnector.prototype._setupRegularCleanup = function() {
   // key expiration too, the scheduled cleanup is merely a performance
   // optimization.
   var self = this;
-  this._cleanupTimer = setInterval(
-    function() { self._removeExpiredItems(); },
+  var timer = this._cleanupTimer = setInterval(
+    function() {
+      if (self && self._removeExpiredItems) {
+        self._removeExpiredItems();
+      } else {
+        // The datasource/connector was destroyed - cancel the timer
+        clearInterval(timer);
+      }
+    },
     1000);
   this._cleanupTimer.unref();
 };

--- a/test/kv-memory.js
+++ b/test/kv-memory.js
@@ -2,15 +2,9 @@ var kvMemory = require('../lib/connectors/kv-memory');
 var DataSource = require('..').DataSource;
 
 describe('KeyValue-Memory connector', function() {
-  var lastDataSource;
   var dataSourceFactory = function() {
-    lastDataSource = new DataSource({ connector: kvMemory });
-    return lastDataSource;
+    return new DataSource({ connector: kvMemory });
   };
-
-  afterEach(function disconnectKVMemoryConnector() {
-    if (lastDataSource) return lastDataSource.disconnect();
-  });
 
   require('./kvao.suite')(dataSourceFactory);
 });


### PR DESCRIPTION
Fix bug in "_setupRegularCleanup()" where the interval callback was trying to access an object that has been garbage-collected in the meantime.

back-port of #1039
