### PR TITLE
fix _targetClass on scope function

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -254,7 +254,8 @@ function defineScope(cls, targetClass, name, params, methods, options) {
 
       f._targetClass = targetModel.modelName;
       if (f._scope.collect) {
-        f._targetClass = i8n.camelize(f._scope.collect);
+        const rel = targetModel.relations[f._scope.collect];
+        f._targetClass = rel && rel.modelTo && rel.modelTo.modelName || i8n.camelize(f._scope.collect);
       }
 
       f.getAsync = function(condOrRefresh, options, cb) {

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -1364,6 +1364,30 @@ describe('relations', function() {
     });
   });
 
+  describe('hasMany through - customized relation name and foreign key', function() {
+    var Physician, Patient, Appointment;
+
+    beforeEach(function(done) {
+      // db = getSchema();
+      Physician = db.define('Physician', {name: String});
+      Patient = db.define('Patient', {name: String});
+      Appointment = db.define('Appointment', {date: {type: Date, defaultFn: 'now'}});
+
+      db.automigrate(['Physician', 'Patient', 'Appointment'], done);
+    });
+
+    it('should use real target class', function() {
+      Physician.hasMany(Patient, {through: Appointment, as: 'xxx', foreignKey: 'aaaId', keyThrough: 'bbbId'});
+      Patient.hasMany(Physician, {through: Appointment, as: 'yyy', foreignKey: 'bbbId', keyThrough: 'aaaId'});
+      Appointment.belongsTo(Physician, {as: 'aaa', foreignKey: 'aaaId'});
+      Appointment.belongsTo(Patient, {as: 'bbb', foreignKey: 'bbbId'});
+      var physician = new Physician({id: 1});
+      physician.xxx.should.have.property('_targetClass', 'Patient');
+      var patient = new Patient({id: 1});
+      patient.yyy.should.have.property('_targetClass', 'Physician');
+    });
+  });
+
   describe('hasMany through bi-directional relations on the same model', function() {
     var User, Follow, Address;
 


### PR DESCRIPTION
Fix `_targetClass` on scope function when using hasManyThrough relation with customized relation names and foreignKey/keyThrough.

This bug is cause by `_targetClass` uses the camel-case of `relationName`(e.g.: if `relationName` is `bbb`, `targetClass` would be `Bbb`), which is not exists.

This will also suppress "not exposed" warnings when generating angular sdk, and generate end-points for this scope.

### Description


#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
