### PR TITLE
Allow retrieval of _rev property

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -369,7 +369,14 @@ DataAccessObject.create = function(data, options, cb) {
             defineReadonlyProp(obj, _idName, id);
           }
           if (rev) {
-            obj._rev = rev;
+            // if cloudant, send out the `_rev` in `__data`
+            // and specify it to be a readonly prop
+            if (connector.name === 'cloudant') {
+              obj.__data._rev = rev;
+              defineReadonlyProp(obj, '_rev', rev);
+            }  else {
+              obj._rev = rev;
+            }
           }
           if (err) {
             return cb(err, obj);


### PR DESCRIPTION
connect to https://github.com/strongloop/loopback-connector-cloudant/issues/55

Allow retrieval of `_rev` property for Cloudant connector. Make it a readonly prop, similar to `_id`.