### PR TITLE
Remove node 7 support in 2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "posttest": "npm run lint"
   },
   "engines": {
-    "node": ">= 0.6"
+    "node": ">= 0.6 <7"
   },
   "devDependencies": {
     "async-iterators": "^0.2.2",


### PR DESCRIPTION
### Description

IMO, the LB@2.x should support any node versions before the release of LB@3.x, but for new released versions like node 7, we may want to stop supporting them.