### PR TITLE
Fix CI introduced by `use strict`

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -3,8 +3,6 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-'use strict';
-
 /*!
  * Module dependencies
  */


### PR DESCRIPTION
This PR fixes our CI for now for an old issue which has always been there but unnoticed and using `use strict` has discovered the problem/bug.

```
Cannot assign to read only property 'type' of number
TypeError: Cannot assign to read only property 'type' of number
  at DataSource.defineForeignKey (node_modules/loopback-datasource-juggler/lib/datasource.js:1833:37)
  at Function.hasMany (node_modules/loopback-datasource-juggler/lib/relation-definition.js:638:24)
  at Function.hasMany (node_modules/loopback-datasource-juggler/lib/relations.js:74:29)
  at Context.defineProductAndCategoryModels (test/relations.integration.js:53:14)
```

Connect to https://github.com/strongloop/loopback-datasource-juggler/pull/1062