### PR TITLE
docs: add DateString definition

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -2,6 +2,7 @@
     "content": [
         "lib/datasource.js",
         "lib/model.js",
+        "lib/date-string.js",
         "lib/geo.js",
         "lib/hooks.js",
         "lib/include.js",


### PR DESCRIPTION
### Description
Add the DateString to the docs.json so that they end up in our API docs.