### PR TITLE
WIP Fixes #1346 set connector fk for referencesMany

### DIFF
--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -2368,9 +2368,23 @@ RelationDefinition.embedsMany = function embedsMany(modelFrom, modelTo, params) 
     embed: true,
   });
 
-  modelFrom.dataSource.defineProperty(modelFrom.modelName, propertyName, {
-    type: [modelTo], default: function() { return []; },
-  });
+  // We need to retain any connector specific properties if they have already
+  // been specified. Note a SQL RDBMS either needs to be some kinds of native
+  // array, a jsonb or a string, _not_ an integer or whatever the id of the
+  // other side is. However, DataSource.defineForeignKey(...) is not suitable
+  // because it resets the property to the id type...
+  if (modelFrom.definition.properties[propertyName]) {
+    if (!Array.isArray(modelFrom.definition.properties[propertyName].type)) {
+      throw new Error(g.f('ReferencesMany foreign key property type must be an array: %s %s',
+          this.name, propertyName));
+    }
+    // NOTE: this is connector specific, but in an ideal world we would abort
+    // if the connector specific type is not able to hold an array of modelTo
+  } else {
+    modelFrom.dataSource.defineProperty(modelFrom.modelName, propertyName, {
+      type: [modelTo], default: function() { return []; },
+    });
+  }
 
   if (typeof modelTo.dataSource.connector.generateId !== 'function') {
     modelFrom.validate(propertyName, function(err) {
@@ -3044,7 +3058,7 @@ RelationDefinition.referencesMany = function referencesMany(modelFrom, modelTo, 
   // because it resets the property to the id type...
   if (modelFrom.definition.properties[fk]) {
     if (!Array.isArray(modelFrom.definition.properties[fk].type)) {
-      throw new Error(g.f('ReferencesMany foreign key property type must be an array: %s', this.name));
+      throw new Error(g.f('ReferencesMany foreign key property type must be an array: %s %s', this.name, fk));
     }
     // NOTE: this is connector specific, but in an ideal world we would abort
     // if the connector specific type is not able to hold an array of idType

--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -3037,9 +3037,22 @@ RelationDefinition.referencesMany = function referencesMany(modelFrom, modelTo, 
     options: params.options,
   });
 
-  modelFrom.dataSource.defineProperty(modelFrom.modelName, fk, {
-    type: [idType], default: function() { return []; },
-  });
+  // We need to retain any connector specific properties if they have already
+  // been specified. Note a SQL RDBMS either needs to be some kinds of native
+  // array, a jsonb or a string, _not_ an integer or whatever the id of the
+  // other side is. However, DataSource.defineForeignKey(...) is not suitable
+  // because it resets the property to the id type...
+  if (modelFrom.definition.properties[fk]) {
+    if (!Array.isArray(modelFrom.definition.properties[fk].type)) {
+      throw new Error(g.f('ReferencesMany foreign key property type must be an array: %s', this.name));
+    }
+    // NOTE: this is connector specific, but in an ideal world we would abort
+    // if the connector specific type is not able to hold an array of idType
+  } else {
+    modelFrom.dataSource.defineProperty(modelFrom.modelName, fk, {
+      type: [idType], default: function() { return []; },
+    });
+  }
 
   modelFrom.validate(relationName, function(err) {
     var ids = this[fk] || [];

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -16,7 +16,7 @@ var DataSource = jdb.DataSource;
 var createPromiseCallback = require('../lib/utils.js').createPromiseCallback;
 
 var db, tmp, Book, Chapter, Author, Reader;
-var Category, Job;
+var Category, Job, Container, Item;
 var Picture, PictureLink;
 var Person, Address;
 var Link;
@@ -5172,8 +5172,9 @@ describe('relations', function() {
       db = getSchema();
       Category = db.define('Category', {name: String});
       Job = db.define('Job', {name: String});
-
-      db.automigrate(['Job', 'Category'], done);
+      Container = db.define('Container', {name: String, fk2: {doc: 'x', type: [Number], preserved: 'value'}});
+      Item = db.define('Item', {blob: String});
+      db.automigrate(['Job', 'Category', 'Item', 'Container'], done);
     });
 
     it('can be declared', function(done) {
@@ -5194,6 +5195,9 @@ describe('relations', function() {
       Category.referencesMany(Job, {scopeMethods: {
         reverse: reverse,
       }});
+
+      (new Category).jobs.should.be.an.instanceOf(Function);
+      Object.keys((new Category).toObject()).should.containEql('jobIds');
 
       Category.prototype['__reverse__jobs'].should.be.a.function;
       should.exist(Category.prototype['__reverse__jobs'].shared);
@@ -5223,6 +5227,29 @@ describe('relations', function() {
           p.name.should.equal('Job 2');
           job2 = p;
           done();
+        });
+      });
+    });
+
+    it('can have a custom fk', function(done) {
+      Item.create({blob: 'Item 1'}, function(err, p) {
+        Item.create({blob: 'Item 3'}, function(err, p) {
+          Container.referencesMany(Item, {foreignKey: 'fk2', as: 'anotherRelation'});
+          (new Container).anotherRelation.should.be.an.instanceOf(Function);
+          Object.keys((new Container).toObject()).should.containEql('fk2');
+          Container.definition.properties.fk2.preserved.should.eql('value');
+          db.automigrate(['Item', 'Container'], done);
+          Container.create({name: 'Container X'}, function(err, cat) {
+            cat.fk2.should.be.an.array;
+            cat.fk2.should.have.length(0);
+            cat.anotherRelation.create({blob: 'Item X'}, function(err, p) {
+              if (err) return done(err);
+              cat.fk2.should.have.lengthOf(1);
+              cat.fk2[0].should.eql(p.id);
+              p.blob.should.equal('Item X');
+              done();
+            });
+          });
         });
       });
     });


### PR DESCRIPTION
### Description

This is a fix for #1346 

If there is a property matching the foreign key of a referencesMany relation, then dont clobber it, presuming the  the user has knowing put it there to describe a connector type and column name for that field.


#### Related issues

#1346

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->



### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
