### PR TITLE
Throw error when model relation name is trigger

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -461,6 +461,8 @@ DataSource.prototype.defineRelations = function(modelClass, relations) {
     Object.keys(relations).forEach(function(rn) {
       var r = relations[rn];
       assert(DataSource.relationTypes.indexOf(r.type) !== -1, 'Invalid relation type: ' + r.type);
+      assert(isValidRelationName(rn), 'Invalid relation name: ' + rn);
+
       var targetModel, polymorphicName;
 
       if (r.polymorphic && r.type !== 'belongsTo' && !r.model) {
@@ -502,6 +504,12 @@ DataSource.prototype.defineRelations = function(modelClass, relations) {
     });
   }
 };
+
+function isValidRelationName(relationName) {
+  var invalidRelationNames = ['trigger'];
+
+  return invalidRelationNames.indexOf(relationName) === -1;
+}
 
 /*!
  * Set up the data access functions from the data source

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -5609,4 +5609,24 @@ describe('relations', function() {
       .catch(done);
     });
   });
+
+  describe('relation names', function() {
+    it('throws error when a relation name is `trigger`', function() {
+      Chapter = db.define('Chapter', {name: String});
+
+      (function() {
+        db.define(
+          'Book',
+          {name: String},
+          {
+            relations: {
+              trigger: {
+                model: 'Chapter',
+                type: 'hasMany',
+              },
+            },
+          });
+      }).should.throw('Invalid relation name: trigger');
+    });
+  });
 });


### PR DESCRIPTION


### Description
Defining a model relation with the name "trigger" causes the model not
able to insert records. No error is thrown when a model relation with
the name "trigger" is defined. Adding a check for the model relation
name "trigger" will now throw an error.

#### Related issues
@bajtos This was originally submitted for a fix in strongloop/loopback#2988. Per your request to apply the patch to this repository. Please review.
<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->


### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
