### PR TITLE
Fix order of query results

### DIFF
--- a/test/basic-querying.test.js
+++ b/test/basic-querying.test.js
@@ -341,8 +341,8 @@ describe('basic-querying', function() {
         should.not.exist(err);
         should.exist(users);
         users.should.have.property('length', 2);
-        users[0].name.should.equal('John Lennon');
-        users[1].name.should.equal('Paul McCartney');
+        should(users[0].name).be.oneOf('John Lennon', 'Paul McCartney');
+        should(users[1].name).be.oneOf('John Lennon', 'Paul McCartney');
         done();
       });
     });


### PR DESCRIPTION
### Description
The order of the instances in the array could be reverted sometimes. That's is causing CI failures sometimes. 
so users[0].name could be 'John Lennon' or Paul McCartney' and the same for users[1].name, 
so the fix is trying to ignore the order of names but to ensure that both names are still there. 
 
