### PR TITLE
Support {defaultFn: 'shortid'}

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -26,6 +26,7 @@ var _extend = util._extend;
 var utils = require('./utils');
 var fieldsToArray = utils.fieldsToArray;
 var uuid = require('node-uuid');
+var shortid = require('shortid');
 
 // Set up an object for quick lookup
 var BASE_TYPES = {
@@ -307,6 +308,9 @@ ModelBaseClass.prototype._initProperties = function(data, options) {
           break;
         case 'now':
           propVal = new Date();
+          break;
+        case 'shortid':
+          propVal = shortid.generate();
           break;
         default:
           // TODO Support user-provided functions via a registry of functions

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "minimatch": "^3.0.3",
     "node-uuid": "^1.4.2",
     "qs": "^3.1.0",
+    "shortid": "^2.2.6",
     "strong-globalize": "^2.6.2",
     "traverse": "^0.6.6"
   },

--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -1704,21 +1704,21 @@ describe('manipulation', function() {
     });
 
     describe('shortid defaultFn', function() {
-      var CustomModel;
+      var ModelWithShortid;
 
       before(function(done) {
-        CustomModel = db.define('CustomModel6', {
+        ModelWithShortid = db.define('ModelWithShortid', {
           shortid: {type: String, defaultFn: 'shortid'},
         });
-        db.automigrate('CustomModel6', done);
+        db.automigrate('ModelWithShortid', done);
       });
 
       it('should generate a new id when "defaultFn" is "shortid"', function(done) {
         var SHORTID_REGEXP = /^[0-9a-z_\-]{7,14}$/i;
 
-        CustomModel.create(function(err, customModel) {
+        ModelWithShortid.create(function(err, modelWithShortid) {
           if (err) return done(err);
-          customModel.shortid.should.match(SHORTID_REGEXP);
+          modelWithShortid.shortid.should.match(SHORTID_REGEXP);
           done();
         });
       });

--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -12,7 +12,6 @@ var db, Person;
 var ValidationError = require('..').ValidationError;
 
 var UUID_REGEXP = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-var SHORTID_REGEXP = /^[0-9a-z_\-]{7,14}$/i;
 
 describe('manipulation', function() {
 
@@ -1715,9 +1714,11 @@ describe('manipulation', function() {
       });
 
       it('should generate a new id when "defaultFn" is "shortid"', function(done) {
-        var inst = CustomModel.create(function(err, m) {
-          should.not.exists(err);
-          m.shortid.should.match(SHORTID_REGEXP);
+        var SHORTID_REGEXP = /^[0-9a-z_\-]{7,14}$/i;
+
+        CustomModel.create(function(err, customModel) {
+          if (err) return done(err);
+          customModel.shortid.should.match(SHORTID_REGEXP);
           done();
         });
       });

--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -12,6 +12,7 @@ var db, Person;
 var ValidationError = require('..').ValidationError;
 
 var UUID_REGEXP = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+var SHORTID_REGEXP = /^[0-9a-z_\-]{7,14}$/i;
 
 describe('manipulation', function() {
 
@@ -1675,7 +1676,7 @@ describe('manipulation', function() {
         db.automigrate('CustomModel5', done);
       });
 
-      it('should generate a new id when "defaultfn" is "uuid"', function(done) {
+      it('should generate a new id when "defaultFn" is "uuid"', function(done) {
         var inst = CustomModel.create(function(err, m) {
           should.not.exists(err);
           m.guid.should.match(UUID_REGEXP);
@@ -1694,10 +1695,29 @@ describe('manipulation', function() {
         db.automigrate('CustomModel5', done);
       });
 
-      it('should generate a new id when "defaultfn" is "uuidv4"', function(done) {
+      it('should generate a new id when "defaultFn" is "uuidv4"', function(done) {
         var inst = CustomModel.create(function(err, m) {
           should.not.exists(err);
           m.guid.should.match(UUID_REGEXP);
+          done();
+        });
+      });
+    });
+
+    describe('shortid defaultFn', function() {
+      var CustomModel;
+
+      before(function(done) {
+        CustomModel = db.define('CustomModel6', {
+          shortid: {type: String, defaultFn: 'shortid'},
+        });
+        db.automigrate('CustomModel6', done);
+      });
+
+      it('should generate a new id when "defaultFn" is "shortid"', function(done) {
+        var inst = CustomModel.create(function(err, m) {
+          should.not.exists(err);
+          m.shortid.should.match(SHORTID_REGEXP);
           done();
         });
       });


### PR DESCRIPTION
[shortid](https://www.npmjs.com/package/shortid) is a pretty popular lightweight alternative to GUIDs. This patch lets you specify `'shortid'` for `defaultFn` so that you don't need to set `default` to `shortid.generate` yourself.