### PR TITLE
Included models from include operations do not change defined `strict` model option

### DIFF
--- a/lib/include.js
+++ b/lib/include.js
@@ -971,7 +971,7 @@ Inclusion.include = function(objects, include, options, cb) {
             result = new List(result, relation.modelTo);
           }
           obj.__data[relationName] = result;
-          obj.setStrict(false);
+          // obj.setStrict(false); issue #1252
         } else {
           obj[relationName] = result;
         }

--- a/lib/model.js
+++ b/lib/model.js
@@ -205,16 +205,17 @@ ModelBaseClass.prototype._initProperties = function(data, options) {
       var relationType = ctor.relations[p].type;
 
       var modelTo;
-      /* Issue #1252
       if (!properties[p]) {
         modelTo = ctor.relations[p].modelTo || ModelBaseClass;
         var multiple = ctor.relations[p].multiple;
         var typeName = multiple ? 'Array' : modelTo.modelName;
         var propType = multiple ? [modelTo] : modelTo;
         properties[p] = {name: typeName, type: propType};
+        /* Issue #1252
         this.setStrict(false);
+        */
       }
-      */
+
       // Relation
       if (relationType === 'belongsTo' && propVal != null) {
         // If the related model is populated

--- a/lib/model.js
+++ b/lib/model.js
@@ -205,6 +205,7 @@ ModelBaseClass.prototype._initProperties = function(data, options) {
       var relationType = ctor.relations[p].type;
 
       var modelTo;
+      /* Issue #1252
       if (!properties[p]) {
         modelTo = ctor.relations[p].modelTo || ModelBaseClass;
         var multiple = ctor.relations[p].multiple;
@@ -213,7 +214,7 @@ ModelBaseClass.prototype._initProperties = function(data, options) {
         properties[p] = {name: typeName, type: propType};
         this.setStrict(false);
       }
-
+      */
       // Relation
       if (relationType === 'belongsTo' && propVal != null) {
         // If the related model is populated


### PR DESCRIPTION
### Description
Changed behaviour when including related models in find operations forces to change the flag of strict to false, so any change to the model will also save in the datasource tha included properties...
I believe it should not change the default strict setting as in the original model definition

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- #1252 

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
