### PR TITLE
Fix test case for expire

### DIFF
--- a/test/kvao/expire.suite.js
+++ b/test/kvao/expire.suite.js
@@ -36,7 +36,8 @@ module.exports = function(dataSourceFactory, connectorCapabilities) {
     });
 
     it('returns error when expiring a key that has expired', function() {
-      return CacheItem.set('expired-key', 'a-value', 1).delay(20)
+      return Promise.resolve(CacheItem.set('expired-key', 'a-value', 1))
+        .delay(20)
         .then(function() { return CacheItem.expire('expired-key', 1000); })
         .then(
           function() { throw new Error('expire() should have failed'); },


### PR DESCRIPTION
Forwardport of #1074. #1072 was missing Promise.resolve before using delay(20)
and causing Travis to fail on 2.x. This PR makes the test code consistent on
both master and 2.x.

@bajtos Merging without review as this is a simple fix for #1072 which has already been reviewed.