### PR TITLE
Fix for #1328 Attempting to where filter on type Date = null fails with backtrace

### DIFF
--- a/lib/geo.js
+++ b/lib/geo.js
@@ -25,7 +25,7 @@ exports.nearFilter = function nearFilter(where) {
           if (ret) return ret;
         });
       } else {
-        if (clause[clauseKey].hasOwnProperty('near')) {
+        if (clause[clauseKey] && clause[clauseKey].hasOwnProperty('near')) {
           var result = clause[clauseKey];
           nearResults.push({
             near: result.near,

--- a/test/basic-querying.test.js
+++ b/test/basic-querying.test.js
@@ -320,6 +320,30 @@ describe('basic-querying', function() {
       });
     });
 
+    it('should support where date "neq" null', function(done) {
+      User.find({where: {birthday: {'neq': null},
+      }}, function(err, users) {
+        should.not.exist(err);
+        users.should.have.property('length', 2);
+        users[0].name.should.equal('John Lennon');
+        users[1].name.should.equal('Paul McCartney');
+        done();
+      });
+    });
+
+    it('should support where date is null', function(done) {
+      User.find({where: {birthday: null,
+      }}, function(err, users) {
+        should.not.exist(err);
+        users.should.have.property('length', 4);
+        users[0].name.should.equal('George Harrison');
+        users[1].name.should.equal('Ringo Starr');
+        users[2].name.should.equal('Pete Best');
+        users[3].name.should.equal('Stuart Sutcliffe');
+        done();
+      });
+    });
+
     it('should support date "gte" that is satisfied', function(done) {
       User.find({where: {birthday: {'gte': new Date('1980-12-08')},
       }}, function(err, users) {


### PR DESCRIPTION
### Description

Fix for #1328 - fix backend error when attempting to query with where on Date type is null 

#### Related issues

- #1328 

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [X] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
