### PR TITLE
Add name mapping to Discovery API

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -911,6 +911,18 @@ DataSource.prototype.autoupdate = function(models, cb) {
 };
 
 /**
+ * Name mapper function for converting names of certain object types to
+ * the appropriate name. Override this function to provide custom mapping.
+ */
+DataSource.prototype.mapName = function(type, name) {
+  if (type === 'table' || type === 'model') {
+    return fromDBName(name, false);
+  } else {
+    return fromDBName(name, true);
+  }
+};
+
+/**
  * Discover existing database tables.
  * This method returns an array of model objects, including {type, name, onwer}
  *
@@ -992,7 +1004,9 @@ DataSource.prototype.discoverModelProperties = function(modelName, options, cb) 
   cb = cb || utils.createPromiseCallback();
 
   if (this.connector.discoverModelProperties) {
-    this.connector.discoverModelProperties(modelName, options, cb);
+    var nameMapper = options.nameMapper || this.mapName;
+    var name = nameMapper('table', modelName);
+    this.connector.discoverModelProperties(name, options, cb);
   } else if (cb) {
     process.nextTick(cb);
   }
@@ -1008,7 +1022,9 @@ DataSource.prototype.discoverModelProperties = function(modelName, options, cb) 
 DataSource.prototype.discoverModelPropertiesSync = function(modelName, options) {
   this.freeze();
   if (this.connector.discoverModelPropertiesSync) {
-    return this.connector.discoverModelPropertiesSync(modelName, options);
+    var nameMapper = options.nameMapper || this.mapName;
+    var name = nameMapper('table', modelName);
+    return this.connector.discoverModelPropertiesSync(name, options);
   }
   return null;
 };
@@ -1041,7 +1057,9 @@ DataSource.prototype.discoverPrimaryKeys = function(modelName, options, cb) {
   cb = cb || utils.createPromiseCallback();
 
   if (this.connector.discoverPrimaryKeys) {
-    this.connector.discoverPrimaryKeys(modelName, options, cb);
+    var nameMapper = options.nameMapper || this.mapName;
+    var name = nameMapper('table', modelName);
+    this.connector.discoverPrimaryKeys(name, options, cb);
   } else if (cb) {
     process.nextTick(cb);
   }
@@ -1058,7 +1076,9 @@ DataSource.prototype.discoverPrimaryKeys = function(modelName, options, cb) {
 DataSource.prototype.discoverPrimaryKeysSync = function(modelName, options) {
   this.freeze();
   if (this.connector.discoverPrimaryKeysSync) {
-    return this.connector.discoverPrimaryKeysSync(modelName, options);
+    var nameMapper = options.nameMapper || this.mapName;
+    var name = nameMapper('table', modelName);
+    return this.connector.discoverPrimaryKeysSync(name, options);
   }
   return null;
 };
@@ -1097,7 +1117,9 @@ DataSource.prototype.discoverForeignKeys = function(modelName, options, cb) {
   cb = cb || utils.createPromiseCallback();
 
   if (this.connector.discoverForeignKeys) {
-    this.connector.discoverForeignKeys(modelName, options, cb);
+    var nameMapper = options.nameMapper || this.mapName;
+    var name = nameMapper('table', modelName);
+    this.connector.discoverForeignKeys(name, options, cb);
   } else if (cb) {
     process.nextTick(cb);
   }
@@ -1114,7 +1136,9 @@ DataSource.prototype.discoverForeignKeys = function(modelName, options, cb) {
 DataSource.prototype.discoverForeignKeysSync = function(modelName, options) {
   this.freeze();
   if (this.connector.discoverForeignKeysSync) {
-    return this.connector.discoverForeignKeysSync(modelName, options);
+    var nameMapper = options.nameMapper || this.mapName;
+    var name = nameMapper('table', modelName);
+    return this.connector.discoverForeignKeysSync(name, options);
   }
   return null;
 };
@@ -1153,7 +1177,9 @@ DataSource.prototype.discoverExportedForeignKeys = function(modelName, options, 
   cb = cb || utils.createPromiseCallback();
 
   if (this.connector.discoverExportedForeignKeys) {
-    this.connector.discoverExportedForeignKeys(modelName, options, cb);
+    var nameMapper = options.nameMapper || this.mapName;
+    var name = nameMapper('table', modelName);
+    this.connector.discoverExportedForeignKeys(name, options, cb);
   } else if (cb) {
     process.nextTick(cb);
   }
@@ -1169,7 +1195,9 @@ DataSource.prototype.discoverExportedForeignKeys = function(modelName, options, 
 DataSource.prototype.discoverExportedForeignKeysSync = function(modelName, options) {
   this.freeze();
   if (this.connector.discoverExportedForeignKeysSync) {
-    return this.connector.discoverExportedForeignKeysSync(modelName, options);
+    var nameMapper = options.nameMapper || this.mapName;
+    var name = nameMapper('table', modelName);
+    return this.connector.discoverExportedForeignKeysSync(name, options);
   }
   return null;
 };
@@ -1312,13 +1340,7 @@ DataSource.prototype.discoverSchemas = function(modelName, options, cb) {
     nameMapper = options.nameMapper;
   } else {
     // Default name mapper
-    nameMapper = function mapName(type, name) {
-      if (type === 'table' || type === 'model') {
-        return fromDBName(name, false);
-      } else {
-        return fromDBName(name, true);
-      }
-    };
+    nameMapper = self.mapName;
   }
 
   if (this.connector.discoverSchemas) {
@@ -1490,18 +1512,12 @@ DataSource.prototype.discoverSchemasSync = function(modelName, options) {
   var self = this;
   var dbType = this.name || this.connector.name;
 
+  var nameMapper = options.nameMapper || this.mapName;
+
   var columns = this.discoverModelPropertiesSync(modelName, options);
   if (!columns || columns.length === 0) {
     return [];
   }
-
-  var nameMapper = options.nameMapper || function mapName(type, name) {
-    if (type === 'table' || type === 'model') {
-      return fromDBName(name, false);
-    } else {
-      return fromDBName(name, true);
-    }
-  };
 
   // Handle primary keys
   var primaryKeys = this.discoverPrimaryKeysSync(modelName, options);
@@ -1635,7 +1651,9 @@ DataSource.prototype.discoverSchemasSync = function(modelName, options) {
 DataSource.prototype.discoverAndBuildModels = function(modelName, options, cb) {
   var self = this;
   options = options || {};
-  this.discoverSchemas(modelName, options, function(err, schemas) {
+  var nameMapper = options.nameMapper || this.mapName;
+  var name = nameMapper('table', modelName);
+  this.discoverSchemas(name, options, function(err, schemas) {
     if (err) {
       cb && cb(err, schemas);
       return;
@@ -1673,7 +1691,9 @@ DataSource.prototype.discoverAndBuildModels = function(modelName, options, cb) {
  */
 DataSource.prototype.discoverAndBuildModelsSync = function(modelName, options) {
   options = options || {};
-  var schemas = this.discoverSchemasSync(modelName, options);
+  var nameMapper = options.nameMapper || this.mapName;
+  var name = nameMapper('table', modelName);
+  var schemas = this.discoverSchemasSync(name, options);
 
   var schemaList = [];
   for (var s in schemas) {

--- a/test/discovery.test.js
+++ b/test/discovery.test.js
@@ -434,6 +434,27 @@ describe('discoverModelProperties', function() {
       done(err);
     });
   });
