### PR TITLE
create sequence for nosql id

### DIFF
--- a/test/basic-querying.test.js
+++ b/test/basic-querying.test.js
@@ -856,8 +856,8 @@ describe('basic-querying', function() {
           if (err) return done(err);
           users.length.should.be.equal(2);
           var expectedUsers = ['John Lennon', 'Paul McCartney'];
-          (expectedUsers.indexOf(users[0].name) > -1).should.be.ok();
-          (expectedUsers.indexOf(users[1].name) > -1).should.be.ok();
+          expectedUsers.indexOf(users[0].name).should.not.equal(-1);
+          expectedUsers.indexOf(users[1].name).should.not.equal(-1);
           done();
         });
       });

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -836,7 +836,7 @@ describe('relations', function() {
               should.exist(ch);
               ch.should.have.lengthOf(2);
               if (typeof idArr[0] === 'object') {
-                // mongodb returns `id` as an object 
+                // mongodb returns `id` as an object
                 idArr[0] = idArr[0].toString();
                 idArr[1] = idArr[1].toString();
                 idArr.indexOf(ch[0].id.toString()).should.be.above(-1);

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -835,8 +835,16 @@ describe('relations', function() {
               if (err) return done(err);
               should.exist(ch);
               ch.should.have.lengthOf(2);
-              idArr.indexOf(ch[0].id).should.be.above(-1);
-              idArr.indexOf(ch[1].id).should.be.above(-1);
+              if (typeof idArr[0] === 'object') {
+                // mongodb returns `id` as an object 
+                idArr[0] = idArr[0].toString();
+                idArr[1] = idArr[1].toString();
+                idArr.indexOf(ch[0].id.toString()).should.be.above(-1);
+                idArr.indexOf(ch[1].id.toString()).should.be.above(-1);
+              } else {
+                idArr.indexOf(ch[0].id).should.be.above(-1);
+                idArr.indexOf(ch[1].id).should.be.above(-1);
+              }
               done();
             });
           });

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -839,11 +839,11 @@ describe('relations', function() {
                 // mongodb returns `id` as an object
                 idArr[0] = idArr[0].toString();
                 idArr[1] = idArr[1].toString();
-                idArr.indexOf(ch[0].id.toString()).should.be.above(-1);
-                idArr.indexOf(ch[1].id.toString()).should.be.above(-1);
+                idArr.indexOf(ch[0].id.toString()).should.not.equal(-1);
+                idArr.indexOf(ch[1].id.toString()).should.not.equal(-1);
               } else {
-                idArr.indexOf(ch[0].id).should.be.above(-1);
-                idArr.indexOf(ch[1].id).should.be.above(-1);
+                idArr.indexOf(ch[0].id).should.not.equal(-1);
+                idArr.indexOf(ch[1].id).should.not.equal(-1);
               }
               done();
             });


### PR DESCRIPTION
### Description
PR created when recovering test cases in cloudant:
cloudant creates string type id which could not guarantee id are incremented. To solve the problem, I add a `sequence` property to make sure the related test case returns result ordered by sequence and will skip the first data. 

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
