### PR TITLE
Return promise for batch create

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -265,7 +265,7 @@ DataAccessObject.create = function(data, options, cb) {
 
   data = data || {};
   options = options || {};
-  cb = cb || (Array.isArray(data) ? noCallback : utils.createPromiseCallback());
+  cb = cb || utils.createPromiseCallback();
 
   assert(typeof data === 'object', 'The data argument must be an object or array');
   assert(typeof options === 'object', 'The options argument must be an object');
@@ -305,7 +305,7 @@ DataAccessObject.create = function(data, options, cb) {
       }
       cb(errors, data);
     });
-    return;
+    return cb.promise;
   }
 
   var enforced = {};

--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -277,6 +277,34 @@ describe('manipulation', function() {
       });
     });
 
+    it('should create batch of objects (promise variant)', function(done) {
+      var batch = [
+        {name: 'ShaltayPromise'},
+        {name: 'BoltayPromise'},
+        {},
+      ];
+      Person.create(batch).then(function(ps) {
+        should.exist(ps);
+        ps.should.be.instanceOf(Array);
+        ps.should.have.lengthOf(batch.length);
+
+        Person.validatesPresenceOf('name');
+        Person.create(batch, function(errors, persons) {
+          delete Person.validations;
+          should.exist(errors);
+          errors.should.have.lengthOf(batch.length);
+          should.not.exist(errors[0]);
+          should.not.exist(errors[1]);
+          should.exist(errors[2]);
+
+          should.exist(persons);
+          persons.should.have.lengthOf(batch.length);
+          persons[0].errors.should.be.false;
+          done();
+        });
+      });
+    });
+
     it('should create batch of objects with beforeCreate', function(done) {
       Person.beforeCreate = function(next, data) {
         if (data && data.name === 'A') {


### PR DESCRIPTION
### Description

The issue was discovered in loopback-next. When an array of values is passed into Model.create() without a callback function, it does NOT return a promise. The PR fixes the issue.

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
