### PR TITLE
Fix to avoid beaking filters for null fields

### DIFF
--- a/lib/geo.js
+++ b/lib/geo.js
@@ -25,7 +25,7 @@ exports.nearFilter = function nearFilter(where) {
           if (ret) return ret;
         });
       } else {
-        if (clause[clauseKey].hasOwnProperty('near')) {
+        if (clause[clauseKey] && clause[clauseKey].hasOwnProperty('near')) {
           var result = clause[clauseKey];
           nearResults.push({
             near: result.near,


### PR DESCRIPTION
### Description
Fix to avoid breaking all "...where myfield is null " conditions, that have the following sintax in loopback:
{ where: { myfield: null } }

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
