### PR TITLE
Add support for `loaded` operation hook for DAO.find() when near is used

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1821,7 +1821,7 @@ DataAccessObject.find = function find(query, options, cb) {
       }
 
       function queryGeo(query) {
-        function geoCallback(err, data) {
+        function geoCallbackWithoutNotify(err, data) {
           var memory = new Memory();
           var modelName = self.modelName;
 
@@ -1847,6 +1847,29 @@ DataAccessObject.find = function find(query, options, cb) {
           }
         }
 
+        function geoCallbackWithNotify(err, data) {
+          if (err) return cb(err);
+
+          async.map(data, function(item, next) {
+            var context = {
+              Model: self,
+              data: item,
+              isNewInstance: false,
+              hookState: hookState,
+              options: options,
+            };
+
+            self.notifyObserversOf('loaded', context, function(err) {
+              if (err) return next(err);
+              next(null, context.data);
+            });
+          }, function(err, results) {
+            if (err) return cb(err);
+            geoCallbackWithoutNotify(null, results);
+          });
+        }
+
+        var geoCallback = options.notify === false ? geoCallbackWithoutNotify : geoCallbackWithNotify;
         if (connector.all.length === 4) {
           connector.all(self.modelName, {}, options, geoCallback);
         } else {


### PR DESCRIPTION
* Add support for `loaded` operation hook for DAO.find() when near is used

Connect to https://github.com/strongloop/loopback-datasource-juggler/issues/1135