### PR TITLE
Allow `after save` hook to see count of records changed

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -2267,6 +2267,7 @@ DataAccessObject.destroyAll = function destroyAll(where, options, cb) {
         where: where,
         hookState: hookState,
         options: options,
+        info: info,
       };
       Model.notifyObserversOf('after delete', context, function(err) {
         cb(err, info);
@@ -2686,6 +2687,7 @@ DataAccessObject.updateAll = function(where, data, options, cb) {
         data: data,
         hookState: hookState,
         options: options,
+        info: info,
       };
       Model.notifyObserversOf('after save', context, function(err, ctx) {
         return cb(err, info);
@@ -2803,6 +2805,7 @@ DataAccessObject.prototype.remove =
               instance: inst,
               hookState: hookState,
               options: options,
+              info: info,
             };
             Model.notifyObserversOf('after delete', context, function(err) {
               cb(err, info);
@@ -2829,6 +2832,7 @@ DataAccessObject.prototype.remove =
                 instance: inst,
                 hookState: hookState,
                 options: options,
+                info: info,
               };
               Model.notifyObserversOf('after delete', context, function(err) {
                 cb(err, info);

--- a/test/persistence-hooks.suite.js
+++ b/test/persistence-hooks.suite.js
@@ -2859,7 +2859,7 @@ module.exports = function(dataSource, should, connectorCapabilities) {
           ctxRecorder.records.should.eql(aCtxForModel(TestModel, {
             where: {id: existingInstance.id},
             instance: existingInstance,
-            info: { count: 1 }
+            info: {count: 1},
           }));
           done();
         });
@@ -2872,7 +2872,7 @@ module.exports = function(dataSource, should, connectorCapabilities) {
           if (err) return done(err);
           ctxRecorder.records.should.eql(aCtxForModel(TestModel, {
             where: {name: existingInstance.name},
-            info: { count: 1 }
+            info: {count: 1},
           }));
           done();
         });
@@ -2906,7 +2906,7 @@ module.exports = function(dataSource, should, connectorCapabilities) {
             }),
             aCtxForModel(TestModel, {
               hookState: {foo: 'BAR'},
-              info: { count: 1 },
+              info: {count: 1},
               where: {id: '1'},
               instance: existingInstance,
             }),
@@ -3063,7 +3063,7 @@ module.exports = function(dataSource, should, connectorCapabilities) {
             ctxRecorder.records.should.eql(aCtxForModel(TestModel, {
               where: {id: existingInstance.id},
               data: {name: 'updated name'},
-              info: { count: 1 }
+              info: {count: 1},
             }));
             done();
           });

--- a/test/persistence-hooks.suite.js
+++ b/test/persistence-hooks.suite.js
@@ -2748,18 +2748,22 @@ module.exports = function(dataSource, should, connectorCapabilities) {
 
         TestModel.deleteAll(function(err) {
           if (err) return done(err);
-          ctxRecorder.records.should.eql(aCtxForModel(TestModel, {where: {}}));
+          ctxRecorder.records.should.eql(aCtxForModel(TestModel, {
+            where: {},
+            info: {count: 2},
+          }));
           done();
         });
       });
 
-      it('triggers `after delete` hook without query', function(done) {
+      it('triggers `after delete` hook with query', function(done) {
         TestModel.observe('after delete', ctxRecorder.recordAndNext());
 
         TestModel.deleteAll({name: existingInstance.name}, function(err) {
           if (err) return done(err);
           ctxRecorder.records.should.eql(aCtxForModel(TestModel, {
             where: {name: existingInstance.name},
+            info: {count: 1},
           }));
           done();
         });
@@ -2855,6 +2859,7 @@ module.exports = function(dataSource, should, connectorCapabilities) {
           ctxRecorder.records.should.eql(aCtxForModel(TestModel, {
             where: {id: existingInstance.id},
             instance: existingInstance,
+            info: { count: 1 }
           }));
           done();
         });
@@ -2867,6 +2872,7 @@ module.exports = function(dataSource, should, connectorCapabilities) {
           if (err) return done(err);
           ctxRecorder.records.should.eql(aCtxForModel(TestModel, {
             where: {name: existingInstance.name},
+            info: { count: 1 }
           }));
           done();
         });
@@ -2900,6 +2906,7 @@ module.exports = function(dataSource, should, connectorCapabilities) {
             }),
             aCtxForModel(TestModel, {
               hookState: {foo: 'BAR'},
+              info: { count: 1 },
               where: {id: '1'},
               instance: existingInstance,
             }),
@@ -3056,6 +3063,7 @@ module.exports = function(dataSource, should, connectorCapabilities) {
             ctxRecorder.records.should.eql(aCtxForModel(TestModel, {
               where: {id: existingInstance.id},
               data: {name: 'updated name'},
+              info: { count: 1 }
             }));
             done();
           });


### PR DESCRIPTION
### Description

This change sends the `info` object, which contains the count of records updated to the `after save` hook. Currently this information is returned in the callback / Promise from an update, but it is not sent to the after-save hook. This PR fixes that.

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
