### PR TITLE
datatype.test: minimize rounding failures

### DIFF
--- a/test/datatype.test.js
+++ b/test/datatype.test.js
@@ -83,7 +83,7 @@ describe('datatypes', function() {
         m.arr[0].should.be.equal(1);
         m.arr[1].should.be.equal('str');
         m.date.should.be.an.instanceOf(Date);
-        m.date.toString().should.equal(d.toString(), 'Time must match');
+        m.date.toISOString().should.equal(d.toISOString(), 'Time must match');
         next();
       });
     }


### PR DESCRIPTION
The current implementation will rarely fail as a result of a
rounding error between both values, so switching the comparison to
ISO timestamps to reduce the likelihood of such an event in future.

### Description


#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
