### PR TITLE
fix incorrect engines property in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
     "test": "mocha",
     "posttest": "npm run lint"
   },
-  "engines": [
-    "node >= 0.6"
-  ],
+  "engines": {
+    "node": ">= 0.6"
+  },
   "devDependencies": {
     "async-iterators": "^0.2.2",
     "bluebird": "^2.9.9",


### PR DESCRIPTION
This breaks our repo scanner, but since it is actually invalid the way it is I'm opting to fix it here instead of in the scanner.

Same as #1262 but for 2.x branch.