### PR TITLE
Unskip test case

### DIFF
--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -855,7 +855,12 @@ describe('manipulation', function() {
         });
     });
 
-    it.skip('updates specific instances when PK is not an auto-generated id', function(done) {
+    it('updates specific instances when PK is not an auto-generated id', function(done) {
+      // skip the test if the connector is mssql
+      // https://github.com/strongloop/loopback-connector-mssql/pull/92#r72853474
+      var dsName = Post.dataSource.name;
+      if (dsName === 'mssql') return done();
+
       Post.create([
         {title: 'postA', content: 'contentA'},
         {title: 'postB', content: 'contentB'},


### PR DESCRIPTION
### Description

Unskipping test case that was usually failing on mssql connector. 
The test will only be skipped for mssql connector, since the fix in mssql might cause incomptability
More info: https://github.com/strongloop/loopback-connector-mssql/pull/92

connect to https://github.com/strongloop/loopback-datasource-juggler/issues/1305