### PR TITLE
Fix Order query test case

### DIFF
--- a/test/basic-querying.test.js
+++ b/test/basic-querying.test.js
@@ -485,7 +485,7 @@ describe('basic-querying', function() {
       return User.find({where: {seq: {inq: [0, 1, 100]}}})
         .then(result => {
           const seqsFound = result.map(r => r.seq);
-          should(seqsFound).eql([0, 1]);
+          should(seqsFound).be.oneOf([0, 1], [1, 0]);
         });
     });
 


### PR DESCRIPTION
### Description

when !order, it returns empty string causing a failing test case. 
#### Related issues

connect to https://github.com/strongloop/loopback-connector-oracle/issues/123
### Checklist

test case in` loopback-datasoruce-juggler/basic-query.test.js`

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
