### PR TITLE
Revert "Make this lib peerDepend on loopback-connector"

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,13 +34,9 @@
     "async-iterators": "^0.2.2",
     "eslint": "^3.12.2",
     "eslint-config-loopback": "^8.0.0",
-    "loopback-connector": "^4.0.0",
     "loopback-connector-throwing": "file:./test/fixtures/loopback-connector-throwing",
     "mocha": "^3.2.0",
     "should": "^8.4.0"
-  },
-  "peerDependencies": {
-    "loopback-connector": "^4.0.0"
   },
   "dependencies": {
     "async": "~2.1.4",
@@ -48,6 +44,7 @@
     "debug": "^2.1.1",
     "depd": "^1.0.0",
     "inflection": "^1.6.0",
+    "loopback-connector": "^4.0.0",
     "minimatch": "^3.0.3",
     "qs": "^6.3.0",
     "shortid": "^2.2.6",


### PR DESCRIPTION
Revert back strongloop/loopback-datasource-juggler#1326 due to `loopback` requiring `loopback-connector` as a default dependency through this module.

connect to https://github.com/strongloop/loopback-workspace/issues/487