### PR TITLE
Add flush operation to KVAO

### DIFF
--- a/lib/connectors/kv-memory.js
+++ b/lib/connectors/kv-memory.js
@@ -201,6 +201,12 @@ KeyValueMemoryConnector.prototype.disconnect = function(callback) {
   process.nextTick(callback);
 };
 
+KeyValueMemoryConnector.prototype.flush =
+function(modelName, options, callback) {
+  this._store = Object.create(null);
+  callback();
+};
+
 function StoreItem(value, ttl) {
   this.value = value;
   this.setTtl(ttl);

--- a/lib/kvao/flush.js
+++ b/lib/kvao/flush.js
@@ -1,0 +1,30 @@
+'use strict';
+
+var assert = require('assert');
+var utils = require('../utils');
+
+/**
+ * Delete all keys (and values) associated to the current model.
+ *
+ * @options {Object} options Unused ATM, placeholder for future options.
+ * @callback {Function} callback
+ * @param {Error} err Error object.
+ * @promise
+ *
+ * @header KVAO.prototype.flush(options, cb)
+ */
+module.exports = function flush(options, callback) {
+  if (callback == undefined && typeof options === 'function') {
+    callback = options;
+    options = {};
+  } else if (!options) {
+    options = {};
+  }
+
+  assert(typeof options === 'object', 'options must be an object');
+
+  callback = callback || utils.createPromiseCallback();
+
+  this.getConnector().flush(this.modelName, options, callback);
+  return callback.promise;
+};

--- a/lib/kvao/index.js
+++ b/lib/kvao/index.js
@@ -8,6 +8,7 @@ module.exports = KeyValueAccessObject;
 KeyValueAccessObject.get = require('./get');
 KeyValueAccessObject.set = require('./set');
 KeyValueAccessObject.expire = require('./expire');
+KeyValueAccessObject.flush = require('./flush');
 KeyValueAccessObject.ttl = require('./ttl');
 KeyValueAccessObject.iterateKeys = require('./iterate-keys');
 KeyValueAccessObject.keys = require('./keys');

--- a/test/kvao/flush.suite.js
+++ b/test/kvao/flush.suite.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const bdd = require('../helpers/bdd-if');
+const helpers = require('./_helpers');
+const should = require('should');
+
+module.exports = function(dataSourceFactory, connectorCapabilities) {
+  var supportsFlushOperation =
+    connectorCapabilities.supportsFlushOperation !== false;
+
+  bdd.describeIf(supportsFlushOperation, 'flush', function() {
+    let CacheItem;
+    beforeEach(function unpackContext() {
+      CacheItem = helpers.givenCacheItem(dataSourceFactory);
+    });
+
+    it('removes all associated keys for a given model', function() {
+      return helpers.givenKeys(CacheItem, ['key1', 'key2'])
+        .then(() => CacheItem.flush())
+        .then(() => CacheItem.keys())
+        .done((keys) => {
+          should(keys).eql([]);
+        });
+    });
+  });
+};


### PR DESCRIPTION
Used to delete all keys (and values) associated to the current model.

Connect to https://github.com/strongloop-internal/scrum-loopback/issues/1379

cc @bajtos 