### PR TITLE
Fix error message formatting when trying to update an id property

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -3130,8 +3130,9 @@ function(data, options, cb) {
   for (var i = 0, n = idNames.length; i < n; i++) {
     var idName = idNames[i];
     if (data[idName] !== undefined && !idEquals(data[idName], inst[idName])) {
-      var err = new Error(g.f('{{id}} property (%s) ' +
-        'cannot be updated from %s to %s'), idName, inst[idName], data[idName]);
+      var err = new Error(g.f('{{id}} cannot be updated from ' +
+        '%s to %s when forceId is set to true',
+        inst[idName], data[idName]));
       err.statusCode = 400;
       process.nextTick(function() {
         cb(err);

--- a/test/optional-validation.test.js
+++ b/test/optional-validation.test.js
@@ -308,6 +308,19 @@ describe('optional-validation', function() {
           d.updateAttributes({'name': NEW_NAME}, expectChangeSuccess(done));
         });
       });
+
+      it('returns an error when trying to update the id property when forceId is set to true',
+      function(done) {
+        ModelWithForceId.create({name: 'foo'}, function(err, model) {
+          if (err) return done(err);
+          model.updateAttributes({id: 123}, function(err) {
+            err.should.be.instanceOf(Error);
+            err.message.should.eql('id cannot be updated from ' + model.id +
+              ' to 123 when forceId is set to true');
+            done();
+          });
+        });
+      });
     });
   });
 


### PR DESCRIPTION
### Description
Fixed a bug preventing an error stack to display proper input values.

#### Related issues

- strongloop/loopback-connector-mysql/#216

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
