### PR TITLE
Use correct data on replace callback

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -3059,7 +3059,9 @@ DataAccessObject.replaceById = function(id, data, options, cb) {
 
         function replaceCallback(err, data) {
           if (err) return cb(err);
-
+          if (typeof connector.generateContextData === 'function') {
+            context = connector.generateContextData(context, data);
+          }
           var ctx = {
             Model: Model,
             hookState: hookState,


### PR DESCRIPTION
connected to https://github.com/strongloop/loopback-connector-cloudant/issues/55

Previously, it would just pass the old data. Need to pass the updated data because cloudant changes the `_rev` property on CRUD call.