+
+  it('should use custom nameMapper function to `discoverModelProperties`', function(done) {
+    // Custom version of fake -- need to assert that modelName is being overridden!
+    ds.connector.discoverModelProperties = function(modelName, options, cb) {
+      modelName.should.equal('INVENTORY');
+      process.nextTick(function() {
+        cb(null, modelProperties);
+      });
+    };
+    var customMapper = function(type, name) {
+      return name.toUpperCase();
+    };
+    // Table name is intentionally lowercase!
+    ds.discoverModelProperties('inventory', {
+      nameMapper: customMapper,
+    }, function(err, schemas) {
+      if (err) return done(err);
+      schemas.should.be.eql(modelProperties);
+      done();
+    });
+  });
 });
 
 describe('discoverPrimaryKeys', function() {
@@ -494,6 +515,27 @@ describe('discoverPrimaryKeys', function() {
         done(err);
       });
   });
+
+  it('should use custom nameMapper function to `discoverPrimaryKeys`', function(done) {
+    // Custom version of fake -- need to assert that modelName is being overridden!
+    ds.connector.discoverPrimaryKeys = function(modelName, options, cb) {
+      modelName.should.equal('INVENTORY');
+      process.nextTick(function() {
+        cb(null, primaryKeys);
+      });
+    };
+    var customMapper = function(type, name) {
+      return name.toUpperCase();
+    };
+    // Table name is intentionally lowercase!
+    ds.discoverPrimaryKeys('inventory', {
+      nameMapper: customMapper,
+    }, function(err, schemas) {
+      if (err) return done(err);
+      schemas.should.be.eql(primaryKeys);
+      done();
+    });
+  });
 });
 
 describe('discoverForeignKeys', function() {
@@ -550,6 +592,27 @@ describe('discoverForeignKeys', function() {
       .catch(function(err) {
         done(err);
       });
+  });
+
+  it('should use custom nameMapper function to `discoverForeignKeys`', function(done) {
+    // Custom version of fake -- need to assert that modelName is being overridden!
+    ds.connector.discoverForeignKeys = function(modelName, options, cb) {
+      modelName.should.equal('INVENTORY');
+      process.nextTick(function() {
+        cb(null, foreignKeys);
+      });
+    };
+    var customMapper = function(type, name) {
+      return name.toUpperCase();
+    };
+    // Table name is intentionally lowercase!
+    ds.discoverForeignKeys('inventory', {
+      nameMapper: customMapper,
+    }, function(err, schemas) {
+      if (err) return done(err);
+      schemas.should.be.eql(foreignKeys);
+      done();
+    });
   });
 });
 
@@ -608,6 +671,27 @@ describe('discoverExportedForeignKeys', function() {
       .catch(function(err) {
         done(err);
       });
+  });
+
+  it('should use custom nameMapper function to `discoverExportedForeignKeys`', function(done) {
+    // Custom version of fake -- need to assert that modelName is being overridden!
+    ds.connector.discoverExportedForeignKeys = function(modelName, options, cb) {
+      modelName.should.equal('INVENTORY');
+      process.nextTick(function() {
+        cb(null, exportedForeignKeys);
+      });
+    };
+    var customMapper = function(type, name) {
+      return name.toUpperCase();
+    };
+    // Table name is intentionally lowercase!
+    ds.discoverExportedForeignKeys('inventory', {
+      nameMapper: customMapper,
+    }, function(err, schemas) {
+      if (err) return done(err);
+      schemas.should.be.eql(exportedForeignKeys);
+      done();
+    });
   });
 });
 


### PR DESCRIPTION
Add the mapName prototype to allow consistent mapping across
discovery functions, and add hooks into each discovery function
to allow in-flight override of the name mapping.

Additionally, the prototype can also be overridden to replace the
behaviour across all discovery functions.

### Description


#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
