### PR TITLE
WIP: Custom validator promises and options

### DIFF
--- a/lib/validations.js
+++ b/lib/validations.js
@@ -340,7 +340,8 @@ function validateCustom(attr, conf, err, options, done) {
     done = options;
     options = {};
   }
-  conf.customValidator.call(this, err, done);
+
+  conf.customValidator.call(this, err, done, options);
 }
 
 /*!

--- a/lib/validations.js
+++ b/lib/validations.js
@@ -341,7 +341,19 @@ function validateCustom(attr, conf, err, options, done) {
     options = {};
   }
 
-  conf.customValidator.call(this, err, done, options);
+  if (conf.customValidator.length <= 1) {
+    conf.customValidator.call(this, options)
+      .then((isValid) => {
+        if (!isValid) throw new Error();
+        done();
+      })
+      .catch(() => {
+        err();
+        done();
+      });
+  } else {
+    conf.customValidator.call(this, err, done, options);
+  }
 }
 
 /*!

--- a/test/validations.test.js
+++ b/test/validations.test.js
@@ -657,6 +657,17 @@ describe('validations', function() {
         done();
       })).should.be.false;
     });
+
+    it.only('should validate using custom async validation using promises', function(done) {
+      User.validateAsync('email', function(options) {
+        return Promise.resolve(true);
+      }, {});
+      var u = new User({email: 'hello'});
+      Boolean(u.isValid(function(valid) {
+        valid.should.be.true;
+        done();
+      })).should.be.false;
+    });
   });
 
   describe('invalid value formatting', function() {


### PR DESCRIPTION
### Description

@bajtos recently added support for passing context through to remote methods, hooks, etc.

While the options were passed as far as `isValid` and even `validateCustom`, they weren't then being passed onto a user-defined custom validator function.

This PR seeks to:

1. Pass through options (achieved by simply adding the `options` argument to `conf.customValidator.call(this, err, done);` in `validations.js`
2. Add Promise support for custom async validators (as a bonus, though this is a nice-to-have vs. the missing `options` which is a bug)

I'm not clear on what tests are needed for passing through the `options`, and would appreciate any help here.

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
