### PR TITLE
Fix the case where qWhere[idKey] is null

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -130,7 +130,13 @@ ScopeDefinition.prototype.related = function(receiver, scopeParams, condOrRefres
           return mergedWhere;
         };
         if (queryRelated.where !== undefined) {
-          queryRelated.where = buildWhere();
+          if (!queryRelated.where[IdKey]) {
+            // If it's null, don't bother calling smartMerge or model.find.
+            // Simply return an empty result to the client.
+            return cb(null, []);
+          } else {
+            queryRelated.where = buildWhere();
+          }
         } else {
           queryRelated.where = {};
           queryRelated.where[IdKey] = collectTargetIds(data, IdKey);

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -819,6 +819,15 @@ describe('relations', function() {
             done();
           });
         });
+        it('returns empty result when filtering with wrong id key', function(done) {
+          var wrongWhereFilter = {where: {wrongIdKey: samplePatientId}};
+          physician.patients(wrongWhereFilter, function(err, ch) {
+            if (err) return done(err);
+            should.exist(ch);
+            ch.should.have.lengthOf(0);
+            done();
+          });
+        });
         it('returns patients where id in an array', function(done) {
           var idArr = [];
           var whereFilter;


### PR DESCRIPTION
### Description
Fix the case where qWhere[idKey] is null
#### Related issues

https://github.com/strongloop/loopback-datasource-juggler/issues/1381
<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
