### PR TITLE
Add some connectors to ignoreList

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,11 @@
   "license": "MIT",
   "ci": {
     "downstreamIgnoreList": [
-      "loopback-connector-db2z"
+      "loopback-connector-db2z",
+      "loopback-connector-informix",
+      "loopback-connector-mqlight",
+      "loopback-connector-mssql",
+      "loopback-connector-oracle"
     ]
   }
 }


### PR DESCRIPTION
loopback-connector-informix
loopback-connector-mssql
loopback-connector-mqlight
loopback-connector-oracle

Those four connectors have existing failures that causing downstream CI fail.
Details see: https://github.com/strongloop/loopback-datasource-juggler/pull/1153#issuecomment-263935537