### PR TITLE
Remove expired items before executing expire

### DIFF
--- a/lib/connectors/kv-memory.js
+++ b/lib/connectors/kv-memory.js
@@ -121,6 +121,8 @@ function(modelName, key, value, options, callback) {
 
 KeyValueMemoryConnector.prototype.expire =
 function(modelName, key, ttl, options, callback) {
+  this._removeIfExpired(modelName, key);
+
   var store = this._getStoreForModel(modelName);
 
   if (!(key in store)) {

--- a/test/kvao/expire.suite.js
+++ b/test/kvao/expire.suite.js
@@ -35,6 +35,17 @@ module.exports = function(dataSourceFactory, connectorCapabilities) {
         .then(function(value) { should.equal(value, null); });
     });
 
+    it('returns error when expiring a key that has expired', function() {
+      return CacheItem.set('expired-key', 'a-value', 1).delay(20)
+        .then(function() { return CacheItem.expire('expired-key', 1000); })
+        .then(
+          function() { throw new Error('expire() should have failed'); },
+          function(err) {
+            err.message.should.match(/expired-key/);
+            err.should.have.property('statusCode', 404);
+          });
+    });
+
     it('returns error when key does not exist', function() {
       return CacheItem.expire('key-does-not-exist', 1).then(
         function() { throw new Error('expire() should have failed'); },


### PR DESCRIPTION
The expire feature is falsely returning 204 instead of 404 because it is not
removing expired items before execution.