### PR TITLE
prevent duplicate generated foreignKeys

### DIFF
--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -1247,7 +1247,7 @@ RelationDefinition.belongsTo = function(modelFrom, modelTo, params) {
     pkName = params.primaryKey || modelTo.dataSource.idName(modelTo.modelName) || 'id';
     relationName = params.as || i8n.camelize(modelTo.modelName, true);
     fk = params.foreignKey || relationName + 'Id';
-    
+ 
     // Check for any matching matching mirror relations and don't inject a foreign key property
     // into the model if any are found.
     // Why? Because The mirrored relation defintion will have already ensured a foreign key exists so if BelongsTo

--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -1247,8 +1247,17 @@ RelationDefinition.belongsTo = function(modelFrom, modelTo, params) {
     pkName = params.primaryKey || modelTo.dataSource.idName(modelTo.modelName) || 'id';
     relationName = params.as || i8n.camelize(modelTo.modelName, true);
     fk = params.foreignKey || relationName + 'Id';
+    
+    // Check for any matching matching mirror relations and don't inject a foreign key property
+    // into the model if any are found.
+    // Why? Because The mirrored relation defintion will have already ensured a foreign key exists so if BelongsTo
+    // injects a foreignkey it will be a duplicate, representing the same relation.
+    var matchingHasManyRelations = Object.keys(modelTo.relations)
+      .filter(function isMirroredRelation(rk) { return modelTo.relations[rk].modelTo.modelName === modelFrom.modelName });
 
-    modelFrom.dataSource.defineForeignKey(modelFrom.modelName, fk, modelTo.modelName, pkName);
+    if (!matchingHasManyRelations.length) {
+      modelFrom.dataSource.defineForeignKey(modelFrom.modelName, fk, modelTo.modelName, pkName);
+    }
   }
 
   var definition = modelFrom.relations[relationName] = new RelationDefinition({

--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -1247,13 +1247,15 @@ RelationDefinition.belongsTo = function(modelFrom, modelTo, params) {
     pkName = params.primaryKey || modelTo.dataSource.idName(modelTo.modelName) || 'id';
     relationName = params.as || i8n.camelize(modelTo.modelName, true);
     fk = params.foreignKey || relationName + 'Id';
- 
-    // Check for any matching matching mirror relations and don't inject a foreign key property
-    // into the model if any are found.
-    // Why? Because The mirrored relation defintion will have already ensured a foreign key exists so if BelongsTo
+
+    // Check for any matching matching reverse HasMany relations and don't
+    // inject a foreign key property into the model if any are found.
+    // Why? Because The revese HasMany relation will have already ensured a foreign key exists so if BelongsTo
     // injects a foreignkey it will be a duplicate, representing the same relation.
     var matchingHasManyRelations = Object.keys(modelTo.relations)
-      .filter(function isMirroredRelation(rk) { return modelTo.relations[rk].modelTo.modelName === modelFrom.modelName });
+      .filter(function isMirroredRelation(rk) {
+        return modelTo.relations[rk].modelTo.modelName === modelFrom.modelName;
+      });
 
     if (!matchingHasManyRelations.length) {
       modelFrom.dataSource.defineForeignKey(modelFrom.modelName, fk, modelTo.modelName, pkName);

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -2563,6 +2563,17 @@ describe('relations', function() {
       }).catch(done);
     });
 
+    it('should avoid creating a foriegn key on the model if one already exists', function(done) {
+      var Fajita = db.define('Fajita');
+      var Vegetable = db.define('Vegetable');
+
+      Fajita.hasMany(Vegetable);
+      Vegetable.belongsTo(Fajita, { as: 'burrito' });
+
+      (new Vegetable).toObject().should.not.have.property('burritoId');
+      done();
+    });
+
   });
 
   describe('belongsTo with scope', function() {


### PR DESCRIPTION
The belongsTo relation definition should not set a foreignKey if the model has an opposite hasMany relation because hasMany will have already set a foreignKey property.

This should prevent the behavior seen in strongloop/loopback#2587.

This is a rough draft and I would very much appreciate feedback.
