### PR TITLE
Support multiple fk relations

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -1342,6 +1342,8 @@ DataSource.prototype.discoverSchemas = function(modelName, options, cb) {
     nameMapper = function mapName(type, name) {
       if (type === 'table' || type === 'model') {
         return fromDBName(name, false);
+      } else if (type == 'fk') {
+        return fromDBName(name + 'Rel', true);
       } else {
         return fromDBName(name, true);
       }
@@ -1464,7 +1466,7 @@ DataSource.prototype.discoverSchemas = function(modelName, options, cb) {
 
       schema.options.relations = {};
       foreignKeys.forEach(function(fk) {
-        var propName = nameMapper('column', fk.pkTableName);
+        var propName = nameMapper('fk', (fk.fkName || fk.pkTableName));
         schema.options.relations[propName] = {
           model: nameMapper('table', fk.pkTableName),
           type: 'belongsTo',


### PR DESCRIPTION
### Description

Before when we had more than one FK in `Table A` referencing the primary key in `Table B` it would only return the last foreign key to create a relation. It was simply because it was using the "table_name" to generate the relation name and the last one would overwrite any previous relations with the same "table_name".

#### Related issues

- https://github.com/strongloop/loopback-connector-mysql/issues/253
