### PR TITLE
Documentation for RelationDefinition.referencesMany

### DIFF
--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -3081,6 +3081,39 @@ EmbedsMany.prototype.remove = function(acInst, options, cb) {
   return cb.promise;
 };
 
+/**
+ * Declare "referencesMany" relation that sets up an embedded one-to-many
+ * association with another model, such that each instance of the declaring
+ * model has an independent unique set of assocations to other model instances.
+ *
+ * This creates a property which is an array of foreign keys to instances of
+ * the other model in the declaring model.
+ *
+ * For example, if an application includes Items and Customers, and each item
+ * can have its own list of Customers that might have been sold to,
+ * you can declare this as follows:
+ * ```
+ * Item.referencesMany(Customer, {as: 'customers', foreignKey: 'customerIds'});
+ * ```
+ *
+ * This creates a property `Item.customerIds` - if the value was `[ 1, 2 ]`
+ * the Item instances has a reference to `Customer.id==1` and `Customer.id==2` -
+ * and a relation remote method customers. Patch customerIds to change the list.
+ *
+ * This relation is a loose association, in that an instance of the other model
+ * us  independent of and may have no knowlegde that it has been referenced by
+ * instance(s) of the declaring model.
+ *
+ * Note: to map the array property to a SQL dB create a matching property
+ * as is done to achieve this for belongsTo relations.
+ *
+ * @param {Model} modelFrom Source model class
+ * @param {Object|String} modelTo Model object (or String name of model) to which you are creating the relationship.
+ * @options {Object} params Configuration parameters; see below.
+ * @property {String} as Name of the property (relation) in the referring model that corresponds to the foreign key field in the related model.
+ * @property {String} foreignKey Property name of foreign key field (the array) - if not specified, is pluralised from relation name (`as`) by default
+ * @property {Object} model Model object
+ */
 RelationDefinition.referencesMany = function referencesMany(modelFrom, modelToRef, params) {
   params = params || {};
   normalizeRelationAs(params, modelToRef);

--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -3108,10 +3108,13 @@ EmbedsMany.prototype.remove = function(acInst, options, cb) {
  * as is done to achieve this for belongsTo relations.
  *
  * @param {Model} modelFrom Source model class
- * @param {Object|String} modelTo Model object (or String name of model) to which you are creating the relationship.
+ * @param {Object|String} modelTo Model object (or String name of model) to
+ *  which you are creating the relationship.
  * @options {Object} params Configuration parameters; see below.
- * @property {String} as Name of the property (relation) in the referring model that corresponds to the foreign key field in the related model.
- * @property {String} foreignKey Property name of foreign key field (the array) - if not specified, is pluralised from relation name (`as`) by default
+ * @property {String} as Name of the property (relation) in the referring model
+ *  that corresponds to the foreign key field in the related model.
+ * @property {String} foreignKey Property name of foreign key field (the array)
+ *  If not specified, is pluralised from relation name (`as`) by default
  * @property {Object} model Model object
  */
 RelationDefinition.referencesMany = function referencesMany(modelFrom, modelToRef, params) {


### PR DESCRIPTION
### Description

This was not documented in any detail. I guess this should also be transcribed over to http://loopback.io/doc/en/lb3/Embedded-models-and-relations.html#referencesmany but I'm not sure where that gets generated from.

Done while looking at #1346

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
