### PR TITLE
test/kvao: setup global.Promise on Node v0.10 [2.x only]

### DIFF
--- a/test/kvao.suite.js
+++ b/test/kvao.suite.js
@@ -4,6 +4,9 @@ var debug = require('debug')('test');
 var fs = require('fs');
 var path = require('path');
 
+if (!global.Promise)
+  global.Promise = require('bluebird');
+
 module.exports = function(dataSourceFactory, connectorCapabilities) {
   describe('KeyValue API', function loadAllTestFiles() {
     var testRoot = path.resolve(__dirname, 'kvao');


### PR DESCRIPTION
When running the tests on Node v0.10, setup `global.Promise` with Bluebird implementation. That way we don't have to run this setup in the test suite of each kv connector.

@superkhau PTAL

Related: https://github.com/strongloop/loopback-connector-kv-redis/pull/5