### PR TITLE
Support for IBM Object Storage

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -348,6 +348,14 @@ DataSource.prototype.setup = function(name, settings) {
     if (settings.initialize) {
       connector = settings;
     } else if (settings.connector) {
+      // some connectors are aliases to loopback-component-storage
+      if (['object-storage'].indexOf(settings.connector) > -1) {
+        settings.provider = 'openstack';
+        settings.connector = 'loopback-component-storage';
+        settings.useServiceCatalog = true;
+        settings.useInternal = false;
+        settings.keystoneAuthVersion = 'v3';
+      }
       connector = settings.connector;
     } else if (settings.adapter) {
       connector = settings.adapter;

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "depd": "^1.0.0",
     "inflection": "^1.6.0",
     "lodash": "^4.17.4",
+    "loopback-component-storage": "^3.2.0",
     "loopback-connector": "^4.0.0",
     "minimatch": "^3.0.3",
     "qs": "^6.3.0",

--- a/test/object-storage.test.js
+++ b/test/object-storage.test.js
@@ -1,0 +1,15 @@
+'use strict';
+var assert = require('assert');
+var DataSource = require('..').DataSource;
+
+describe('object-storage connector', function() {
+  it('should be set up properly', function() {
+    var ds = new DataSource({connector: 'object-storage'});
+    assert.equal(ds.name, 'loopback-component-storage');
+    assert.equal(ds.settings.connector, 'loopback-component-storage');
+    assert.equal(ds.settings.provider, 'openstack');
+    assert.equal(ds.settings.useServiceCatalog, true);
+    assert.equal(ds.settings.useInternal, false);
+    assert.equal(ds.settings.keystoneAuthVersion, 'v3');
+  });
+});


### PR DESCRIPTION
### Description

Add support for `object-storage` connector.

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
