### PR TITLE
DataAccessObject._coerce now continues after encountering a logical op

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1559,7 +1559,8 @@ DataAccessObject._coerce = function(where) {
         err.statusCode = 400;
         throw err;
       }
-      return where;
+
+      continue;
     }
     var DataType = props[p] && props[p].type;
     if (!DataType) {

--- a/test/loopback-dl.test.js
+++ b/test/loopback-dl.test.js
@@ -1421,6 +1421,16 @@ describe('DataAccessObject', function() {
     assert.deepEqual(where, {or: [{age: 10}, {vip: true}]});
   });
 
+  it('continues to coerce properties after a logical operator', function() {
+    var clause = {and: [{age: '10'}], vip: 'true'};
+
+    // Key order is predictable but not guaranteed. We prefer false negatives (failure) to false positives.
+    assert(Object.keys(clause)[0] === 'and', 'Unexpected key order.');
+
+    where = model._coerce(clause);
+    assert.deepEqual(where, {and: [{age: 10}], vip: true});
+  });
+
   it('should throw if the where property is not an object', function() {
     try {
       // The where clause has to be an object
@@ -1467,6 +1477,20 @@ describe('DataAccessObject', function() {
     try {
       // The or operator only takes an array of objects
       model._coerce({or: ['x']});
+    } catch (err) {
+      error = err;
+    }
+    assert(error, 'An error should have been thrown');
+  });
+
+  it('throws an error when malformed logical operators follow valid logical clauses', function() {
+    var invalid = {and: [{x: 1}], or: 'bogus'};
+
+    // Key order is predictable but not guaranteed. We prefer false negatives (failure) to false positives.
+    assert(Object.keys(invalid)[0] !== 'or', 'Unexpected key order.');
+
+    try {
+      model._coerce(invalid);
     } catch (err) {
       error = err;
     }


### PR DESCRIPTION
I discovered this while working on https://github.com/strongloop/loopback/issues/2824 and felt it needed to be fixed. Please let me know if there's some non-obvious reason why logical operators should halt coercion.
