### PR TITLE
Fix updateAttributes cb

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -3250,8 +3250,11 @@ function(data, options, cb) {
             var typedData = convertSubsetOfPropertiesByType(inst, data);
             context.data = typedData;
 
-            function updateAttributesCallback(err) {
+            function updateAttributesCallback(err, data) {
               if (err) return cb(err);
+              if (typeof connector.generateContextData === 'function') {
+                context = connector.generateContextData(context, data);
+              }
               var ctx = {
                 Model: Model,
                 data: context.data,


### PR DESCRIPTION
Currently, the `updateAttributes` callback does not pass through the updated data from the database to juggler.

Allow pass through of the new data from the connector itself and update the context data to have the new `_rev` value got after the update.

Similar to the [replaceCallback in dao](https://github.com/strongloop/loopback-datasource-juggler/blob/master/lib/dao.js#L3062)

connect to https://github.com/strongloop/loopback-connector-cloudant/issues/35

