### PR TITLE
Detect deleteAll support in KVAO tests

### DIFF
--- a/test/kvao/_helpers.js
+++ b/test/kvao/_helpers.js
@@ -2,15 +2,28 @@
 
 var Promise = require('bluebird');
 
-exports.givenCacheItem = function(dataSourceFactory) {
-  var dataSource = dataSourceFactory();
-  return dataSource.createModel('CacheItem', {
+exports.givenCacheItem = givenCacheItem;
+exports.givenKeys = givenKeys;
+exports.givenModel = givenModel;
+
+function givenCacheItem(dataSourceFactory) {
+  const modelProperties = {
     key: String,
-    value: 'any',
-  });
+    value: 'Any',
+  };
+  return givenModel(dataSourceFactory, 'CacheItem', modelProperties);
 };
 
-exports.givenKeys = function(Model, keys, cb) {
+function givenModel(dataSourceFactory, modelName,
+modelProperties, options) {
+  const dataSource = dataSourceFactory();
+  const Model = dataSource.createModel(modelName, modelProperties);
+  const p = 'deleteAll' in dataSource.connector ?
+    Model.deleteAll() : Promise.resolve();
+  return p.then(() => Model);
+};
+
+function givenKeys(Model, keys, cb) {
   var p = Promise.all(
     keys.map(function(k) {
       return Model.set(k, 'value-' + k);

--- a/test/kvao/delete-all.suite.js
+++ b/test/kvao/delete-all.suite.js
@@ -7,30 +7,31 @@ const should = require('should');
 module.exports = function(dataSourceFactory, connectorCapabilities) {
   var supportsDeleteAll = 'deleteAll' in dataSourceFactory().connector;
 
-  bdd.describeIf(supportsDeleteAll, 'deleteAll', function() {
+  bdd.describeIf(supportsDeleteAll, 'deleteAll', () => {
     let CacheItem;
-    beforeEach(function unpackContext() {
-      CacheItem = helpers.givenCacheItem(dataSourceFactory);
-    });
+    beforeEach(setupCacheItem);
 
-    it('removes all key-value pairs for the given model', function() {
+    it('removes all key-value pairs for the given model', () => {
       return helpers.givenKeys(CacheItem, ['key1', 'key2'])
         .then(() => CacheItem.deleteAll())
         .then(() => CacheItem.keys())
-        .then((keys) => {
-          should(keys).eql([]);
-        });
+        .then(keys => should(keys).eql([]));
     });
 
-    it('does not remove data from other existing models', function() {
-      var AnotherModel = dataSourceFactory().createModel('AnotherModel');
-      return helpers.givenKeys(CacheItem, ['key1', 'key2'])
+    it('does not remove data from other existing models', () => {
+      let AnotherModel;
+      helpers.givenModel(dataSourceFactory, 'AnotherModel')
+        .then(ModelCtor => AnotherModel = ModelCtor)
+        .then(() => helpers.givenKeys(CacheItem, ['key1', 'key2']))
         .then(() => helpers.givenKeys(AnotherModel, ['key3', 'key4']))
         .then(() => CacheItem.deleteAll())
         .then(() => AnotherModel.keys())
-        .then((keys) => {
-          should(keys).eql(['key3', 'key4']);
-        });
+        .then(keys => should(keys.sort()).eql(['key3', 'key4']));
     });
+
+    function setupCacheItem() {
+      return helpers.givenCacheItem(dataSourceFactory)
+        .then(ModelCtor => CacheItem = ModelCtor);
+    }
   });
 };

--- a/test/kvao/delete.suite.js
+++ b/test/kvao/delete.suite.js
@@ -5,16 +5,13 @@ const helpers = require('./_helpers');
 const should = require('should');
 
 module.exports = function(dataSourceFactory, connectorCapabilities) {
-  var supportsDelete = 'delete' in dataSourceFactory().connector;
+  const supportsDelete = 'delete' in dataSourceFactory().connector;
 
-  bdd.describeIf(supportsDelete, 'delete', function() {
+  bdd.describeIf(supportsDelete, 'delete', () => {
     let CacheItem;
-    beforeEach(function unpackContext() {
-      CacheItem = helpers.givenCacheItem(dataSourceFactory);
-      return CacheItem.deleteAll();
-    });
+    beforeEach(setupCacheItem);
 
-    it('removes the key-value pair for the given key', function() {
+    it('removes the key-value pair for the given key', () => {
       return helpers.givenKeys(CacheItem, ['key1', 'key2'])
         .then(() => CacheItem.delete('key1'))
         .then(() => CacheItem.keys())
@@ -22,5 +19,10 @@ module.exports = function(dataSourceFactory, connectorCapabilities) {
           keys.should.eql(['key2']);
         });
     });
+
+    function setupCacheItem() {
+      return helpers.givenCacheItem(dataSourceFactory)
+        .then(ModelCtor => CacheItem = ModelCtor);
+    }
   });
 };

--- a/test/kvao/expire.suite.js
+++ b/test/kvao/expire.suite.js
@@ -14,9 +14,7 @@ module.exports = function(dataSourceFactory, connectorCapabilities) {
 
   bdd.describeIf(canExpire, 'expire', function() {
     var CacheItem;
-    beforeEach(function unpackContext() {
-      CacheItem = helpers.givenCacheItem(dataSourceFactory);
-    });
+    beforeEach(setupCacheItem);
 
     it('sets key ttl - Callback API', function(done) {
       CacheItem.set('a-key', 'a-value', function(err) {
@@ -62,5 +60,10 @@ module.exports = function(dataSourceFactory, connectorCapabilities) {
           err.should.have.property('statusCode', 404);
         });
     });
+
+    function setupCacheItem() {
+      return helpers.givenCacheItem(dataSourceFactory)
+        .then(ModelCtor => CacheItem = ModelCtor);
+    };
   });
 };

--- a/test/kvao/get-set.suite.js
+++ b/test/kvao/get-set.suite.js
@@ -9,9 +9,7 @@ module.exports = function(dataSourceFactory, connectorCapabilities) {
 
   describe('get/set', function() {
     var CacheItem;
-    beforeEach(function unpackContext() {
-      CacheItem = helpers.givenCacheItem(dataSourceFactory);
-    });
+    beforeEach(setupCacheItem);
 
     it('works for string values - Callback API', function(done) {
       CacheItem.set('a-key', 'a-value', function(err) {
@@ -101,5 +99,10 @@ module.exports = function(dataSourceFactory, connectorCapabilities) {
           .then(function(value) { should.equal(value, 'another-value'); });
       });
     });
+
+    function setupCacheItem() {
+      return helpers.givenCacheItem(dataSourceFactory)
+        .then(ModelCtor => CacheItem = ModelCtor);
+    };
   });
 };

--- a/test/kvao/iterate-keys.suite.js
+++ b/test/kvao/iterate-keys.suite.js
@@ -12,9 +12,7 @@ module.exports = function(dataSourceFactory, connectorCapabilities) {
 
   bdd.describeIf(canIterateKeys, 'iterateKeys', function() {
     var CacheItem;
-    beforeEach(function unpackContext() {
-      CacheItem = helpers.givenCacheItem(dataSourceFactory);
-    });
+    beforeEach(setupCacheItem);
 
     it('returns AsyncIterator covering all keys', function() {
       return helpers.givenKeys(CacheItem, ['key1', 'key2'])
@@ -47,5 +45,10 @@ module.exports = function(dataSourceFactory, connectorCapabilities) {
           should(key).equal(undefined);
         });
     });
+
+    function setupCacheItem() {
+      return helpers.givenCacheItem(dataSourceFactory)
+        .then(ModelCtor => CacheItem = ModelCtor);
+    };
   });
 };

--- a/test/kvao/keys.suite.js
+++ b/test/kvao/keys.suite.js
@@ -9,15 +9,15 @@ module.exports = function(dataSourceFactory, connectorCapabilities) {
   var canIterateKeys = connectorCapabilities.canIterateKeys !== false;
 
   bdd.describeIf(canIterateKeys, 'keys', function() {
-    var CacheItem;
-    beforeEach(function unpackContext() {
-      CacheItem = helpers.givenCacheItem(dataSourceFactory);
-      CacheItem.sortedKeys = function(filter, options) {
-        return this.keys(filter, options).then(function(keys) {
-          keys.sort();
-          return keys;
+    let CacheItem;
+    beforeEach(function setupCacheItem() {
+      return helpers.givenCacheItem(dataSourceFactory)
+        .then(ModelCtor => CacheItem = ModelCtor)
+        .then(() => {
+          CacheItem.sortedKeys = function(filter, options) {
+            return this.keys(filter, options).then(keys => keys.sort());
+          };
         });
-      };
     });
 
     it('returns all keys - Callback API', function(done) {
@@ -44,17 +44,13 @@ module.exports = function(dataSourceFactory, connectorCapabilities) {
     });
 
     it('returns keys of the given model only', function() {
-      var AnotherModel = CacheItem.dataSource.createModel('AnotherModel');
-      return helpers.givenKeys(CacheItem, ['key1', 'key2'])
-        .then(function() {
-          return helpers.givenKeys(AnotherModel, ['otherKey1', 'otherKey2']);
-        })
-        .then(function() {
-          return CacheItem.sortedKeys();
-        })
-        .then(function(keys) {
-          should(keys).eql(['key1', 'key2']);
-        });
+      let AnotherModel;
+      helpers.givenModel(dataSourceFactory, 'AnotherModel')
+        .then(ModelCtor => AnotherModel = ModelCtor)
+        .then(() => helpers.givenKeys(CacheItem, ['key1', 'key2']))
+        .then(() => helpers.givenKeys(AnotherModel, ['otherKey1', 'otherKey2']))
+        .then(() => CacheItem.sortedKeys())
+        .then(keys => should(keys).eql(['key1', 'key2']));
     });
 
     var largeKeySets = connectorCapabilities.canIterateLargeKeySets !== false;

--- a/test/kvao/ttl.suite.js
+++ b/test/kvao/ttl.suite.js
@@ -20,10 +20,8 @@ module.exports = function(dataSourceFactory, connectorCapabilities) {
   var canQueryTtl = connectorCapabilities.canQueryTtl !== false;
 
   bdd.describeIf(canQueryTtl, 'ttl', function() {
-    var CacheItem;
-    beforeEach(function unpackContext() {
-      CacheItem = helpers.givenCacheItem(dataSourceFactory);
-    });
+    let CacheItem;
+    beforeEach(setupCacheItem);
 
     it('gets TTL when key with unexpired TTL exists - Promise API',
     function() {
@@ -75,5 +73,10 @@ module.exports = function(dataSourceFactory, connectorCapabilities) {
           err.should.have.property('statusCode', 404);
         });
     });
+
+    function setupCacheItem() {
+      return helpers.givenCacheItem(dataSourceFactory)
+        .then(ModelCtor => CacheItem = ModelCtor);
+    }
   });
 };


### PR DESCRIPTION
Clear CacheItem data between tests if connector supports `deleteAll`. Tests fail with 501 if this check is not used.