### PR TITLE
refactor: rename internal instance errors property to __errors

### DIFF
--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -2065,9 +2065,9 @@ RelationDefinition.embedsOne = function(modelFrom, modelToRef, params) {
       var inst = this[propertyName];
       if (inst instanceof modelTo) {
         if (!inst.isValid()) {
-          var first = Object.keys(inst.errors)[0];
-          var msg = 'is invalid: `' + first + '` ' + inst.errors[first];
-          this.errors.add(relationName, msg, 'invalid');
+          var first = Object.keys(inst.__errors)[0];
+          var msg = 'is invalid: `' + first + '` ' + inst.__errors[first];
+          this.__errors.add(relationName, msg, 'invalid');
           err(false);
         }
       }
@@ -2455,7 +2455,7 @@ RelationDefinition.embedsMany = function embedsMany(modelFrom, modelToRef, param
           hasErrors = true;
           var msg = 'contains invalid item at index `' + idx + '`:';
           msg += ' `' + idName + '` is blank';
-          self.errors.add(propertyName, msg, 'invalid');
+          self.__errors.add(propertyName, msg, 'invalid');
         }
       });
       if (hasErrors) err(false);
@@ -2470,7 +2470,7 @@ RelationDefinition.embedsMany = function embedsMany(modelFrom, modelToRef, param
         return utils.findIndexOf(ids, id, idEquals) === pos;
       });
       if (ids.length !== uniqueIds.length) {
-        this.errors.add(propertyName, 'contains duplicate `' + idName + '`', 'uniqueness');
+        this.__errors.add(propertyName, 'contains duplicate `' + idName + '`', 'uniqueness');
         err(false);
       }
     }, {code: 'uniqueness'});
@@ -2487,16 +2487,16 @@ RelationDefinition.embedsMany = function embedsMany(modelFrom, modelToRef, param
           if (!item.isValid()) {
             hasErrors = true;
             var id = item[idName];
-            var first = Object.keys(item.errors)[0];
+            var first = Object.keys(item.__errors)[0];
             let msg = id ?
               'contains invalid item: `' + id + '`' :
               'contains invalid item at index `' + idx + '`';
-            msg += ' (`' + first + '` ' + item.errors[first] + ')';
-            self.errors.add(propertyName, msg, 'invalid');
+            msg += ' (`' + first + '` ' + item.__errors[first] + ')';
+            self.__errors.add(propertyName, msg, 'invalid');
           }
         } else {
           hasErrors = true;
-          self.errors.add(propertyName, 'contains invalid item', 'invalid');
+          self.__errors.add(propertyName, 'contains invalid item', 'invalid');
         }
       });
       if (hasErrors) err(false);
@@ -3122,7 +3122,7 @@ RelationDefinition.referencesMany = function referencesMany(modelFrom, modelToRe
     });
     if (ids.length !== uniqueIds.length) {
       var msg = 'contains duplicate `' + modelTo.modelName + '` instance';
-      this.errors.add(relationName, msg, 'uniqueness');
+      this.__errors.add(relationName, msg, 'uniqueness');
       err(false);
     }
   }, {code: 'uniqueness'});

