### PR TITLE
Fixes #1275. `Include` filter transforms fields property into array.

### DIFF
--- a/lib/include.js
+++ b/lib/include.js
@@ -97,12 +97,16 @@ function execTasksWithInterLeave(tasks, callback) {
   // Context Switch BEFORE Heavy Computation
   process.nextTick(function() {
     // Heavy Computation
-    async.parallel(tasks, function(err, info) {
-      // Context Switch AFTER Heavy Computation
-      process.nextTick(function() {
-        callback(err, info);
+    try {
+      async.parallel(tasks, function(err, info) {
+        // Context Switch AFTER Heavy Computation
+        process.nextTick(function() {
+          callback(err, info);
+        });
       });
-    });
+    } catch (err) {
+      callback(err);
+    }
   });
 }
 
@@ -485,6 +489,11 @@ Inclusion.include = function(objects, include, options, cb) {
             async.each(targets, linkManyToMany, next);
             function linkManyToMany(target, next) {
               var targetId = target[modelToIdName];
+              if (!targetId) {
+                var err = new Error(g.f('LinkManyToMany received target that doesn\'t contain required "%s"',
+                  modelToIdName));
+                return next(err);
+              }
               var objList = targetObjsMap[targetId.toString()];
               async.each(objList, function(obj, next) {
                 if (!obj) return next();

--- a/lib/include.js
+++ b/lib/include.js
@@ -328,6 +328,10 @@ Inclusion.include = function(objects, include, options, cb) {
     filter.where = filter.where || {};
     // if fields are specified, make sure target foreign key is present
     var fields = filter.fields;
+    if (typeof fields === 'string') {
+      // transform string into array containing this string
+      filter.fields = fields = [fields];
+    }
     if (Array.isArray(fields) && fields.indexOf(relation.keyTo) === -1) {
       fields.push(relation.keyTo);
     } else if (isPlainObject(fields) && !fields[relation.keyTo]) {

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -835,6 +835,24 @@ describe('relations', function() {
         });
       });
 
+      context('findById with include filter that contains string fields', function() {
+        it('should accept string and convert it to array', function(done) {
+          var includeFilter = {include: {relation: 'patients', scope: {fields: 'name'}}};
+          var physicianId = physician.id;
+          Physician.findById(physicianId, includeFilter, function(err, result) {
+            should.not.exist(err);
+            should.exist(result);
+            result.id.should.eql(physicianId);
+            should.exist(result.patients);
+            result.patients().should.be.an.instanceOf(Array);
+            should.exist(result.patients()[0]);
+            should.exist(result.patients()[0].name);
+            should.not.exist(result.patients()[0].age);
+            done();
+          });
+        });
+      });
+
       function createSampleData(done) {
         Physician.create(function(err, result) {
           result.patients.create({name: 'a', age: '10'}, function(err, p) {


### PR DESCRIPTION
`Include` filter takes into consideration string property 'fields' and transforms it into an array containing this string.

### Description


#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- #1275

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
