### PR TITLE
Flush data during test setup

### DIFF
--- a/test/kvao/expire.suite.js
+++ b/test/kvao/expire.suite.js
@@ -16,6 +16,7 @@ module.exports = function(dataSourceFactory, connectorCapabilities) {
     var CacheItem;
     beforeEach(function unpackContext() {
       CacheItem = helpers.givenCacheItem(dataSourceFactory);
+      return CacheItem.flush();
     });
 
     it('sets key ttl - Callback API', function(done) {

--- a/test/kvao/flush.suite.js
+++ b/test/kvao/flush.suite.js
@@ -12,6 +12,7 @@ module.exports = function(dataSourceFactory, connectorCapabilities) {
     let CacheItem;
     beforeEach(function unpackContext() {
       CacheItem = helpers.givenCacheItem(dataSourceFactory);
+      return CacheItem.flush();
     });
 
     it('removes all associated keys for a given model', function() {

--- a/test/kvao/get-set.suite.js
+++ b/test/kvao/get-set.suite.js
@@ -11,6 +11,7 @@ module.exports = function(dataSourceFactory, connectorCapabilities) {
     var CacheItem;
     beforeEach(function unpackContext() {
       CacheItem = helpers.givenCacheItem(dataSourceFactory);
+      return CacheItem.flush();
     });
 
     it('works for string values - Callback API', function(done) {

--- a/test/kvao/iterate-keys.suite.js
+++ b/test/kvao/iterate-keys.suite.js
@@ -14,6 +14,7 @@ module.exports = function(dataSourceFactory, connectorCapabilities) {
     var CacheItem;
     beforeEach(function unpackContext() {
       CacheItem = helpers.givenCacheItem(dataSourceFactory);
+      return CacheItem.flush();
     });
 
     it('returns AsyncIterator covering all keys', function() {

--- a/test/kvao/keys.suite.js
+++ b/test/kvao/keys.suite.js
@@ -18,6 +18,7 @@ module.exports = function(dataSourceFactory, connectorCapabilities) {
           return keys;
         });
       };
+      return CacheItem.flush();
     });
 
     it('returns all keys - Callback API', function(done) {

--- a/test/kvao/ttl.suite.js
+++ b/test/kvao/ttl.suite.js
@@ -23,6 +23,7 @@ module.exports = function(dataSourceFactory, connectorCapabilities) {
     var CacheItem;
     beforeEach(function unpackContext() {
       CacheItem = helpers.givenCacheItem(dataSourceFactory);
+      return CacheItem.flush();
     });
 
     it('gets TTL when key with unexpired TTL exists - Promise API',


### PR DESCRIPTION
Downstream KV connector tests were returning false positives due to
improper test teardown. This fix ensures test fixtures are returned to a
clean state between each test.

Connect to https://github.com/strongloop/loopback-datasource-juggler/pull/1208

cc @bajtos 