### PR TITLE
Fix DAO.upsert to pass options to DAO.find

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -631,10 +631,9 @@ DataAccessObject.upsert = function(data, options, cb) {
         }
       });
     } else {
-      var opts = {notify: false};
-      if (ctx.options && ctx.options.transaction) {
-        opts.transaction = ctx.options.transaction;
-      }
+      var opts = Object.create(options);
+      opts.notify = false;
+
       Model.findOne({where: ctx.query.where}, opts, function(err, inst) {
         if (err) {
           return cb(err);
@@ -798,10 +797,9 @@ DataAccessObject.upsertWithWhere = function(where, data, options, cb) {
         }
       });
     } else {
-      var opts = {notify: false};
-      if (ctx.options && ctx.options.transaction) {
-        opts.transaction = ctx.options.transaction;
-      }
+      var opts = Object.create(options);
+      opts.notify = false;
+
       self.find({where: ctx.query.where}, opts, function(err, instances) {
         if (err) return cb(err);
         var modelsLength = instances.length;
@@ -982,10 +980,9 @@ DataAccessObject.replaceOrCreate = function replaceOrCreate(data, options, cb) {
         }
       });
     } else {
-      var opts = {notify: false};
-      if (ctx.options && ctx.options.transaction) {
-        opts.transaction = ctx.options.transaction;
-      }
+      var opts = Object.create(options);
+      opts.notify = false;
+
       Model.findOne({where: ctx.query.where}, opts, function(err, found) {
         if (err) return cb(err);
         if (!isOriginalQuery) {


### PR DESCRIPTION
Adding reuse of give options to subsequent `Model.find()` calls instead of passing a new stripped opts object.


<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- #1253


<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)

Closes: #1253