### PR TITLE
objListis empty in linkOneToMany function

### DIFF
--- a/lib/include.js
+++ b/lib/include.js
@@ -680,6 +680,7 @@ Inclusion.include = function(objects, include, options, cb) {
             async.each(targets, linkOneToMany, next);
             function linkOneToMany(target, next) {
               var objList = targetObjsMap[target[relation.keyTo].toString()];
+              if (!objList) return next();
               async.each(objList, function(obj, next) {
                 if (!obj) return next();
                 obj.__cachedRelations[relationName] = target;
@@ -810,6 +811,7 @@ Inclusion.include = function(objects, include, options, cb) {
           function linkOneToMany(target, next) {
             var targetId = target[relation.keyTo];
             var objList = objTargetIdMap[targetId.toString()];
+            if (!objList) return next();
             async.each(objList, function(obj, next) {
               if (!obj) return next();
               obj.__cachedRelations[relationName] = target;
@@ -927,4 +929,3 @@ Inclusion.include = function(objects, include, options, cb) {
     }
   }
 };
-


### PR DESCRIPTION
### Description
Fixed 502 if relation object doesn't exist and query entity with remote-connector as datasource.

#### Related issues
Can be related to
- #951
<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
