### PR TITLE
Use dataSource.connect to avoid duplicate connects

### DIFF
--- a/lib/connectors/memory.js
+++ b/lib/connectors/memory.js
@@ -23,7 +23,8 @@ var debug = require('debug')('loopback:connector:memory');
  */
 exports.initialize = function initializeDataSource(dataSource, callback) {
   dataSource.connector = new Memory(null, dataSource.settings);
-  dataSource.connector.connect(callback);
+  // Use dataSource.connect to avoid duplicate file reads from cache
+  dataSource.connect(callback);
 };
 
 exports.Memory = Memory;

--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -264,6 +264,65 @@ DataSource._resolveConnector = function(name, loader) {
 };
 
 /**
+ * Connect to the data source
+ * @param callback
+ */
+DataSource.prototype.connect = function(callback) {
+  callback = callback || utils.createPromiseCallback();
+  var self = this;
+  if (this.connected) {
+    // The data source is already connected, return immediately
+    process.nextTick(callback);
+    return callback.promise;
+  }
+  if (typeof this.connector.connect !== 'function') {
+    // Connector doesn't have the connect function
+    // Assume no connect is needed
+    self.connected = true;
+    self.connecting = false;
+    process.nextTick(function() {
+      self.emit('connected');
+      callback();
+    });
+    return callback.promise;
+  }
+
+  // Queue the callback
+  this.pendingConnectCallbacks = this.pendingConnectCallbacks || [];
+  this.pendingConnectCallbacks.push(callback);
+
+  // The connect is already in progress
+  if (this.connecting) return callback.promise;
+  // Set connecting flag to be true
+  this.connecting = true;
+  this.connector.connect(function(err, result) {
+    self.connecting = false;
+    if (!err) self.connected = true;
+    var cbs = self.pendingConnectCallbacks;
+    self.pendingConnectCallbacks = [];
+    if (!err) {
+      self.emit('connected');
+    } else {
+      self.emit('error', err);
+    }
+    // Invoke all pending callbacks
+    async.each(cbs, function(cb, done) {
+      try {
+        cb(err);
+      } catch (e) {
+        // Ignore error to make sure all callbacks are invoked
+        debug('Uncaught error raised by connect callback function: ', e);
+      } finally {
+        done();
+      }
+    }, function(err) {
+      if (err) throw err; // It should not happen
+    });
+  });
+  return callback.promise;
+};
+
+/**
  * Set up the data source
  * @param {String} name The name
  * @param {Object} settings The settings
@@ -364,61 +423,6 @@ DataSource.prototype.setup = function(name, settings) {
       throw err;
     }
   }
-
-  dataSource.connect = function(callback) {
-    callback = callback || utils.createPromiseCallback();
-    var self = this;
-    if (this.connected) {
-      // The data source is already connected, return immediately
-      process.nextTick(callback);
-      return callback.promise;
-    }
-    if (typeof dataSource.connector.connect !== 'function') {
-      // Connector doesn't have the connect function
-      // Assume no connect is needed
-      self.connected = true;
-      self.connecting = false;
-      process.nextTick(function() {
-        self.emit('connected');
-        callback();
-      });
-      return callback.promise;
-    }
-
-    // Queue the callback
-    this.pendingConnectCallbacks = this.pendingConnectCallbacks || [];
-    this.pendingConnectCallbacks.push(callback);
-
-    // The connect is already in progress
-    if (this.connecting) return callback.promise;
-    // Set connecting flag to be true
-    this.connecting = true;
-    this.connector.connect(function(err, result) {
-      self.connecting = false;
-      if (!err) self.connected = true;
-      var cbs = self.pendingConnectCallbacks;
-      self.pendingConnectCallbacks = [];
-      if (!err) {
-        self.emit('connected');
-      } else {
-        self.emit('error', err);
-      }
-      // Invoke all pending callbacks
-      async.each(cbs, function(cb, done) {
-        try {
-          cb(err);
-        } catch (e) {
-          // Ignore error to make sure all callbacks are invoked
-          debug('Uncaught error raised by connect callback function: ', e);
-        } finally {
-          done();
-        }
-      }, function(err) {
-        if (err) throw err; // It should not happen
-      });
-    });
-    return callback.promise;
-  };
 };
 
 function isModelClass(cls) {
@@ -1924,6 +1928,7 @@ DataSource.prototype.disconnect = function disconnect(cb) {
     });
   } else {
     process.nextTick(function() {
+      self.connected = false;
       cb && cb();
     });
   }


### PR DESCRIPTION
### Description

During code review of https://github.com/strongloop/loopback-datasource-juggler/pull/1300, we removed the duplicate protection in mem connector but it led to a path to create duplicate connects. This follow-up PR fixes the issue.

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
