### PR TITLE
Add two basic tests for "inq" operator

### DIFF
--- a/test/basic-querying.test.js
+++ b/test/basic-querying.test.js
@@ -464,6 +464,23 @@ describe('basic-querying', function() {
       });
     });
 
+    it('supports non-empty inq', function() {
+      // note there is no record with seq=100
+      return User.find({where: {seq: {inq: [0, 1, 100]}}})
+        .then(result => {
+          const seqsFound = result.map(r => r.seq);
+          should(seqsFound).eql([0, 1]);
+        });
+    });
+
+    it('supports empty inq', function() {
+      return User.find({where: {seq: {inq: []}}})
+        .then(result => {
+          const seqsFound = result.map(r => r.seq);
+          should(seqsFound).eql([]);
+        });
+    });
+
     var itWhenIlikeSupported = connectorCapabilities.ilike ? it : it.skip.bind(it);
 
     itWhenIlikeSupported('should support "like" that is satisfied', function(done) {


### PR DESCRIPTION
While investigating https://github.com/fuwaneko/loopback-connector-rethinkdb/issues/10, I found that the shared test suite does not have any tests covering the `inq` operator. This patch adds two basic tests for a started.

@superkhau PTAL