### PR TITLE
Replace deprecated node-uuid with uuid module

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -25,7 +25,7 @@ var validations = require('./validations');
 var _extend = util._extend;
 var utils = require('./utils');
 var fieldsToArray = utils.fieldsToArray;
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var deprecated = require('depd')('loopback-datasource-juggler');
 var shortid = require('shortid');
 

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -6,7 +6,7 @@
 
 var g = require('strong-globalize')();
 var debug = require('debug')('loopback:connector:transaction');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var utils = require('./utils');
 var jutil = require('./jutil');
 var ObserverMixin = require('./observer');

--- a/package.json
+++ b/package.json
@@ -46,11 +46,11 @@
     "inflection": "^1.6.0",
     "loopback-connector": "^2.1.0",
     "minimatch": "^3.0.3",
-    "node-uuid": "^1.4.2",
     "qs": "^3.1.0",
     "shortid": "^2.2.6",
     "strong-globalize": "^2.6.2",
-    "traverse": "^0.6.6"
+    "traverse": "^0.6.6",
+    "uuid": "^3.0.1"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
### Description

Replace deprecated `node-uuid` with `uuid`.

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
