### PR TITLE
Upgrade dependencies to remove npm install warnings

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -25,7 +25,7 @@ var validations = require('./validations');
 var _extend = util._extend;
 var utils = require('./utils');
 var fieldsToArray = utils.fieldsToArray;
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var shortid = require('shortid');
 
 // Set up an object for quick lookup

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -6,7 +6,7 @@
 
 var g = require('strong-globalize')();
 var debug = require('debug')('loopback:connector:transaction');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var utils = require('./utils');
 var jutil = require('./jutil');
 var ObserverMixin = require('./observer');

--- a/package.json
+++ b/package.json
@@ -34,22 +34,23 @@
     "async-iterators": "^0.2.2",
     "eslint": "^3.12.2",
     "eslint-config-loopback": "^7.0.1",
-    "mocha": "^2.1.0",
-    "should": "^8.0.2"
+    "mocha": "^3.2.0",
+    "should": "^11.1.2"
   },
   "dependencies": {
-    "async": "~1.0.0",
+    "async": "~2.1.4",
     "bluebird": "^3.1.1",
     "debug": "^2.1.1",
     "depd": "^1.0.0",
     "inflection": "^1.6.0",
-    "loopback-connector": "^2.1.0",
+    "loopback-connector": "^3.0.0",
     "minimatch": "^3.0.3",
-    "node-uuid": "^1.4.2",
-    "qs": "^3.1.0",
+    "qs": "^6.3.0",
     "shortid": "^2.2.6",
+    "should": "^8.4.0",
     "strong-globalize": "^2.6.2",
-    "traverse": "^0.6.6"
+    "traverse": "^0.6.6",
+    "uuid": "^3.0.1"
   },
   "license": "MIT",
   "ci": {


### PR DESCRIPTION
### Description

Upgrade dependencies to remove warnings from `npm install`.

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- #1227

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
