### PR TITLE
Throw error when model relation name is trigger [2.x]

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -460,6 +460,8 @@ DataSource.prototype.defineRelations = function(modelClass, relations) {
     Object.keys(relations).forEach(function(rn) {
       var r = relations[rn];
       assert(DataSource.relationTypes.indexOf(r.type) !== -1, 'Invalid relation type: ' + r.type);
+      assert(isValidRelationName(rn), 'Invalid relation name: ' + rn);
+
       var targetModel, polymorphicName;
 
       if (r.polymorphic && r.type !== 'belongsTo' && !r.model) {
@@ -501,6 +503,12 @@ DataSource.prototype.defineRelations = function(modelClass, relations) {
     });
   }
 };
+
+function isValidRelationName(relationName) {
+  var invalidRelationNames = ['trigger'];
+
+  return invalidRelationNames.indexOf(relationName) === -1;
+}
 
 /*!
  * Set up the data access functions from the data source

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -5483,4 +5483,24 @@ describe('relations', function() {
       .catch(done);
     });
   });
+
+  describe('relation names', function() {
+    it('throws error when a relation name is `trigger`', function() {
+      Chapter = db.define('Chapter', {name: String});
+
+      (function() {
+        db.define(
+          'Book',
+          {name: String},
+          {
+            relations: {
+              trigger: {
+                model: 'Chapter',
+                type: 'hasMany',
+              },
+            },
+          });
+      }).should.throw('Invalid relation name: trigger');
+    });
+  });
 });


### PR DESCRIPTION
Defining a model relation with the name "trigger" causes the model not
able to insert records. No error is thrown when a model relation with
the name "trigger" is defined. Adding a check for the model relation
name "trigger" will now throw an error.

Backport #1204 

cc @schempy