### PR TITLE
Alter relations test case

### DIFF
--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -4987,7 +4987,10 @@ describe('relations', function() {
       Category.findById(category.id, function(err, cat) {
         if (err) return done(err);
         var link = cat.items.at(0);
-        link.updateAttributes({notes: 'Updated notes...'}, function(err, link) {
+        // use 'updateById' instead as a replacement as it is one of the embedsMany methods,
+        // that works with all connectors. `updateAttributes` does not recognize the query done on
+        // the Category Model, resulting with an error in three connectors: mssql, oracle, postgresql
+        cat.items.updateById(link.id, {notes: 'Updated notes...'}, function(err, link) {
           if (err) return done(err);
           link.notes.should.equal('Updated notes...');
           done();


### PR DESCRIPTION
### Description
This Pr https://github.com/strongloop/loopback-connector/pull/100  is failing on the three connectors: `mssql`, `oracle` and  `postgresql`.
EmbedsMany  relation model does not really work with connectors `mssql`, `oracle`, `postgresql`
and the id cannot be found and it generates an error: ` Error: Could not update attributes. Object with id 5 does not exist!`. 

The test case can only see one query where the id is `link.id`, however that id does not exist in the db. 

#### Related issues

connect to https://github.com/strongloop/loopback-datasource-juggler/issues/1331
connect to https://github.com/strongloop/loopback-datasource-juggler/issues/1185

#### Related PRS:
https://github.com/strongloop/loopback-datasource-juggler/pull/1304
https://github.com/strongloop/loopback-connector/pull/100
