### PR TITLE
test/helpers: annotate skipped tests

### DIFF
--- a/test/basic-querying.test.js
+++ b/test/basic-querying.test.js
@@ -573,59 +573,66 @@ describe('basic-querying', function() {
         });
     });
 
-    var itWhenIlikeSupported = connectorCapabilities.ilike ? it : it.skip.bind(it);
+    var itWhenIlikeSupported = connectorCapabilities.ilike;
+    bdd.describeIf(itWhenIlikeSupported, 'ilike', function() {
+      it('should support "like" that is satisfied',
+        function(done) {
+          User.find({where: {name: {like: 'John'}}},
+            function(err, users) {
+              if (err) return done(err);
+              users.length.should.equal(1);
+              users[0].name.should.equal('John Lennon');
+              done();
+            });
+        });
 
-    itWhenIlikeSupported('should support "like" that is satisfied', function(done) {
-      User.find({where: {name: {like: 'John'}}}, function(err, users) {
-        if (err) return done(err);
-        users.length.should.equal(1);
-        users[0].name.should.equal('John Lennon');
-        done();
+      it('should support "like" that is not satisfied',
+        function(done) {
+          User.find({where: {name: {like: 'Bob'}}},
+            function(err, users) {
+              if (err) return done(err);
+              users.length.should.equal(0);
+              done();
+            });
+        });
+      it('should support "ilike" that is satisfied', function(done) {
+        User.find({where: {name: {ilike: 'john'}}},
+          function(err, users) {
+            if (err) return done(err);
+            users.length.should.equal(1);
+            users[0].name.should.equal('John Lennon');
+            done();
+          });
+      });
+      it('should support "ilike" that is not satisfied', function(done) {
+        User.find({where: {name: {ilike: 'bob'}}}, function(err, users) {
+          if (err) return done(err);
+          users.length.should.equal(0);
+          done();
+        });
       });
     });
 
-    itWhenIlikeSupported('should support "like" that is not satisfied', function(done) {
-      User.find({where: {name: {like: 'Bob'}}}, function(err, users) {
-        if (err) return done(err);
-        users.length.should.equal(0);
-        done();
+    var itWhenNilikeSupported = connectorCapabilities.nilike !== false;
+    bdd.describeIf(itWhenNilikeSupported, 'nilike', function() {
+      it('should support "nlike" that is satisfied', function(done) {
+        User.find({where: {name: {nlike: 'John'}}},
+          function(err, users) {
+            if (err) return done(err);
+            users.length.should.equal(5);
+            users[0].name.should.equal('Paul McCartney');
+            done();
+          });
       });
-    });
 
-    var itWhenNilikeSupported = connectorCapabilities.nilike ? it : it.skip.bind(it);
-
-    itWhenNilikeSupported('should support "nlike" that is satisfied', function(done) {
-      User.find({where: {name: {nlike: 'John'}}}, function(err, users) {
-        if (err) return done(err);
-        users.length.should.equal(5);
-        users[0].name.should.equal('Paul McCartney');
-        done();
-      });
-    });
-
-    itWhenIlikeSupported('should support "ilike" that is satisfied', function(done) {
-      User.find({where: {name: {ilike: 'john'}}}, function(err, users) {
-        if (err) return done(err);
-        users.length.should.equal(1);
-        users[0].name.should.equal('John Lennon');
-        done();
-      });
-    });
-
-    itWhenIlikeSupported('should support "ilike" that is not satisfied', function(done) {
-      User.find({where: {name: {ilike: 'bob'}}}, function(err, users) {
-        if (err) return done(err);
-        users.length.should.equal(0);
-        done();
-      });
-    });
-
-    itWhenNilikeSupported('should support "nilike" that is satisfied', function(done) {
-      User.find({where: {name: {nilike: 'john'}}}, function(err, users) {
-        if (err) return done(err);
-        users.length.should.equal(5);
-        users[0].name.should.equal('Paul McCartney');
-        done();
+      it('should support "nilike" that is satisfied', function(done) {
+        User.find({where: {name: {nilike: 'john'}}},
+          function(err, users) {
+            if (err) return done(err);
+            users.length.should.equal(5);
+            users[0].name.should.equal('Paul McCartney');
+            done();
+          });
       });
     });
 
@@ -838,8 +845,8 @@ describe('basic-querying', function() {
       });
     });
 
-    var describeWhenNestedSupported = connectorCapabilities.nestedProperty ? describe : describe.skip;
-    describeWhenNestedSupported('query with nested property', function() {
+    var describeWhenNestedSupported = connectorCapabilities.nestedProperty;
+    bdd.describeIf(describeWhenNestedSupported, 'query with nested property', function() {
       it('should support nested property in query', function(done) {
         User.find({where: {'address.city': 'San Jose'}}, function(err, users) {
           if (err) return done(err);
@@ -1030,6 +1037,7 @@ describe('basic-querying', function() {
   });
 });
 
+// FIXME: This should either be re-enabled or removed.
 describe.skip('queries', function() {
   var Todo;
 

--- a/test/helpers/bdd-if.js
+++ b/test/helpers/bdd-if.js
@@ -4,16 +4,20 @@
 // License text available at https://opensource.org/licenses/MIT
 'use strict';
 
+var fmt = require('util').format;
+
 exports.describeIf = function describeIf(cond, name, fn) {
   if (cond)
     describe(name, fn);
-  else
-    describe.skip(name, fn);
+  else {
+    describe.skip(fmt('[UNSUPPORTED] - %s', name), fn);
+  }
 };
 
 exports.itIf = function itIf(cond, name, fn) {
   if (cond)
     it(name, fn);
-  else
-    it.skip(name, fn);
+  else {
+    it.skip(fmt('[UNSUPPORTED] - %s', name), fn);
+  }
 };

--- a/test/persistence-hooks.suite.js
+++ b/test/persistence-hooks.suite.js
@@ -21,8 +21,9 @@ var HookMonitor = require('./helpers/hook-monitor');
 module.exports = function(dataSource, should, connectorCapabilities) {
   if (!connectorCapabilities) connectorCapabilities = {};
   if (connectorCapabilities.replaceOrCreateReportsNewInstance === undefined) {
-    console.warn('The connector does not support a recently added feature:' +
-      ' replaceOrCreateReportsNewInstance');
+    var warn = 'The connector does not support a recently added feature:' +
+      ' replaceOrCreateReportsNewInstance';
+    console.warn(warn);
   }
   describe('Persistence hooks', function() {
     var ctxRecorder, hookMonitor, expectedError;


### PR DESCRIPTION
Differentiate between tests skipped by feature flags, and those
manually marked as skipped.

Tests that use the `bdd.describe` and `bdd.it` helper functions
will be marked as `[UNSUPPORTED]` if they are conditionally disabled.

### Description
Annotate all of the tests at the start of the run to indicate which of them has been skipped due to lack of support in the connector (support flags are disabled).

Hopefully, this should also help find tests that are *not* being skipped for those reasons...

#### Related issues
- connected to https://github.com/strongloop/loopback-connector-mysql/issues/234

### Checklist
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
