### PR TITLE
Fix assert as array does not guarantee order

### DIFF
--- a/test/basic-querying.test.js
+++ b/test/basic-querying.test.js
@@ -467,7 +467,7 @@ describe('basic-querying', function() {
       return User.find({where: {seq: {inq: [0, 1, 100]}}})
         .then(function(result) {
           var seqsFound = result.map(function(r) { return r.seq; });
-          should(seqsFound).eql([0, 1]);
+          should(seqsFound.sort()).eql([0, 1]);
         });
     });
 


### PR DESCRIPTION
### Description
There is no guarantee on the order that the array values comes back so sort before asserting value.

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
