### PR TITLE
Added strict filter condition

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -249,7 +249,9 @@ ModelBaseClass.prototype._initProperties = function(data, options) {
           ));
         }
       } else {
-        this.__unknownProperties.push(p);
+        if(strict !== 'filter') {
+          this.__unknownProperties.push(p);
+        }
       }
     }
   }


### PR DESCRIPTION
I want to be able to filter the out the properties given to a model from either inputs in remoting or outputs from juggler instead of throwing an error.

Small code code

if(strict !=='filter'){
   this.__unknownProperties.push(p);
}

@ssh24 