### PR TITLE
fix incorrect engines property in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
   "scripts": {
     "test": "make test"
   },
-  "engines": [
-    "node >= 0.6"
-  ],
+  "engines": {
+    "node": ">= 0.6"
+  },
   "devDependencies": {
     "should": "~1.2.2",
     "mocha": "~1.20.1"


### PR DESCRIPTION
This breaks our repo scanner, but since it is actually invalid the way it is I'm opting to fix it here instead of in the scanner.