### PR TITLE
CI/downstreamIgnoreList

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,5 +53,13 @@
     "traverse": "^0.6.6",
     "uuid": "^3.0.1"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "ci": {
+    "downstreamIgnoreList": [
+      "loopback-connector-db2z",
+      "loopback-connector-informix",
+      "loopback-connector-mqlight",
+      "loopback-connector-cassandra"
+    ]
+  }
 }


### PR DESCRIPTION
### Description

juggler@2.x branch fails a lot, details see https://github.com/strongloop/loopback-datasource-juggler/pull/1342
More PRs needed in the near future, this is the first one.

Add same downstreamIgnoreList as master branch(juggler@3.x), and `loopback-connector-cassandra`.

For cassandra, there might be better way to tell CI it only works with juggler@3.x but not juggler@2.x, appreciate it if people more familiar with module's dependency version could share their thought here. Thanks.


### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes(get old ones pass, don't need new ones)
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
