### PR TITLE
dao: catch sync errors on setAttributes

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1982,7 +1982,7 @@ DataAccessObject.find = function find(query, options, cb) {
           try {
             obj = new Model(data, ctorOpts);
           } catch (err) {
-            return cb(err);
+            return callback(err);
           }
 
           if (query && query.include) {

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1978,7 +1978,12 @@ DataAccessObject.find = function find(query, options, cb) {
             applySetters: false,
             persisted: true,
           };
-          var obj = new Model(data, ctorOpts);
+          var obj;
+          try {
+            obj = new Model(data, ctorOpts);
+          } catch (err) {
+            return cb(err);
+          }
 
           if (query && query.include) {
             if (query.collect) {
@@ -3173,7 +3178,11 @@ function(data, options, cb) {
       }
 
       // update instance's properties
-      inst.setAttributes(data);
+      try {
+        inst.setAttributes(data);
+      } catch (err) {
+        return cb(err);
+      }
 
       if (doValidate) {
         inst.isValid(function(valid) {

--- a/test/basic-querying.test.js
+++ b/test/basic-querying.test.js
@@ -654,6 +654,15 @@ describe('basic-querying', function() {
           done();
         });
       });
+
+      it('should fail when querying with an invalid value for a type',
+      function(done) {
+        User.find({where: {birthday: 'notadate'}}, function(err, users) {
+          should.exist(err);
+          err.message.should.equal('Invalid date: notadate');
+          done();
+        });
+      });
     });
   });
 

--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -685,6 +685,15 @@ describe('manipulation', function() {
         });
       });
 
+    it('should fail if field validation fails', function(done) {
+      person.updateAttributes({'name': 'John', dob: 'notadate'},
+      function(err, p) {
+        should.exist(err);
+        err.message.should.equal('Invalid date: notadate');
+        done();
+      });
+    });
+
     it('should allow model instance on updateAttributes', function(done) {
       person.updateAttributes(new Person({'name': 'John', age: undefined}),
         function(err, p) {


### PR DESCRIPTION
### Description
Wrap inst.setAttributes in try-catch to prevent synchronous errors
from crashing the application.

#### Related issues
#1247 

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
