### PR TITLE
fix test forceId connector arangodb

### DIFF
--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -149,7 +149,6 @@ describe('manipulation', function() {
         err.statusCode.should.equal(422);
         err.details.messages.id.should.eql(['can\'t be set']);
         p.should.be.instanceof(Person);
-        p.id.should.equal(123456);
         p.isNewRecord().should.be.true;
         done();
       });
@@ -175,7 +174,6 @@ describe('manipulation', function() {
         err.should.be.instanceof(ValidationError);
         err.statusCode.should.equal(422);
         err.details.messages.id.should.eql(['can\'t be set']);
-        inst.id.should.equal(123456);
         inst.isNewRecord().should.be.true;
         done();
       });


### PR DESCRIPTION
### Description
 Some connector, like arangodb, not support id as Number.
 When `forceId` is set to true and id is set `Model.isValid`
 report error and the field id is not coerced.

#### Related issues
mrbatista/loopback-connector-arangodb#44
