### PR TITLE
Fix linting errors

### DIFF
--- a/lib/validations.js
+++ b/lib/validations.js
@@ -131,7 +131,7 @@ Validatable.validatesNumericalityOf = getConfigurator('numericality');
  * @param {String} propertyName  Property name to validate.
  * @options {Object} Options See below
  * @property {Array} inArray Property must match one of the values in the array to be valid.
- * @property {String} message Optional error message if property is not valid.   
+ * @property {String} message Optional error message if property is not valid.
  * Default error message: "is not included in the list".
  * @property {Boolean} allowNull Whether null values are allowed.
  */
@@ -146,7 +146,7 @@ Validatable.validatesInclusionOf = getConfigurator('inclusion');
  * @options {Object} Options
  * @property {Array} inArray Property must match one of the values in the array to be valid.
  * @property {String} message Optional error message if property is not valid.  Default error message: "is reserved".
- * @property {Boolean} allowNull Whether null values are allowed. 
+ * @property {Boolean} allowNull Whether null values are allowed.
  */
 Validatable.validatesExclusionOf = getConfigurator('exclusion');
 
@@ -160,7 +160,7 @@ Validatable.validatesExclusionOf = getConfigurator('exclusion');
  * @options {Object} Options
  * @property {RegExp} with Regular expression to validate format.
  * @property {String} message Optional error message if property is not valid.  Default error message: " is invalid".
- * @property {Boolean} allowNull Whether null values are allowed. 
+ * @property {Boolean} allowNull Whether null values are allowed.
  */
 Validatable.validatesFormatOf = getConfigurator('format');
 
@@ -214,7 +214,7 @@ Validatable.validate = getConfigurator('custom');
  * @param {Function} validatorFn Custom validation function.
  * @options {Object} Options See below
  * @property {String} message Optional error message if property is not valid.  Default error message: " is invalid".
- * @property {Boolean} allowNull Whether null values are allowed. 
+ * @property {Boolean} allowNull Whether null values are allowed.
  */
 Validatable.validateAsync = getConfigurator('custom', {async: true});
 
@@ -239,7 +239,7 @@ Validatable.validateAsync = getConfigurator('custom', {async: true});
  * @property {RegExp} with Regular expression to validate format.
  * @property {Array.<String>} scopedTo List of properties defining the scope.
  * @property {String} message Optional error message if property is not valid.  Default error message: "is not unique".
- * @property {Boolean} allowNull Whether null values are allowed. 
+ * @property {Boolean} allowNull Whether null values are allowed.
  */
 Validatable.validatesUniquenessOf = getConfigurator('uniqueness', {async: true});
 


### PR DESCRIPTION
Trailing spaces in comments causing linter to fail. Errors introduced
at commit 9a1ef0849575a124f963ceb2043916b0b89fbf40.

cc @Amir-61 @crandmck @strongloop/fa-db-connectors 