### PR TITLE
Fix datasource to report connector-loading errors

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -224,7 +224,16 @@ function tryModules(names, loader) {
     try {
       mod = loader(names[m]);
     } catch (e) {
-      /* ignore */
+      var notFound = e.code === 'MODULE_NOT_FOUND' &&
+        e.message && e.message.indexOf(names[m]) > 0;
+
+      if (notFound) {
+        debug('Module %s not found, will try another candidate.', names[m]);
+        continue;
+      }
+
+      debug('Cannot load connector %s: %s', names[m], e.stack || e);
+      throw e;
     }
     if (mod) {
       break;

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "bluebird": "^2.9.9",
     "eslint": "^2.13.1",
     "eslint-config-loopback": "^4.0.0",
+    "loopback-connector-throwing": "file:./test/fixtures/loopback-connector-throwing",
     "mocha": "^2.1.0",
     "should": "^8.0.2"
   },

--- a/test/datasource.test.js
+++ b/test/datasource.test.js
@@ -24,4 +24,24 @@ describe('DataSource', function() {
       });
     }).should.throw(/loopback-connector-throwing/);
   });
+
+  it('reports helpful error when connector init via short name throws', function() {
+    (function() {
+      // this is what LoopBack does
+      return new DataSource({
+        name: 'dsname',
+        connector: 'throwing',
+      });
+    }).should.throw(/expected test error/);
+  });
+
+  it('reports helpful error when connector init via long name throws', function() {
+    (function() {
+      // this is what LoopBack does
+      return new DataSource({
+        name: 'dsname',
+        connector: 'loopback-connector-throwing',
+      });
+    }).should.throw(/expected test error/);
+  });
 });

--- a/test/fixtures/loopback-connector-throwing/index.js
+++ b/test/fixtures/loopback-connector-throwing/index.js
@@ -1,0 +1,8 @@
+// Copyright IBM Corp. 2013,2016. All Rights Reserved.
+// Node module: loopback-datasource-juggler
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+throw new Error('expected test error');

--- a/test/fixtures/loopback-connector-throwing/package.json
+++ b/test/fixtures/loopback-connector-throwing/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "loopback-connector-throwing",
+  "version": "1.0.0",
+  "description": "A dummy connector that throws at initialization time."
+}


### PR DESCRIPTION
Before this change, when resolving full connector path, all errors were
ignored. As a result, when the connector was installed but not
correctly built (e.g. loopback-connector-db2 which uses a native addon),
a very confusing message was reported by LoopBack.

In this commit, I am fixing the code handling `require()` errors
to ignore only MODULE_NOT_FOUND errors that contain the name
of the required module.

Backport #1241