### PR TITLE
fix: alllow updates with unknown properties if strict=filter

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -93,7 +93,7 @@ function applyStrictCheck(model, strict, data, inst, cb) {
     key = keys[i];
     if (props[key]) {
       result[key] = data[key];
-    } else if (strict) {
+    } else if (strict && strict !== 'filter') {
       inst.__unknownProperties.push(key);
     }
   }

--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -633,6 +633,20 @@ describe('manipulation', function() {
         });
       });
 
+    it('should remove unknown attributes when strict: filter',
+      function(done) {
+        Person.definition.settings.strict = 'filter';
+        Person.findById(person.id, function(err, p) {
+          if (err) return done(err);
+          p.updateAttributes({name: 'John', foo: 'bar'},
+            function(err, p) {
+              if (err) return done(err);
+              p.should.not.have.property('foo');
+              done();
+            });
+        });
+      });
+
     // Prior to version 3.0 `strict: true` used to silently remove unknown properties,
     // now return validationError upon unknown properties
     it('should return error on unknown attributes when strict: true',

--- a/test/model-inheritance.test.js
+++ b/test/model-inheritance.test.js
@@ -73,7 +73,7 @@ describe('Model class inheritance', function() {
         relations: {patch: true},
       };
 
-        // saving original getMergePolicy method
+      // saving original getMergePolicy method
       let originalGetMergePolicy = base.getMergePolicy;
 
       // the injected getMergePolicy method captures the provided configureModelMerge option


### PR DESCRIPTION
Fix for #1422 

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)

---

Update:

It should also fix issue https://github.com/strongloop/loopback-connector-mongodb/issues/445