### PR TITLE
Fixes #1230 coerceArray converts empty Objects to array

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1567,7 +1567,14 @@ function coerceArray(val) {
     throw new Error(g.f('Value is not an {{array}} or {{object}} with sequential numeric indices'));
   }
 
-  var arrayVal = new Array(Object.keys(val).length);
+  // It is an object, check if empty
+  var props = Object.keys(val);
+
+  if (props.length === 0) {
+    throw new Error(g.f('Value is an empty {{object}}'));
+  }
+
+  var arrayVal = new Array(props.length);
   for (var i = 0; i < arrayVal.length; ++i) {
     if (!val.hasOwnProperty(i)) {
       throw new Error(g.f('Value is not an {{array}} or {{object}} with sequential numeric indices'));

--- a/test/loopback-dl.test.js
+++ b/test/loopback-dl.test.js
@@ -1312,6 +1312,8 @@ describe('DataAccessObject', function() {
       date: Date,
       location: 'GeoPoint',
       scores: [Number],
+      array: 'array',
+      object: 'object',
     });
   });
 
@@ -1546,7 +1548,7 @@ describe('DataAccessObject', function() {
     assert(error, 'An error should have been thrown');
   });
 
-  it('throws an error if the filter.limit property is nagative', function() {
+  it('throws an error if the filter.limit property is negative', function() {
     try {
       // The limit param must be a valid number
       filter = model._normalize({limit: -1});
@@ -1625,6 +1627,18 @@ describe('DataAccessObject', function() {
   it('does not coerce undefined values', function() {
     where = model._coerce({date: undefined});
     assert.deepEqual(where, {date: undefined});
+  });
+
+  it('does not coerce empty objects to arrays', function() {
+    where = model._coerce({object: {}});
+    where.object.should.not.be.an.Array();
+    where.object.should.be.an.Object();
+  });
+
+  it('does not coerce an empty array', function() {
+    where = model._coerce({array: []});
+    where.array.should.be.an.Array();
+    where.array.should.have.length(0);
   });
 
   it('does not coerce to a number for a simple value that produces NaN',


### PR DESCRIPTION
### Description
When declaring a property in model definition JSON as `object` type and initialize a model that has this property as an empty object, it gets converted to an empty array. coerceArray misses check for empty Object type. This results into false program logic where checks are made for object and find an array

#### Related issues

#1230 

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
