### PR TITLE
User Provided Default Model Value Callbacks

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -118,6 +118,8 @@ function DataSource(name, settings, modelBuilder) {
   // Initialize it before calling setup as the connector might register operations
   this._operations = {};
 
+  this.__defaultFns = {};
+
   this.setup(name, settings);
 
   this._setupConnector();
@@ -784,6 +786,32 @@ DataSource.prototype.defineProperty = function(model, prop, params) {
   var resolvedProp = this.getModelDefinition(model).properties[prop];
   if (this.connector && this.connector.defineProperty) {
     this.connector.defineProperty(model, prop, resolvedProp);
+  }
+};
+
+/**
+ * Define a new custom default functions for creating default model values
+ * @param {function()} type Type constructor.
+ * @param {string[]=} aliases Optional list of alternative names for this type.
+ */
+DataSource.prototype.defineDefaultFn = function(fn, names) {
+  names = names || [];
+  names = names.concat([fn.name]);
+  this.__defaultFns = this.__defaultFns || {};
+  for (var n = 0; n < names.length; n++) {
+    this.__defaultFns[names[n].toLowerCase()] = fn;
+  }
+};
+
+/**
+ * Get a defaultFn by its name
+ * @param {string} name The name of the callback being retrieved
+ */
+DataSource.prototype.getDefaultFn = function(name) {
+  if (this.__defaultFns.hasOwnProperty(name) > -1) {
+    return this.__defaultFns[name.toLowerCase()];
+  } else {
+    return false;
   }
 };
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -313,8 +313,21 @@ ModelBaseClass.prototype._initProperties = function(data, options) {
           propVal = shortid.generate();
           break;
         default:
-          // TODO Support user-provided functions via a registry of functions
-          g.warn('Unknown default value provider %s', defn);
+
+          // get the property definition to pass to the custom callback
+          var propDef = properties[p];
+
+          // Retrieve the custom callback by name if defn is a string
+          var defaultFn = this.getDataSource().getDefaultFn(defn);
+
+          // Handle custom defined defaultFns
+          if (typeof defn === 'string' && defaultFn) {
+            propVal = defaultFn(propDef);
+          } else if (typeof defn === 'function') {
+            propVal = defn(propDef);
+          } else {
+            g.warn('Unknown default value provider %s', defn);
+          }
       }
       // FIXME: We should coerce the value
       // will implement it after we refactor the PropertyDefinition

--- a/lib/model.js
+++ b/lib/model.js
@@ -322,9 +322,9 @@ ModelBaseClass.prototype._initProperties = function(data, options) {
 
           // Handle custom defined defaultFns
           if (typeof defn === 'string' && defaultFn) {
-            propVal = defaultFn(propDef);
+            propVal = defaultFn(propDef, self.__data);
           } else if (typeof defn === 'function') {
-            propVal = defn(propDef);
+            propVal = defn(propDef, self.__data);
           } else {
             g.warn('Unknown default value provider %s', defn);
           }


### PR DESCRIPTION
### Description
In order to use custom defined `defaultFn` I added the following code to a `server/boot/manipulation.js` file to test this feature:

```
module.exports = function(server) {
  server.dataSources.mysql.defineDefaultFn(function MyDefaultName(prop, data) {
    return "John Doe"
  }, ['my-default-name']);
};
```

And my `model.json`:
```
{
  "name": "Human",
  "plural": "humans",
  "base": "PersistedModel",
  "idInjection": false,
  "options": {
  },
  "properties": {
    "name": {
      "type": "String",
      "required": true,
      "defaultFn": "MyDefaultName"
    },
  },
  "validations": [],
  "relations": {},
  "acls": [],
  "methods": {}
}

```

#### Related issues
- #458
- strongloop/loopback#292

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] Add test to `manipulation.test.js` to register and handle custom `defaultFn`
- [ ] Community testing & feedback
- [ ] Review and approve how to define custom callbacks
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] Sign Contributor License Agreement (CLA)
