### PR TITLE
Remove valid connectors from downstream ignore list

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,9 +57,7 @@
     "downstreamIgnoreList": [
       "loopback-connector-db2z",
       "loopback-connector-informix",
-      "loopback-connector-mqlight",
-      "loopback-connector-mssql",
-      "loopback-connector-oracle"
+      "loopback-connector-mqlight"
     ]
   }
 }


### PR DESCRIPTION
- Remove Microsoft SQL connector
- Remove Oracle connector

@jannyHou We know these connectors should be fully functional on CI, removing from downstream ignore list. The real solution is to pass those issues you create to fix CI to the relevant squad leads to get it planned/interrupted if necessary.