### PR TITLE
Make this lib peerDepend on loopback-connector

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,13 @@
     "async-iterators": "^0.2.2",
     "eslint": "^3.12.2",
     "eslint-config-loopback": "^8.0.0",
+    "loopback-connector": "^4.0.0",
     "loopback-connector-throwing": "file:./test/fixtures/loopback-connector-throwing",
     "mocha": "^3.2.0",
     "should": "^8.4.0"
+  },
+  "peerDependencies": {
+    "loopback-connector": "^4.0.0"
   },
   "dependencies": {
     "async": "~2.1.4",
@@ -44,7 +48,6 @@
     "debug": "^2.1.1",
     "depd": "^1.0.0",
     "inflection": "^1.6.0",
-    "loopback-connector": "^4.0.0",
     "minimatch": "^3.0.3",
     "qs": "^6.3.0",
     "shortid": "^2.2.6",


### PR DESCRIPTION
### Description

 * Allows sharing object models between this libary and the others
   helping orchestrate this (eg: loopback-connector,
   loopback-connector-postgresql)
 * EG: All copies of the library will share one
   loopback-connector.ParameterizedSQL object

see: https://github.com/AccelerationNet/loopback-connector-postgresql/commit/0661c6c8a0690b0655d2f70a559b3667f41a9c7e

#### Tests

I was unsure how to add tests for this as the bug is only apparent in a full working loopback, but there are possible bugs because the loopback-connector-postgresql creates ParameterizedSQL objects that 
are incompatible with the ones here because both list loopback-connector as a dependency rather than a peerDependency.  If we are sharing object models, they all need to come from one instance of the library rather than from separate ones

#### Related issues

 - strongloop/loopback-connector-postgresql#246

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