--- a/lib/validations.js
+++ b/lib/validations.js
@@ -467,8 +467,8 @@ function getConfigurator(name, opts) {
 
 /**
  * This method performs validation and triggers validation hooks.
- * Before validation the `obj.errors` collection is cleaned.
- * Each validation can add errors to `obj.errors` collection.
+ * Before validation the `obj.__errors` collection is cleaned.
+ * Each validation can add errors to `obj.__errors` collection.
  * If collection is not blank, validation failed.
  *
  * NOTE: This method can be called as synchronous only when no asynchronous validation is
@@ -478,14 +478,14 @@ function getConfigurator(name, opts) {
  * ```javascript
  * user.isValid(function (valid) {
  *     if (valid) res.render({user: user});
- *     else res.flash('error', 'User is not valid'), console.log(user.errors), res.redirect('/users');
+ *     else res.flash('error', 'User is not valid'), console.log(user.__errors), res.redirect('/users');
  * });
  * ```
  * Another example:
  * ```javascript
  * user.isValid(function (valid) {
  *     if (!valid) {
- *           console.log(user.errors);
+ *           console.log(user.__errors);
  *         // => hash of errors
  *         // => {
  *         // => username: [errmessage, errmessage, ...],
@@ -520,7 +520,7 @@ Validatable.prototype.isValid = function(callback, data, options) {
     return valid;
   }
 
-  Object.defineProperty(this, 'errors', {
+  Object.defineProperty(this, '__errors', {
     enumerable: false,
     configurable: true,
     value: new Errors,
@@ -554,7 +554,7 @@ Validatable.prototype.isValid = function(callback, data, options) {
         var key = inst.__unknownProperties[ix];
         var code = 'unknown-property';
         var msg = defaultMessages[code];
-        inst.errors.add(key, msg, code);
+        inst.__errors.add(key, msg, code);
         valid = false;
       }
     }
@@ -591,7 +591,7 @@ Validatable.prototype.isValid = function(callback, data, options) {
 };
 
 function cleanErrors(inst) {
-  Object.defineProperty(inst, 'errors', {
+  Object.defineProperty(inst, '__errors', {
     enumerable: false,
     configurable: true,
     value: false,
@@ -643,7 +643,7 @@ function validationFailed(inst, attr, conf, options, cb) {
         message = 'is invalid';
       }
     }
-    if (kind !== false) inst.errors.add(attr, message, code);
+    if (kind !== false) inst.__errors.add(attr, message, code);
     fail = true;
   });
   validatorArguments.push(options);
@@ -858,15 +858,15 @@ function ValidationError(obj) {
   this.message = g.f(
     'The %s instance is not valid. Details: %s.',
       context ? '`' + context + '`' : 'model',
-      formatErrors(obj.errors, obj.toJSON()) || '(unknown)'
+      formatErrors(obj.__errors, obj.toJSON()) || '(unknown)'
   );
 
   this.statusCode = 422;
 
   this.details = {
     context: context,
-    codes: obj.errors && obj.errors.codes,
-    messages: obj.errors,
+    codes: obj.__errors && obj.__errors.codes,
+    messages: obj.__errors,
   };
 
   if (Error.captureStackTrace) {

--- a/test/loopback-dl.test.js
+++ b/test/loopback-dl.test.js
@@ -505,7 +505,7 @@ describe('DataSource define model', function() {
       var User = ds.define('User', {name: String}, {strict: 'validate'});
       var user = new User({name: 'Joe', age: 20});
       user.isValid().should.be.false;
-      var codes = user.errors && user.errors.codes || {};
+      var codes = user.__errors && user.__errors.codes || {};
       codes.should.have.property('age').eql(['unknown-property']);
     });
   });
@@ -1907,7 +1907,7 @@ describe('ModelBuilder options.models', function() {
     });
     assert.equal(m1.address.number, undefined, 'm1 should not contain number property in address');
     assert.equal(m1.address.isValid(), false, 'm1 address should not validate with extra property');
-    var codes = m1.address.errors && m1.address.errors.codes || {};
+    var codes = m1.address.__errors && m1.address.__errors.codes || {};
     assert.deepEqual(codes.number, ['unknown-property']);
   });
 });

--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -272,7 +272,7 @@ describe('manipulation', function() {
 
           should.exist(persons);
           persons.should.have.lengthOf(batch.length);
-          persons[0].errors.should.be.false;
+          persons[0].__errors.should.be.false;
           done();
         });
       });
@@ -300,7 +300,7 @@ describe('manipulation', function() {
 
           should.exist(persons);
           persons.should.have.lengthOf(batch.length);
-          persons[0].errors.should.be.false;
+          persons[0].__errors.should.be.false;
           done();
         });
       });

--- a/test/validations.test.js
+++ b/test/validations.test.js
@@ -79,7 +79,7 @@ describe('validations', function() {
         var user = new User;
         user.createdByAdmin = true;
         user.isValid().should.be.false();
-        user.errors.pendingPeriod.should.eql(['can\'t be blank']);
+        user.__errors.pendingPeriod.should.eql(['can\'t be blank']);
         user.pendingPeriod = 1;
         user.isValid().should.be.true();
       });
@@ -89,7 +89,7 @@ describe('validations', function() {
         var user = new User;
         user.createdByAdmin = false;
         user.isValid().should.be.true();
-        user.errors.should.be.false();
+        user.__errors.should.be.false();
         user.pendingPeriod = 1;
         user.isValid().should.be.true();
       });
@@ -99,7 +99,7 @@ describe('validations', function() {
         var user = new User;
         user.createdByAdmin = false;
         user.isValid().should.be.false();
-        user.errors.pendingPeriod.should.eql(['can\'t be blank']);
+        user.__errors.pendingPeriod.should.eql(['can\'t be blank']);
         user.pendingPeriod = 1;
         user.isValid().should.be.true();
       });
@@ -109,7 +109,7 @@ describe('validations', function() {
         var user = new User;
         user.createdByAdmin = true;
         user.isValid().should.be.true();
-        user.errors.should.be.false();
+        user.__errors.should.be.false();
         user.pendingPeriod = 1;
         user.isValid().should.be.true();
       });
@@ -125,7 +125,7 @@ describe('validations', function() {
         user.createdByAdmin = false;
         user.isValid(function(valid) {
           valid.should.be.true();
-          user.errors.should.be.false();
+          user.__errors.should.be.false();
           done();
         });
       });
@@ -139,7 +139,7 @@ describe('validations', function() {
         user.createdByAdmin = true;
         user.isValid(function(valid) {
           valid.should.be.false();
-          user.errors.pendingPeriod.should.eql(['can\'t be blank']);
+          user.__errors.pendingPeriod.should.eql(['can\'t be blank']);
           done();
         });
       });
@@ -153,7 +153,7 @@ describe('validations', function() {
         user.createdByAdmin = true;
         user.isValid(function(valid) {
           valid.should.be.true();
-          user.errors.should.be.false();
+          user.__errors.should.be.false();
           done();
         });
       });
@@ -167,7 +167,7 @@ describe('validations', function() {
         user.createdByAdmin = false;
         user.isValid(function(valid) {
           valid.should.be.false();
-          user.errors.pendingPeriod.should.eql(['can\'t be blank']);
+          user.__errors.pendingPeriod.should.eql(['can\'t be blank']);
           done();
         });
       });
@@ -405,7 +405,7 @@ describe('validations', function() {
 
       user.createdByScript = false;
       user.isValid().should.be.false();
-      user.errors.domain.should.eql(['can\'t be blank']);
+      user.__errors.domain.should.eql(['can\'t be blank']);
 
       user.domain = 'domain';
       user.isValid().should.be.true();
@@ -804,7 +804,7 @@ describe('validations', function() {
       User.validatesFormatOf('name', {with: /[a-z][A-Z]*$/, message: CUSTOM_MESSAGE});
       var u = new User({name: 'invalid name string 123'});
       u.isValid().should.be.false();
-      u.errors.should.eql({
+      u.__errors.should.eql({
         name: [CUSTOM_MESSAGE],
         codes: {
           name: ['format'],
@@ -894,14 +894,14 @@ describe('validations', function() {
       User.validatesNumericalityOf('age');
       var user = new User({age: 'notanumber'});
       user.isValid().should.be.false();
-      user.errors.should.eql({age: ['is not a number']});
+      user.__errors.should.eql({age: ['is not a number']});
     });
 
     it('fails when given undefined values', function() {
       User.validatesNumericalityOf('age');
       var user = new User({});
       user.isValid().should.be.false();
-      user.errors.should.eql({age: ['is blank']});
+      user.__errors.should.eql({age: ['is blank']});
     });
 
     it('skips undefined values when allowBlank option is true', function() {
@@ -914,14 +914,14 @@ describe('validations', function() {
       User.validatesNumericalityOf('age', {allowBlank: true});
       var user = new User({age: 'test'});
       user.isValid().should.be.false();
-      user.errors.should.eql({age: ['is not a number']});
+      user.__errors.should.eql({age: ['is not a number']});
     });
 
     it('fails when given null values', function() {
       User.validatesNumericalityOf('age');
       var user = new User({age: null});
       user.isValid().should.be.false();
-      user.errors.should.eql({age: ['is null']});
+      user.__errors.should.eql({age: ['is null']});
     });
 
     it('passes when given null values when allowNull option is true', function() {
@@ -940,7 +940,7 @@ describe('validations', function() {
       User.validatesNumericalityOf('age', {int: true});
       var user = new User({age: 13.37});
       user.isValid().should.be.false();
-      user.errors.should.match({age: /is not an integer/});
+      user.__errors.should.match({age: /is not an integer/});
     });
 
     describe('validate numericality on update', function() {
@@ -1263,20 +1263,20 @@ describe('validations', function() {
       }, {code: 'invalid-email'});
       var u = new User({email: 'hello'});
       Boolean(u.isValid()).should.be.false();
-      u.errors.codes.should.eql({email: ['invalid-email']});
+      u.__errors.codes.should.eql({email: ['invalid-email']});
     });
 
     it('should validate and return detailed error messages', function() {
       User.validate('global', function(err) {
         if (this.email === 'hello' || this.email === 'hey') {
-          this.errors.add('email', 'Cannot be `' + this.email + '`', 'invalid-email');
+          this.__errors.add('email', 'Cannot be `' + this.email + '`', 'invalid-email');
           err(false); // false: prevent global error message
         }
       });
       var u = new User({email: 'hello'});
       Boolean(u.isValid()).should.be.false();
-      u.errors.should.eql({email: ['Cannot be `hello`']});
-      u.errors.codes.should.eql({email: ['invalid-email']});
+      u.__errors.should.eql({email: ['Cannot be `hello`']});
+      u.__errors.codes.should.eql({email: ['invalid-email']});
     });
 
     it('should validate using custom async validation', function(done) {
@@ -1352,7 +1352,7 @@ describe('validations', function() {
       errorVal[propertyName] = [errorMessage];
 
       var obj = {
-        errors: errorVal,
+        __errors: errorVal,
         toJSON: function() { return jsonVal; },
       };
       return new ValidationError(obj);
@@ -1392,7 +1392,7 @@ describe('validations', function() {
       User.validatesDateOf('updatedAt');
       var u = new User({updatedAt: 'invalid date string'});
       u.isValid().should.not.be.true();
-      u.errors.should.eql({
+      u.__errors.should.eql({
         updatedAt: ['is not a valid date'],
         codes: {
           updatedAt: ['date'],
@@ -1416,7 +1416,7 @@ describe('validations', function() {
       });
       var u = new AnotherUser({updatedAt: 'invalid date string'});
       u.isValid().should.not.be.true();
-      u.errors.should.eql({
+      u.__errors.should.eql({
         updatedAt: ['is not a valid date'],
         codes: {
           updatedAt: ['date'],
@@ -1429,7 +1429,7 @@ describe('validations', function() {
       User.validatesDateOf('updatedAt', {message: CUSTOM_MESSAGE});
       var u = new User({updatedAt: 'invalid date string'});
       u.isValid().should.not.be.true();
-      u.errors.should.eql({
+      u.__errors.should.eql({
         updatedAt: [CUSTOM_MESSAGE],
         codes: {
           updatedAt: ['date'],


### PR DESCRIPTION
### Description

This fix ensures that you can define a property called `errors` inside your loopback model and it won't be overwritten by the internal validation.

#### Related issues

To fix this issue: https://github.com/strongloop/loopback-datasource-juggler/issues/1353

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
