### PR TITLE
#1261 Property name "constructor" is not allowed in 'Model' data

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -71,8 +71,8 @@ function ModelBaseClass(data, options) {
 ModelBaseClass.prototype._initProperties = function(data, options) {
   var self = this;
   var ctor = this.constructor;
-
-  if (typeof data !== 'undefined' &&
+                                     // issue#1261
+  if (typeof data !== 'undefined' && data.constructor &&
       typeof (data.constructor) !== 'function') {
     throw new Error(g.f('Property name "{{constructor}}" is not allowed in %s data', ctor.modelName));
   }

--- a/test/loopback-dl.test.js
+++ b/test/loopback-dl.test.js
@@ -275,7 +275,7 @@ describe('ModelBuilder', function() {
     } catch (e) {
       assert(false, 'The code should have not thrown an error');
     }
-    done(null, User);
+    done();
   });
 
   it('instantiates model from data with non function constructor', function(done) {
@@ -299,7 +299,7 @@ describe('ModelBuilder', function() {
       e.message.should.equal('Property name "constructor" is not allowed in User data');
       assert(true, 'The code is expected to throw an error');
     }
-    done(null, User);
+    done();
   });
 });
 

--- a/test/loopback-dl.test.js
+++ b/test/loopback-dl.test.js
@@ -260,6 +260,23 @@ describe('ModelBuilder', function() {
     follow.should.have.property('id');
     assert.deepEqual(follow.id, {followerId: 1, followeeId: 2});
   });
+
+  it('instantiates model from data with no constructor', function(done) {
+    var modelBuilder = new ModelBuilder();
+
+    var User = modelBuilder.define('User', {name: String, age: Number});
+
+    try {
+      var data = Object.create(null);
+      data.name = 'Joe';
+      data.age = 20;
+      var user = new User(data);
+      assert(true, 'The code is expected to pass');
+    } catch (e) {
+      assert(false, 'The code should have not thrown an error');
+    }
+    done(null, User);
+  });
 });
 
 describe('DataSource ping', function() {

--- a/test/loopback-dl.test.js
+++ b/test/loopback-dl.test.js
@@ -277,6 +277,29 @@ describe('ModelBuilder', function() {
     }
     done(null, User);
   });
+
+  it('instantiates model from data with non function constructor', function(done) {
+    var modelBuilder = new ModelBuilder();
+
+    var User = modelBuilder.define('User', {name: String, age: Number});
+
+    try {
+      var Person = function(name, age) {
+        this.name = name;
+        this.age = age;
+      };
+
+      Person.prototype.constructor = 'constructor';
+
+      var data = new Person('Joe', 20);
+
+      var user = new User(data);
+      assert(false, 'The code should have thrown an error');
+    } catch (e) {
+      assert(true, 'The code is expected to throw an error');
+    }
+    done(null, User);
+  });
 });
 
 describe('DataSource ping', function() {

--- a/test/loopback-dl.test.js
+++ b/test/loopback-dl.test.js
@@ -296,6 +296,7 @@ describe('ModelBuilder', function() {
       var user = new User(data);
       assert(false, 'The code should have thrown an error');
     } catch (e) {
+      e.message.should.equal('Property name "constructor" is not allowed in User data');
       assert(true, 'The code is expected to throw an error');
     }
     done(null, User);


### PR DESCRIPTION
### Description
In `model.js` `_initProperties` there's a check on `data.constructor` making sure that it's not a `function`. As @jannyHou already clarified here *https://github.com/strongloop/loopback-datasource-juggler/issues/1261#issuecomment-286838360*, and as stated in the docs *http://loopback.io/doc/en/lb3/Valid-names-in-LoopBack.html#general-rules*, **constructor** is a reserver word.

But looking at the code:
```javascript
if (typeof data !== 'undefined' &&
    typeof (data.constructor) !== 'function') {
    throw new Error(g.f('Property name "{{constructor}}" is not allowed in %s data', ctor.modelName));
}
```

What if we pass an object like:
```javascript
data = {
  name: "this is my name"
}
```

Plain objects will make the condition be **truthy**.

My approach is to check before, if the `data` object has a `constructor` property in the first place.

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- #1261 
- https://github.com/Tallyb/loopback-graphql/issues/44

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Tests has been run with successful output
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
