### PR TITLE
Where filter warning

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1626,7 +1626,7 @@ DataAccessObject._coerce = function(where) {
                   'http://loopback.io/doc/en/lb2/Where-filter.html#rest-api ' +
                   'for a workaround.');
                 }
-                err = new Error(g.f('The %s property has invalid clause %j\n ', p, where[p]));
+                err = new Error(g.f('The %s property has invalid clause %j', p, where[p]));
                 err.statusCode = 400;
                 throw err;
               }

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1555,6 +1555,12 @@ DataAccessObject._coerce = function(where) {
           self._coerce(clauses[k]);
         }
       } else {
+        if (typeof clauses === 'object' && Object.keys(clauses).length > 20) {
+          g.warn('Queries in format `filter[where][or][0][id]` ' +
+          'with over 20 indices gets converted to an object by `qs`, See ' +
+          'http://loopback.io/doc/en/lb2/Where-filter.html#rest-api ' +
+          'for a workaround.');
+        }
         err = new Error(g.f('The %s operator has invalid clauses %j', p, clauses));
         err.statusCode = 400;
         throw err;
@@ -1614,7 +1620,13 @@ DataAccessObject._coerce = function(where) {
             case 'inq':
             case 'nin':
               if (!Array.isArray(val)) {
-                err = new Error(g.f('The %s property has invalid clause %j', p, where[p]));
+                if (typeof val === 'object' && Object.keys(val).length > 20) {
+                  g.warn('Queries in format `filter[where][or][0][id]` ' +
+                  'with over 20 indices gets converted to an object by `qs`, See ' +
+                  'http://loopback.io/doc/en/lb2/Where-filter.html#rest-api ' +
+                  'for a workaround.');
+                }
+                err = new Error(g.f('The %s property has invalid clause %j\n ', p, where[p]));
                 err.statusCode = 400;
                 throw err;
               }


### PR DESCRIPTION
qs converts arrays with over 20 indices into objects
adding a warning message for user to troubleshoot this behavior
see strongloop/loopback#2824

scenario 
```
http://localhost:3000/api/Books?
filter[where][id][inq][0]=1
&filter[where][id][inq][1]=2
&filter[where][id][inq][2]=1
&filter[where][id][inq][3]=1
&filter[where][id][inq][4]=1
&filter[where][id][inq][5]=1
&filter[where][id][inq][6]=1
&filter[where][id][inq][7]=1
&filter[where][id][inq][8]=1
&filter[where][id][inq][9]=1
&filter[where][id][inq][10]=1
&filter[where][id][inq][11]=1
&filter[where][id][inq][12]=1
&filter[where][id][inq][13]=1
&filter[where][id][inq][14]=1
&filter[where][id][inq][15]=1
&filter[where][id][inq][16]=1
&filter[where][id][inq][17]=1
&filter[where][id][inq][18]=1
&filter[where][id][inq][19]=1
&filter[where][id][inq][20]=1
&filter[where][id][inq][21]=1
```
and 
```
http://localhost:3000/api/Books?
filter[where][or][0][id]=1
&filter[where][or][1][id]=2
&filter[where][or][2][id]=1
&filter[where][or][3][id]=1
&filter[where][or][4][id]=1
&filter[where][or][5][id]=1
&filter[where][or][6][id]=1
&filter[where][or][7][id]=1
&filter[where][or][8][id]=1
&filter[where][or][9][id]=1
&filter[where][or][10][id]=1
&filter[where][or][11][id]=1
&filter[where][or][12][id]=1
&filter[where][or][13][id]=1
&filter[where][or][14][id]=1
&filter[where][or][15][id]=1
&filter[where][or][16][id]=1
&filter[where][or][17][id]=1
&filter[where][or][18][id]=1
&filter[where][or][19][id]=1
&filter[where][or][20][id]=1
&filter[where][or][21][id]=1
```
