### PR TITLE
Using a filter with exclusion of a non existent property, removes an existing one

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -265,7 +265,7 @@ function fieldsToArray(fields, properties, excludeUnknown) {
     } else if (excluded.length > 0) {
       for (i = 0, n = excluded.length; i < n; i++) {
         var index = result.indexOf(excluded[i]);
-        result.splice(index, 1);
+        if (index !== -1) result.splice(index, 1); // only when existing field excluded
       }
     }
   }

--- a/test/basic-querying.test.js
+++ b/test/basic-querying.test.js
@@ -603,8 +603,18 @@ describe('basic-querying', function() {
       return User.find({fields: {notExist: false}}, (err, users) => {
         if (err) return done(err);
         users.forEach(user => {
-          Object.keys(user.__data).should.containDeep(['id', 'seq', 'name', 'email', 'role',
-            'order', 'birthday', 'vip', 'address', 'friends']);
+          switch (user.seq) { // all fields depending on each document
+            case 0:
+            case 1:
+              Object.keys(user.__data).should.containDeep(['id', 'seq', 'name', 'order', 'role',
+                'birthday', 'vip', 'address', 'friends']);
+              break;
+            case 4: // seq 4
+              Object.keys(user.__data).should.containDeep(['id', 'seq', 'name', 'order']);
+              break;
+            default: // Other records, seq 2, 3, 5
+              Object.keys(user.__data).should.containDeep(['id', 'seq', 'name', 'order', 'vip']);
+          }
         });
         done();
       });

--- a/test/basic-querying.test.js
+++ b/test/basic-querying.test.js
@@ -601,6 +601,7 @@ describe('basic-querying', function() {
 
     it('should ignore non existing properties when excluding', function(done) {
       return User.find({fields: {notExist: false}}, (err, users) => {
+        if (err) return done(err);
         users.forEach(user => {
           Object.keys(user.__data).should.containDeep(['id', 'seq', 'name', 'email', 'role',
             'order', 'birthday', 'vip', 'address', 'friends']);

--- a/test/basic-querying.test.js
+++ b/test/basic-querying.test.js
@@ -599,6 +599,16 @@ describe('basic-querying', function() {
       sample(['email']).expect(['email']);
     });
 
+    it('should ignore non existing properties when excluding', function(done) {
+      return User.find({fields: {notExist: false}}, (err, users) => {
+        users.forEach(user => {
+          Object.keys(user.__data).should.containDeep(['id', 'seq', 'name', 'email', 'role',
+            'order', 'birthday', 'vip', 'address', 'friends']);
+        });
+        done();
+      });
+    });
+
     var describeWhenNestedSupported = connectorCapabilities.nestedProperty ? describe : describe.skip;
     describeWhenNestedSupported('query with nested property', function() {
       it('should support nested property in query', function(done) {

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -46,6 +46,7 @@ describe('util.fieldsToArray', function() {
     sample({'bat': true, unknown: true}, true).expect(['bat']);
     sample({'bat': 0}, true).expect(['foo', 'bar', 'baz']);
     sample({'bat': false}, true).expect(['foo', 'bar', 'baz']);
+    sample({'other': false}, true).expect(['foo', 'bar', 'bat', 'baz']);
   });
 });
 


### PR DESCRIPTION
### Description
Fixes the referrenced issue for excluding non existing fields

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

#1256 

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
