### PR TITLE
Override collection name for arangodb connector

### DIFF
--- a/test/default-scope.test.js
+++ b/test/default-scope.test.js
@@ -81,6 +81,7 @@ describe('default scope', function() {
       base: 'Product',
       scope: {where: {kind: 'Tool'}, order: 'name'},
       scopes: {active: {where: {active: true}}},
+      arangodb: {collection: 'Product'},
       mongodb: {collection: 'Product'},
       memory: {collection: 'Product'},
     });
@@ -90,6 +91,7 @@ describe('default scope', function() {
       properties: {kind: 'Widget'},
       scope: {where: {kind: 'Widget'}, order: 'name'},
       scopes: {active: {where: {active: true}}},
+      arangodb: {collection: 'Product'},
       mongodb: {collection: 'Product'},
       memory: {collection: 'Product'},
     });
@@ -114,6 +116,7 @@ describe('default scope', function() {
       base: 'Product',
       attributes: propertiesFn,
       scope: scopeFn,
+      arangodb: {collection: 'Product'},
       mongodb: {collection: 'Product'},
       memory: {collection: 'Product'},
     });


### PR DESCRIPTION
### Description
Add collection name settings for arangodb database.
Required to pass common tests included in community connector

#### Related issues

- imported tests fail on https://github.com/mrbatista/loopback-connector-arangodb/pull/44

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
