### PR TITLE
Use = instead of IN if only one FK

### DIFF
--- a/lib/include.js
+++ b/lib/include.js
@@ -251,7 +251,7 @@ Inclusion.include = function(objects, include, options, cb) {
           newFilter.where[w] = filter.where[w];
         }
       }
-      newFilter.where[fkName] = {
+      newFilter.where[fkName] = foreignKeys.length === 1 ? foreignKeys[0] : {
         inq: foreignKeys,
       };
       model.find(newFilter, options, function(err, results) {


### PR DESCRIPTION
### Description

Use = in case there is only one foeignKey to avoid IN as much as possible.

#### Related issues

https://waffle.io/strongloop-internal/scrum-asteroid/cards/59135f6e0fe1c5009245818f
<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
