### PR TITLE
Add a bulkUpdate function

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -2737,6 +2737,108 @@ DataAccessObject.updateAll = function(where, data, options, cb) {
   return cb.promise;
 };
 
+/**
+ * Perform a bulk update on a model instance.
+ *
+ * Supported in Cloudant connector only.
+ *
+ * Example:
+ *
+ *```js
+ * Employee.bulkUpdate([{_id: 1, _rev: 2-c23df06fcd7509dc8b70788c7af88a2c, managerId: 'x001'}], function(err, updates) {
+ *     ...
+ * });
+ * ```
+ *
+ * @param {Object} datas Datas to be updated
+ * @param {Object} [options] Options for bulk update
+ * @param {Function} cb Callback, called with (err, info)
+ */
+DataAccessObject.bulkUpdate = function(datas, options, cb) {
+  var connectionPromise = stillConnecting(this.getDataSource(), this, arguments);
+  if (connectionPromise) {
+    return connectionPromise;
+  }
+
+  assert(arguments.length >= 1, 'The datas argument is required');
+
+  if (cb === undefined && typeof options === 'function') {
+    cb = options;
+    options = {};
+  }
+
+  datas = datas || [];
+  options = options || {};
+  cb = cb || utils.createPromiseCallback();
+
+  assert(datas instanceof Array, 'The datas argument must be an array');
+  assert(typeof options === 'object', 'The options argument must be an object');
+  assert(typeof cb === 'function', 'The cb argument must be a function');
+
+  var Model = this;
+  var connector = Model.getDataSource().connector;
+
+  if (typeof connector.bulkUpdate !== 'function') {
+    var err = new Error(g.f(
+      'The connector %s does not support {{bulkUpdate}} operation. This is not a bug in LoopBack. ' +
+      'Please contact the authors of the connector, preferably via GitHub issues.',
+      connector.name));
+    return cb(err);
+  }
+
+  var context = {
+    Model: Model,
+    options: options,
+  };
+
+  Model.notifyObserversOf('access', context, function(err, ctx) {
+    if (err) return cb(err);
+    var context = {
+      Model: Model,
+      datas: datas,
+      options: options,
+    };
+    Model.notifyObserversOf('before save', context,
+      function(err, ctx) {
+        if (err) return cb(err);
+        doBulkUpdate(ctx.datas);
+      });
+  });
+
+  function doBulkUpdate(datas) {
+    try {
+      datas = removeUndefined(datas);
+    } catch (err) {
+      return process.nextTick(function() {
+        cb(err);
+      });
+    }
+    var context = {
+      Model: Model,
+      datas: datas,
+      options: options,
+    };
+    Model.notifyObserversOf('persist', context, function(err, ctx) {
+      if (err) return cb(err);
+      connector.bulkUpdate(Model.modelName, datas, options, bulkUpdateCallback);
+    });
+  }
+
+  function bulkUpdateCallback(err, info) {
+    if (err) return cb(err);
+    var context = {
+      Model: Model,
+      datas: datas,
+      options: options,
+      info: info,
+    };
+    Model.notifyObserversOf('after save', context, function(err, ctx) {
+      return cb(err, info);
+    });
+  }
+  return cb.promise;
+};
+
 DataAccessObject.prototype.isNewRecord = function() {
   return !this.__persisted;
 };


### PR DESCRIPTION
### Description

Add a static method for `bulkUpdate`. Connectors now can call `bulkUpdate` to perform a bulk update on data.

connect to https://github.com/strongloop/loopback-connector-cloudant/issues/35