### PR TITLE
Allow nested properties to be coerced

### DIFF
--- a/lib/connectors/memory.js
+++ b/lib/connectors/memory.js
@@ -352,27 +352,47 @@ Memory.prototype.fromDb = function(model, data) {
   if (!data) return null;
   data = deserialize(data);
   var props = this._models[model].properties;
+
   for (var key in data) {
-    var val = data[key];
-    if (val === undefined || val === null) {
-      continue;
-    }
-    if (props[key]) {
-      switch (props[key].type.name) {
-        case 'Date':
-          val = new Date(val.toString().replace(/GMT.*$/, 'GMT'));
-          break;
-        case 'Boolean':
-          val = Boolean(val);
-          break;
-        case 'Number':
-          val = Number(val);
-          break;
-      }
-    }
-    data[key] = val;
+    data[key] = this._castPropertyValue(key, data[key], props);
   }
+
   return data;
+};
+
+Memory.prototype._castPropertyValue = function(prop, val, props) {
+  if (val === undefined || val === null || !props[prop]) {
+    return val;
+  }
+
+  if (Array.isArray(val)) {
+    var self = this;
+    return val.map(function(val) {
+      return self._castPropertyValue(prop, val, props);
+    });
+  }
+
+  var isArray = Array.isArray(props[prop].type);
+  var propType = isArray ? props[prop].type[0] : props[prop].type;
+
+  switch (propType.name) {
+    case 'Date':
+      val = new Date(val.toString().replace(/GMT.*$/, 'GMT'));
+      break;
+    case 'Boolean':
+      val = Boolean(val);
+      break;
+    case 'Number':
+      val = Number(val);
+      break;
+    case 'ModelConstructor':
+      for (var subProp in val) {
+        val[subProp] = this._castPropertyValue(subProp, val[subProp], propType.definition.properties);
+      }
+      break;
+  }
+
+  return val;
 };
 
 function getValue(obj, path) {

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1532,10 +1532,14 @@ function NumberType(val) {
  * @returns {Object} The coerced where clause
  * @private
  */
-DataAccessObject._coerce = function(where) {
+DataAccessObject._coerce = function(where, props) {
   var self = this;
   if (!where) {
     return where;
+  }
+
+  if (!props) {
+    props = self.definition.properties;
   }
 
   var err;
@@ -1545,7 +1549,6 @@ DataAccessObject._coerce = function(where) {
     throw err;
   }
 
-  var props = self.definition.properties;
   for (var p in where) {
     // Handle logical operators
     if (p === 'and' || p === 'or' || p === 'nor') {
@@ -1562,7 +1565,24 @@ DataAccessObject._coerce = function(where) {
 
       continue;
     }
+
+    if (p.match(/\./)) {
+      var model = p.split('.')[0];
+      var prop = p.split('.').slice(1);
+
+      if (props[model]) {
+        var clause = {};
+        clause[prop] = where[p];
+        where[p] = Array.isArray(props[model].type) ?
+          self._coerce(clause, props[model].type[0].definition.properties)[prop] :
+          self._coerce(clause, props[model].type.definition.properties)[prop];
+
+        continue;
+      }
+    }
+
     var DataType = props[p] && props[p].type;
+
     if (!DataType) {
       continue;
     }

--- a/test/memory.test.js
+++ b/test/memory.test.js
@@ -158,6 +158,7 @@ describe('Memory connector', function() {
         city: String,
         state: String,
         zipCode: String,
+        occupiedSince: Date,
         tags: [
           {
             tag: String,
@@ -502,6 +503,14 @@ describe('Memory connector', function() {
       });
     });
 
+    it('should support nested date property in query', function(done) {
+      User.find({where: {'address.occupiedSince': new Date('2016-01-01')}},
+        function(err, users) {
+          should(users.length).be.equal(1);
+          done();
+        });
+    });
+
     it('should support nested property with regex over arrays in query', function(done) {
       User.find({where: {'friends.name': {regexp: /^Ringo/}}}, function(err, users) {
         should.not.exist(err);
@@ -571,6 +580,7 @@ describe('Memory connector', function() {
             city: 'San Jose',
             state: 'CA',
             zipCode: '95131',
+            occupiedSince: new Date('2016-01-01'),
             tags: [
                 {tag: 'business'},
                 {tag: 'rent'},


### PR DESCRIPTION
Currently, nested properties (i.e. properties of an embedded model) will
be skipped in the coerce step. For string values, this is not an issue.
For other types, such as dates, this means that comparisons may not
work.