### PR TITLE
Add mysql to ignore list

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
       "loopback-connector-informix",
       "loopback-connector-mqlight",
       "loopback-connector-mssql",
+      "loopback-connector-mysql",
       "loopback-connector-oracle"
     ]
   }


### PR DESCRIPTION
Triggered a CI build of loopback-connector-mysql:
http://ci.strongloop.com/job/loopback-connector-mysql/2154/node=6.x,os=windows/console
http://ci.strongloop.com/job/loopback-connector-mysql/2154/node=4.x,os=windows/console

And issue to fix it is already filed in https://github.com/strongloop-internal/scrum-loopback/issues/1104
