### PR TITLE
model-builder: allow override of DateType

### DIFF
--- a/lib/model-builder.js
+++ b/lib/model-builder.js
@@ -441,7 +441,7 @@ ModelBuilder.prototype.define = function defineClass(className, properties, sett
         if (Array.isArray(DataType) || DataType === Array) {
           DataType = List;
         } else if (DataType === Date) {
-          DataType = DateType;
+          DataType = modelBuilder.DateType;
         } else if (DataType === Boolean) {
           DataType = BooleanType;
         } else if (typeof DataType === 'string') {
@@ -525,12 +525,19 @@ ModelBuilder.prototype.define = function defineClass(className, properties, sett
   return ModelClass;
 };
 
-// DataType for Date
-function DateType(arg) {
+/**
+ * The DateType function. This provides the Date type for Loopback, and
+ * by default, checks to ensure that the value provided is a valid date.
+ * You may override this function to provide custom DateType functionality.
+ * @param {*} arg The provided argument
+ * @returns {Date}
+ * @throws {Error}
+ */
+ModelBuilder.prototype.DateType = function(arg) {
   if (arg === null) return null;
   var d = new Date(arg);
   return d;
-}
+};
 
 // Relax the Boolean coercision
 function BooleanType(arg) {


### PR DESCRIPTION
### Description

DateType handling can now be overridden at the model level by
creating your own definition at the Model's modelBuilder instance.

Ex:
```
// Foo.js
module.exports = function(Foo) {
  Foo.modelBuilder.DateType = function(arg) {
    // do whatever you want here and return a result
  }
};
```

#### Related issues
connected to https://github.com/strongloop/loopback-connector-mysql/issues/149

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
