### PR TITLE
Upgrade eslint-config, fix new violations

### DIFF
--- a/examples/app.js
+++ b/examples/app.js
@@ -41,5 +41,5 @@ console.log(modelBuilder.models);
 console.log(modelBuilder.definitions);
 
 User.mixin(Group);
-var user = new User({name: 'Ray', group: 'Admin'});
+user = new User({name: 'Ray', group: 'Admin'});
 console.log(user);

--- a/examples/load-schemas.js
+++ b/examples/load-schemas.js
@@ -28,13 +28,13 @@ function loadSchemasSync(schemaFile, dataSource) {
 
 var models = loadSchemasSync(path.join(__dirname, 'jdb-schemas.json'));
 
-for (var s in models) {
-  var m = models[s];
+for (const s in models) {
+  const m = models[s];
   console.log(m.modelName, new m());
 }
 
 models = loadSchemasSync(path.join(__dirname, 'schemas.json'));
-for (var s in models) {
-  var m = models[s];
+for (const s in models) {
+  const m = models[s];
   console.log(m.modelName, new m());
 }

--- a/lib/connectors/kv-memory.js
+++ b/lib/connectors/kv-memory.js
@@ -104,7 +104,6 @@ function(modelName, key, options, callback) {
 KeyValueMemoryConnector.prototype.set =
 function(modelName, key, value, options, callback) {
   var store = this._getStoreForModel(modelName);
-  var value;
   if (Buffer.isBuffer(value)) {
     value = 'buffer:' + value.toString('base64');
   } else if (value instanceof Date) {

--- a/lib/connectors/memory.js
+++ b/lib/connectors/memory.js
@@ -589,9 +589,10 @@ function applyFilter(filter) {
         return true;
       }
 
+      var i;
       if (example.inq) {
         // if (!value) return false;
-        for (var i = 0; i < example.inq.length; i++) {
+        for (i = 0; i < example.inq.length; i++) {
           if (example.inq[i] == value) {
             return true;
           }
@@ -600,7 +601,7 @@ function applyFilter(filter) {
       }
 
       if (example.nin) {
-        for (var i = 0; i < example.nin.length; i++) {
+        for (i = 0; i < example.nin.length; i++) {
           if (example.nin[i] == value) {
             return false;
           }

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -2176,13 +2176,6 @@ DataAccessObject.destroyAll = function destroyAll(where, options, cb) {
   this.applyScope(query);
   where = query.where;
 
-  var context = {
-    Model: Model,
-    where: whereIsEmpty(where) ? {} : where,
-    hookState: hookState,
-    options: options,
-  };
-
   if (options.notify === false) {
     doDelete(where);
   } else {
@@ -2209,6 +2202,13 @@ DataAccessObject.destroyAll = function destroyAll(where, options, cb) {
   }
 
   function doDelete(where) {
+    var context = {
+      Model: Model,
+      where: whereIsEmpty(where) ? {} : where,
+      hookState: hookState,
+      options: options,
+    };
+
     if (whereIsEmpty(where)) {
       if (connector.destroyAll.length === 4) {
         connector.destroyAll(Model.modelName, {}, options, done);
@@ -2918,8 +2918,9 @@ DataAccessObject.replaceById = function(id, data, options, cb) {
 
   var connector = this.getConnector();
 
+  var err;
   if (typeof connector.replaceById !== 'function') {
-    var err = new Error(g.f(
+    err = new Error(g.f(
       'The connector %s does not support {{replaceById}} operation. This is not a bug in LoopBack. ' +
       'Please contact the authors of the connector, preferably via GitHub issues.',
       connector.name));
@@ -2945,7 +2946,7 @@ DataAccessObject.replaceById = function(id, data, options, cb) {
   var hookState = {};
 
   if (id !== data[pkName]) {
-    var err = new Error(g.f('{{id}} property (%s) ' +
+    err = new Error(g.f('{{id}} property (%s) ' +
             'cannot be updated from %s to %s', pkName, id, data[pkName]));
     err.statusCode = 400;
     process.nextTick(function() { cb(err); });

--- a/lib/list.js
+++ b/lib/list.js
@@ -21,7 +21,7 @@ function List(items, itemType, parent) {
     try {
       items = JSON.parse(items);
     } catch (e) {
-      var err = new Error(g.f('could not create List from JSON string: %j', items));
+      const err = new Error(g.f('could not create List from JSON string: %j', items));
       err.statusCode = 400;
       throw err;
     }
@@ -32,7 +32,7 @@ function List(items, itemType, parent) {
 
   items = items || [];
   if (!Array.isArray(items)) {
-    var err = new Error(g.f('Items must be an array: %j', items));
+    const err = new Error(g.f('Items must be an array: %j', items));
     err.statusCode = 400;
     throw err;
   }

--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -2931,11 +2931,11 @@ EmbedsMany.prototype.add = function(acInst, data, options, cb) {
   var modelTo = this.definition.modelTo;
   var modelInstance = this.modelInstance;
 
-  var options = definition.options;
-  var belongsTo = options.belongsTo && modelTo.relations[options.belongsTo];
+  var defOpts = definition.options;
+  var belongsTo = defOpts.belongsTo && modelTo.relations[defOpts.belongsTo];
 
   if (!belongsTo) {
-    throw new Error('Invalid reference: ' + options.belongsTo || '(none)');
+    throw new Error('Invalid reference: ' + defOpts.belongsTo || '(none)');
   }
 
   var fk2 = belongsTo.keyTo;
@@ -2952,7 +2952,7 @@ EmbedsMany.prototype.add = function(acInst, data, options, cb) {
   belongsTo.modelTo.findOne(filter, options, function(err, ref) {
     if (ref instanceof belongsTo.modelTo) {
       var inst = self.build(data || {});
-      inst[options.belongsTo](ref);
+      inst[defOpts.belongsTo](ref);
       modelInstance.save(function(err) {
         cb(err, err ? null : inst);
       });
@@ -2978,11 +2978,11 @@ EmbedsMany.prototype.remove = function(acInst, options, cb) {
   var modelTo = this.definition.modelTo;
   var modelInstance = this.modelInstance;
 
-  var options = definition.options;
-  var belongsTo = options.belongsTo && modelTo.relations[options.belongsTo];
+  var defOpts = definition.options;
+  var belongsTo = defOpts.belongsTo && modelTo.relations[defOpts.belongsTo];
 
   if (!belongsTo) {
-    throw new Error('Invalid reference: ' + options.belongsTo || '(none)');
+    throw new Error('Invalid reference: ' + defOpts.belongsTo || '(none)');
   }
 
   var fk2 = belongsTo.keyTo;

--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -3,9 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-// Turning on strict for this file breaks lots of test cases;
-// disabling strict for this file
-/* eslint-disable strict */
+'use strict';
 
 /*!
  * Dependencies
@@ -888,12 +886,13 @@ var throughKeys = function(definition) {
   var modelThrough = definition.modelThrough;
   var pk2 = definition.modelTo.definition.idName();
 
+  let fk1, fk2;
   if (typeof definition.polymorphic === 'object') { // polymorphic
-    var fk1 = definition.keyTo;
+    fk1 = definition.keyTo;
     if (definition.polymorphic.invert) {
-      var fk2 = definition.polymorphic.foreignKey;
+      fk2 = definition.polymorphic.foreignKey;
     } else {
-      var fk2 = definition.keyThrough;
+      fk2 = definition.keyThrough;
     }
   } else if (definition.modelFrom === definition.modelTo) {
     return findBelongsTo(modelThrough, definition.modelTo, pk2).
@@ -904,9 +903,9 @@ var throughKeys = function(definition) {
         return (definition.keyTo === fk1) ? -1 : 1;
       });
   } else {
-    var fk1 = findBelongsTo(modelThrough, definition.modelFrom,
+    fk1 = findBelongsTo(modelThrough, definition.modelFrom,
                             definition.keyFrom)[0];
-    var fk2 = findBelongsTo(modelThrough, definition.modelTo, pk2)[0];
+    fk2 = findBelongsTo(modelThrough, definition.modelTo, pk2)[0];
   }
   return [fk1, fk2];
 };
@@ -2192,7 +2191,7 @@ EmbedsOne.prototype.create = function(targetModelData, options, cb) {
         });
       }
 
-      var err = inst.isValid() ? null : new ValidationError(inst);
+      err = inst.isValid() ? null : new ValidationError(inst);
       if (err) {
         process.nextTick(function() {
           cb(err);
@@ -2411,11 +2410,9 @@ RelationDefinition.embedsMany = function embedsMany(modelFrom, modelTo, params) 
             hasErrors = true;
             var id = item[idName];
             var first = Object.keys(item.errors)[0];
-            if (id) {
-              var msg = 'contains invalid item: `' + id + '`';
-            } else {
-              var msg = 'contains invalid item at index `' + idx + '`';
-            }
+            let msg = id ?
+              'contains invalid item: `' + id + '`' :
+              'contains invalid item at index `' + idx + '`';
             msg += ' (`' + first + '` ' + item.errors[first] + ')';
             self.errors.add(propertyName, msg, 'invalid');
           }
@@ -2659,7 +2656,7 @@ EmbedsMany.prototype.updateById = function(fkId, data, options, cb) {
 
       inst.setAttributes(data);
 
-      var err = inst.isValid() ? null : new ValidationError(inst);
+      err = inst.isValid() ? null : new ValidationError(inst);
       if (err && typeof cb === 'function') {
         return process.nextTick(function() {
           cb(err, inst);
@@ -2836,7 +2833,7 @@ EmbedsMany.prototype.create = function(targetModelData, options, cb) {
       updateEmbedded(cb);
     });
   } else {
-    var err = inst.isValid() ? null : new ValidationError(inst);
+    const err = inst.isValid() ? null : new ValidationError(inst);
     if (err) {
       process.nextTick(function() {
         cb(err);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -116,7 +116,7 @@ function mergeIncludes(destination, source) {
  */
 function convertToArray(include) {
   if (typeof include === 'string') {
-    var obj = {};
+    const obj = {};
     obj[include] = true;
     return [obj];
   } else if (isPlainObject(include)) {
@@ -127,7 +127,7 @@ function convertToArray(include) {
     // Build an array of key/value pairs
     var newInclude = [];
     for (var key in include) {
-      var obj = {};
+      const obj = {};
       obj[key] = include[key];
       newInclude.push(obj);
     }
@@ -137,7 +137,7 @@ function convertToArray(include) {
     for (var i in include) {
       var includeEntry = include[i];
       if (typeof includeEntry === 'string') {
-        var obj = {};
+        const obj = {};
         obj[includeEntry] = true;
         normalized.push(obj);
       } else {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "async-iterators": "^0.2.2",
     "eslint": "^3.12.2",
-    "eslint-config-loopback": "^7.0.1",
+    "eslint-config-loopback": "^8.0.0",
     "mocha": "^3.2.0",
     "should": "^8.4.0"
   },

--- a/test/include.test.js
+++ b/test/include.test.js
@@ -561,7 +561,7 @@ describe('include', function() {
       posts[1].title.should.equal('Post B');
       posts[2].title.should.equal('Post A');
 
-      var posts = users[1].posts();
+      posts = users[1].posts();
       posts.should.be.an.array;
       posts.should.have.length(1);
       posts[0].title.should.equal('Post D');

--- a/test/operation-hooks.suite/embeds-many-destroy.suite.js
+++ b/test/operation-hooks.suite/embeds-many-destroy.suite.js
@@ -48,7 +48,7 @@ module.exports = function(dataSource, should, connectorCapabilities) {
       }
     });
 
-    var ownerInstance, existingInstance, existingItem, existingItem;
+    var ownerInstance, existingInstance, existingItem;
     beforeEach(function setupData() {
       return Owner.create({})
         .then(function(inst) {

--- a/test/persistence-hooks.suite.js
+++ b/test/persistence-hooks.suite.js
@@ -2512,7 +2512,6 @@ module.exports = function(dataSource, should, connectorCapabilities) {
 
               var expectedContext = aCtxForModel(TestModel, expected);
 
-              var expectedContext;
               if (!dataSource.connector.replaceOrCreate) {
                 expectedContext.isNewInstance = false;
               }

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -3729,7 +3729,7 @@ describe('relations', function() {
       Person.findById(personId, function(err, p) {
         p.passportItem.update({name: 'Freddy'}, function(err, passport) {
           should.not.exist(err);
-          var passport = p.passportItem();
+          passport = p.passportItem();
           passport.toObject().should.eql({name: 'Freddy'});
           passport.should.be.an.instanceOf(Passport);
           passport.should.equal(p.passport);
@@ -3841,7 +3841,7 @@ describe('relations', function() {
       .then(function(p) {
         return p.passportItem.update({name: 'Jason'})
         .then(function(passport) {
-          var passport = p.passportItem();
+          passport = p.passportItem();
           passport.toObject().should.eql({name: 'Jason'});
           passport.should.be.an.instanceOf(Passport);
           passport.should.equal(p.passport);
@@ -4622,7 +4622,7 @@ describe('relations', function() {
         if (err) return done(err);
         var link = cat.items.build();
         link.job(job1);
-        var link = cat.items.build();
+        link = cat.items.build();
         link.job(job2);
         cat.save(function(err, cat) {
           if (err) return done(err);
@@ -4631,7 +4631,7 @@ describe('relations', function() {
           job.should.not.have.property('jobId');
           job.id.should.eql(job1.id);
           job.name.should.equal(job1.name);
-          var job = cat.items.at(1);
+          job = cat.items.at(1);
           job.id.should.eql(job2.id);
           job.name.should.equal(job2.name);
           done();
@@ -4882,7 +4882,7 @@ describe('relations', function() {
       Book.create({name: 'Book'}, function(err, book) {
         var link = book.people.build({notes: 'Something ...'});
         link.linked(person1);
-        var link = book.people.build();
+        link = book.people.build();
         link.linked(person2);
         book.save(function(err, book) {
           should.not.exist(err);
@@ -4894,7 +4894,7 @@ describe('relations', function() {
           link.linkedType.should.equal('Author');
           link.name.should.equal('Author 1');
 
-          var link = book.people.at(1);
+          link = book.people.at(1);
           link.should.be.instanceof(Link);
           link.id.should.equal(2);
           link.linkedId.should.eql(person2.id);
@@ -4917,7 +4917,7 @@ describe('relations', function() {
         link.linkedType.should.equal('Author');
         link.notes.should.equal('Something ...');
 
-        var link = book.people.at(1);
+        link = book.people.at(1);
         link.should.be.instanceof(Link);
         link.id.should.equal(2);
         link.linkedId.should.eql(person2.id);

--- a/test/validations.test.js
+++ b/test/validations.test.js
@@ -399,7 +399,7 @@ describe('validations', function() {
       u.isValid().should.not.be.true;
       u.reserved = null;
       u.isValid().should.be.true;
-      var u = new User({reserved: 'foo', locked: false});
+      u = new User({reserved: 'foo', locked: false});
       u.isValid().should.be.true;
     });
   });


### PR DESCRIPTION
### Description

The first commit fixes option propagation in the following two relation methods:
 - EmbedsMany.prototype.remove
 - EmbedsMany.prototype.add

The second commits upgrade eslint config to latest and fixes remaining issues reported by eslint.

#### Related issues

-  strongloop/eslint-config-loopback#19

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
