### PR TITLE
FindOrCreate missing error callback

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1067,6 +1067,7 @@ DataAccessObject.findOrCreate = function findOrCreate(query, data, options, cb) 
   function _findOrCreate(query, data, currentInstance) {
     var modelName = self.modelName;
     function findOrCreateCallback(err, data, created) {
+      if (err) return cb(err);
       var context = {
         Model: Model,
         data: data,


### PR DESCRIPTION
### Description
Add the error callback in FindOrCreate.
PR for 2.x has been merged: https://github.com/strongloop/loopback-datasource-juggler/pull/1226
This PR is for 3.x. 

#### Related issues
https://github.com/strongloop/loopback-datasource-juggler/issues/1223

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
