### PR TITLE
Check for TTL property with objects in KVAO/expire

### DIFF
--- a/lib/kvao/expire.js
+++ b/lib/kvao/expire.js
@@ -24,6 +24,14 @@ module.exports = function keyValueExpire(key, ttl, options, callback) {
     options = {};
   }
 
+  // FIXME [superkhau]: Check for ttl property if ttl is an object. API explorer
+  // passes in an object (because PUT requests are not submitting form data). I
+  // believe it is related to
+  // https://github.com/strongloop/loopback-component-explorer/issues/176.
+  if (typeof ttl === 'object') {
+    ttl = ttl.ttl;
+  }
+
   assert(typeof key === 'string' && key, 'key must be a non-empty string');
   assert(typeof ttl === 'number' && ttl > 0, 'ttl must be a positive integer');
   assert(typeof options === 'object', 'options must be an object');

--- a/test/kvao/expire.suite.js
+++ b/test/kvao/expire.suite.js
@@ -35,6 +35,15 @@ module.exports = function(dataSourceFactory, connectorCapabilities) {
         .then(function(value) { should.equal(value, null); });
     });
 
+    it('sets key ttl when an object with ttl property is provided as the ' +
+    'second argument', function() {
+      return CacheItem.set('a-key', 'a-value')
+        .then(function() { return CacheItem.expire('a-key', {ttl: 1}); })
+        .delay(20)
+        .then(function() { return CacheItem.get('a-key'); })
+        .then(function(value) { should.equal(value, null); });
+    });
+
     it('returns error when expiring a key that has expired', function() {
       return Promise.resolve(CacheItem.set('expired-key', 'a-value', 1))
         .delay(20)


### PR DESCRIPTION
**Prequisite for https://github.com/strongloop/loopback/pull/2806**

API explorer passes in an object because PUT requests are not passing in
form data upon submission. This is most likely related to
https://github.com/strongloop/loopback-component-explorer/issues/176 and
will be addressed when that issue is resolved.

More info for why https://github.com/strongloop/loopback/issues/2770#issuecomment-250597461

Connect to strongloop/loopback#2770

- [ ] Backport

@bajtos PTAL
