### PR TITLE
Rename getAsync() methods to find() and get()

### DIFF
--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -20,6 +20,7 @@ var idEquals = utils.idEquals;
 var ModelBaseClass = require('./model.js');
 var applyFilter = require('./connectors/memory').applyFilter;
 var ValidationError = require('./validations.js').ValidationError;
+var deprecated = require('depd')('loopback-datasource-juggler');
 var debug = require('debug')('loopback:relations');
 
 var RelationTypes = {
@@ -1338,7 +1339,11 @@ RelationDefinition.belongsTo = function(modelFrom, modelToRef, params) {
     get: function() {
       var relation = new BelongsTo(definition, this);
       var relationMethod = relation.related.bind(relation);
-      relationMethod.getAsync = relation.getAsync.bind(relation);
+      relationMethod.get = relation.get.bind(relation);
+      relationMethod.getAsync = function() {
+        deprecated(g.f('BelongsTo method "getAsync()" is deprecated, use "get()" instead.'));
+        return this.get.apply(this, arguments);
+      };
       relationMethod.update = relation.update.bind(relation);
       relationMethod.destroy = relation.destroy.bind(relation);
       if (!polymorphic) {
@@ -1580,9 +1585,8 @@ BelongsTo.prototype.related = function(condOrRefresh, options, cb) {
  * @param {Function} cb Callback of the form function (err, inst)
  * @returns {Promise | Undefined} returns promise if callback is omitted
  */
-BelongsTo.prototype.getAsync = function(options, cb) {
+BelongsTo.prototype.get = function(options, cb) {
   if (typeof options === 'function' && cb === undefined) {
-    // order.customer.getAsync(cb)
     cb = options;
     options = {};
   }
@@ -1712,7 +1716,11 @@ RelationDefinition.hasOne = function(modelFrom, modelToRef, params) {
     get: function() {
       var relation = new HasOne(definition, this);
       var relationMethod = relation.related.bind(relation);
-      relationMethod.getAsync = relation.getAsync.bind(relation);
+      relationMethod.get = relation.get.bind(relation);
+      relationMethod.getAsync = function() {
+        deprecated(g.f('HasOne method "getAsync()" is deprecated, use "get()" instead.'));
+        return this.get.apply(this, arguments);
+      };
       relationMethod.create = relation.create.bind(relation);
       relationMethod.build = relation.build.bind(relation);
       relationMethod.update = relation.update.bind(relation);
@@ -1991,15 +1999,13 @@ HasOne.prototype.related = function(condOrRefresh, options, cb) {
 
 /**
  * Define a Promise-based method for the hasOne relation itself
- * - order.customer.getAsync(cb): Load the target model instance asynchronously
+ * - order.customer.get(cb): Load the target model instance asynchronously
  *
  * @param {Function} cb Callback of the form function (err, inst)
  * @returns {Promise | Undefined} Returns promise if cb is omitted
  */
-
-HasOne.prototype.getAsync = function(options, cb) {
+HasOne.prototype.get = function(options, cb) {
   if (typeof options === 'function' && cb === undefined) {
-    // order.profile.getAsync(cb)
     cb = options;
     options = {};
   }

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -6,6 +6,7 @@
 
 var _ = require('lodash');
 var i8n = require('inflection');
+var g = require('strong-globalize')();
 var utils = require('./utils');
 var defineCachedRelations = utils.defineCachedRelations;
 var setScopeValuesFromWhere = utils.setScopeValuesFromWhere;
@@ -13,6 +14,7 @@ var mergeQuery = utils.mergeQuery;
 var DefaultModelBaseClass = require('./model.js');
 var collectTargetIds = utils.collectTargetIds;
 var idName = utils.idName;
+var deprecated = require('depd')('loopback-datasource-juggler');
 
 /**
  * Module exports
@@ -272,20 +274,23 @@ function defineScope(cls, targetClass, name, params, methods, options) {
         f._targetClass = rel && rel.modelTo && rel.modelTo.modelName || i8n.camelize(f._scope.collect);
       }
 
-      f.getAsync = function(condOrRefresh, options, cb) {
+      f.find = function(condOrRefresh, options, cb) {
         if (typeof condOrRefresh === 'function' &&
             options === undefined && cb === undefined) {
-          // customer.orders.getAsync(cb)
           cb = condOrRefresh;
           options = {};
           condOrRefresh = {};
         } else if (typeof options === 'function' && cb === undefined) {
-          // customer.orders.getAsync(condOrRefresh, cb);
           cb = options;
           options = {};
         }
         options = options || {};
         return definition.related(self, f._scope, condOrRefresh, options, cb);
+      };
+
+      f.getAsync = function() {
+        deprecated(g.f('Scope method "getAsync()" is deprecated, use "find()" instead.'));
+        return this.find.apply(this, arguments);
       };
 
       f.build = build;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -182,7 +182,7 @@ function mergeQuery(base, update, spec) {
     } else {
       if (spec.nestedInclude === true) {
         // specify nestedInclude=true to force nesting of inclusions on scoped
-        // queries. e.g. In physician.patients.getAsync({include: 'address'}),
+        // queries. e.g. In physician.patients.find({include: 'address'}),
         // inclusion should be on patient model, not on physician model.
         var saved = base.include;
         base.include = {};

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -194,13 +194,13 @@ describe('relations', function() {
         }).catch(done);
 
         function verify(book) {
-          return book.chapters.getAsync()
+          return book.chapters.find()
           .then(function(ch) {
             should.exist(ch);
             ch.should.have.lengthOf(3);
             var chapters = book.chapters();
             chapters.should.eql(ch);
-            return book.chapters.getAsync()
+            return book.chapters.find()
             .then(function(c) {
               should.exist(c);
               ch.should.have.lengthOf(3);
@@ -214,7 +214,7 @@ describe('relations', function() {
         }
       });
 
-      it('should fetch all scoped instances with getAsync with callback and condition', function(done) {
+      it('should fetch all scoped instances with find() with callback and condition', function(done) {
         Book.create(function(err, book) {
           book.chapters.create({name: 'a'}, function() {
             book.chapters.create({name: 'z'}, function() {
@@ -232,7 +232,7 @@ describe('relations', function() {
 
             var chapters = book.chapters();
             chapters.should.eql(ch);
-            book.chapters.getAsync(function(e, c) {
+            book.chapters.find(function(e, c) {
               should.not.exist(e);
               should.exist(c);
               ch.should.have.lengthOf(3);
@@ -246,7 +246,7 @@ describe('relations', function() {
         }
       });
 
-      it('should fetch all scoped instances with getAsync with callback and no condition', function(done) {
+      it('should fetch all scoped instances with find() with callback and no condition', function(done) {
         Book.create(function(err, book) {
           book.chapters.create({name: 'a'}, function() {
             book.chapters.create({name: 'z'}, function() {
@@ -265,7 +265,7 @@ describe('relations', function() {
             var chapters = book.chapters();
             chapters.should.eql(ch);
 
-            book.chapters.getAsync(function(e, c) {
+            book.chapters.find(function(e, c) {
               should.not.exist(e);
               should.exist(c);
               should.exist(c.length);
@@ -711,7 +711,7 @@ describe('relations', function() {
         });
       }).catch(done);
       function verify(physician) {
-        return physician.patients.getAsync()
+        return physician.patients.find()
         .then(function(ch) {
           var patients = physician.patients();
           should.equal(patients, ch);
@@ -1012,7 +1012,7 @@ describe('relations', function() {
       }).catch(done);
 
       function verify(physician, addressId) {
-        return physician.patients.getAsync({include: 'address'})
+        return physician.patients.find({include: 'address'})
         .then(function(ch) {
           should.exist(ch);
           ch.should.have.lengthOf(1);
@@ -1646,7 +1646,7 @@ describe('relations', function() {
     it('should find records on scope with promises', function(done) {
       Category.findOne()
       .then(function(c) {
-        return c.jobs.getAsync();
+        return c.jobs.find();
       })
       .then(function(jobs) {
         jobs.should.have.length(2);
@@ -1670,7 +1670,7 @@ describe('relations', function() {
     it('should find record on scope with promises - filtered', function(done) {
       Category.findOne()
       .then(function(c) {
-        return c.jobs.getAsync({where: {type: 'book'}});
+        return c.jobs.find({where: {type: 'book'}});
       })
       .then(function(jobs) {
         jobs.should.have.length(1);
@@ -2051,7 +2051,7 @@ describe('relations', function() {
     it('should find polymorphic relation with promises - employee', function(done) {
       Employee.findOne()
       .then(function(employee) {
-        return employee.mugshot.getAsync()
+        return employee.mugshot.get()
         .then(function(pic) {
           pic.name.should.equal('Mugshot');
           pic.imageableId.toString().should.eql(employee.id.toString());
@@ -3140,7 +3140,7 @@ describe('relations', function() {
       });
     });
 
-    it('can be used to query data with getAsync with callback', function(done) {
+    it('can be used to query data with get() with callback', function(done) {
       List.hasMany('todos', {model: Item});
       db.automigrate(['List', 'Item', 'Fear', 'Find'], function() {
         List.create({name: 'List 1'}, function(e, list) {
@@ -3149,7 +3149,7 @@ describe('relations', function() {
           should.exist(list);
           list.todos.create({name: 'Item 1'}, function(err, todo) {
             itemId = todo.id;
-            todo.list.getAsync(function(e, l) {
+            todo.list.get(function(e, l) {
               should.not.exist(e);
               should.exist(l);
               l.should.be.an.instanceOf(List);
@@ -3173,7 +3173,7 @@ describe('relations', function() {
         })
         .then(function(todo) {
           itemId = todo.id;
-          return todo.list.getAsync()
+          return todo.list.get()
           .then(function(l) {
             should.exist(l);
             l.should.be.an.instanceOf(List);
@@ -3349,7 +3349,7 @@ describe('relations', function() {
           // the first row returned may or may not be the same
           p.personId.should.eql(personCreated.id);
         }
-        return p.person.getAsync();
+        return p.person.get();
       })
       .then(function(person) {
         person.name.should.equal('Fred');
@@ -3467,14 +3467,14 @@ describe('relations', function() {
       });
     });
 
-    it('can be used to query data with getAsync with callback', function(done) {
+    it('can be used to query data with get() with callback', function(done) {
       db.automigrate(['Supplier', 'Account'], function() {
         Supplier.create({name: 'Supplier 1'}, function(e, supplier) {
           supplierId = supplier.id;
           should.not.exist(e);
           should.exist(supplier);
           supplier.account.create({accountNo: 'a01'}, function(err, account) {
-            supplier.account.getAsync(function(e, act) {
+            supplier.account.get(function(e, act) {
               accountId = act.id;
               should.not.exist(e);
               should.exist(act);
@@ -3496,7 +3496,7 @@ describe('relations', function() {
           should.exist(supplier);
           return supplier.account.create({accountNo: 'a01'})
           .then(function(account) {
-            return supplier.account.getAsync();
+            return supplier.account.get();
           })
           .then(function(act) {
             accountId = act.id;
@@ -3575,7 +3575,7 @@ describe('relations', function() {
       Supplier.findById(supplierId)
       .then(function(supplier) {
         should.exist(supplier);
-        return supplier.account.getAsync();
+        return supplier.account.get();
       })
       .then(function(act) {
         should.exist(act);
@@ -3627,7 +3627,7 @@ describe('relations', function() {
       Supplier.findById(supplierId)
       .then(function(supplier) {
         should.exist(supplier);
-        return supplier.account.getAsync();
+        return supplier.account.get();
       })
       .then(function(act) {
         should.not.exist(act);
@@ -3723,7 +3723,7 @@ describe('relations', function() {
           should.exist(supplier);
           return supplier.account.create({accountNo: 'a01', block: false})
           .then(function(account) {
-            return supplier.account.getAsync();
+            return supplier.account.get();
           })
           .then(function(act) {
             accountId = act.id;
@@ -3747,7 +3747,7 @@ describe('relations', function() {
         return Supplier.findById(supplierId);
       })
       .then(function(supplier) {
-        return supplier.account.getAsync();
+        return supplier.account.get();
       })
       .then(function(account) {
         should.not.exist(account);
@@ -3963,7 +3963,7 @@ describe('relations', function() {
             return Employee.create({name: 'a01', companyId: COMPANY_ID})
               .then(function(employee) {
                 should.exist(employee);
-                return boss.employees.getAsync();
+                return boss.employees.find();
               }).then(function(employees) {
                 should.exists(employees);
                 employees.length.should.equal(1);
@@ -4000,7 +4000,7 @@ describe('relations', function() {
           })
           .then(function(employee) {
             should.exists(employee);
-            return employee.boss.getAsync();
+            return employee.boss.get();
           })
           .then(function(boss) {
             should.exists(boss);
@@ -4101,7 +4101,7 @@ describe('relations', function() {
     it('should allow to fetch scoped instances with promises', function(done) {
       Article.findOne()
       .then(function(article) {
-        return article.tagNames.getAsync()
+        return article.tagNames.find()
         .then(function(tags) {
           should.exist(tags);
           article.tagNames().should.eql(tags);
@@ -4132,13 +4132,13 @@ describe('relations', function() {
     'should allow to remove connection with instance with promises', function(done) {
       Article.findOne()
       .then(function(article) {
-        return article.tagNames.getAsync()
+        return article.tagNames.find()
         .then(function(tags) {
           var len = tags.length;
           tags.should.not.be.empty;
           return article.tagNames.remove(tags[0])
           .then(function() {
-            return article.tagNames.getAsync();
+            return article.tagNames.find();
           })
           .then(function(tags) {
             tags.should.have.lengthOf(len - 1);
@@ -5930,7 +5930,7 @@ describe('relations', function() {
       Category.findOne()
       .then(function(cat) {
         cat.jobIds.should.eql([job2.id]);
-        return cat.jobs.getAsync();
+        return cat.jobs.find();
       })
       .then(function(jobs) {
         var p = jobs[0];
@@ -5948,7 +5948,7 @@ describe('relations', function() {
       Category.findOne()
       .then(function(cat) {
         cat.jobIds[0].should.be.oneOf(theExpectedIds);
-        return cat.jobs.getAsync();
+        return cat.jobs.find();
       })
       .then(function(jobs) {
         var p = jobs[0];
@@ -6062,7 +6062,7 @@ describe('relations', function() {
       Category.findOne()
       .then(function(cat) {
         var filter = {where: {name: 'Job 1'}};
-        return cat.jobs.getAsync(filter);
+        return cat.jobs.find(filter);
       })
       .then(function(jobs) {
         jobs.should.have.length(1);
@@ -6095,7 +6095,7 @@ describe('relations', function() {
         var expected = [job2.id, job3.id];
         cat.jobIds.should.have.lengthOf(expected.length);
         cat.jobIds.should.containDeep(expected);
-        return cat.jobs.getAsync();
+        return cat.jobs.find();
       })
       .then(function(jobs) {
         jobs.should.have.length(2);
@@ -6111,7 +6111,7 @@ describe('relations', function() {
       Category.find()
       .then(function(categories) {
         categories.should.have.length(1);
-        return categories[0].jobs.getAsync({order: 'name DESC'});
+        return categories[0].jobs.find({order: 'name DESC'});
       })
       .then(function(jobs) {
         jobs.should.have.length(2);
@@ -6180,7 +6180,7 @@ describe('relations', function() {
         var expected = [job3.id];
         cat.jobIds.should.have.lengthOf(expected.length);
         cat.jobIds.should.containDeep(expected);
-        return cat.jobs.getAsync();
+        return cat.jobs.find();
       })
       .then(function(jobs) {
         jobs.should.have.length(1);


### PR DESCRIPTION
### Description

The `getAsync()` is defined in 3 places: `BelongsTo`, `HasOne` and `HasMany`, which is implemented as a scope. Therefore, it is also present on all scopes.

I find its naming really strange though:

- It is the only function with `Async()` in its name
- Like all other functions on relationships (`create()`, `update()`, `count()`, etc), it accepts a callback function and returns a promise if none is provided.

I would like to suggest to rename it to `find()` for scopes and `HasMany` relationships to mirror `Model.find()`, and `get()` for `BelongsTo` and `BelongsTo` relationships, while keeping the `getAsync()` around for backward compatibility for now. 

@bajtos has pointed me to previous discussions around why `get()` wasn't deemed a good name before here: https://github.com/strongloop/loopback-datasource-juggler/issues/1127#issuecomment-314116414

But after looking more into `EmbedsMany`, I found out a few additional things that weren't considered back then:

`get()` on `EmbedsMany` is a reference to `findById()`, which takes a callback or returns a value synchronously in the absence of the callback. But in all other cases I have found, those versions of `findById()` return asynchronously, so the same problem that was pointed out when the name `get()` was proposed applies here as well, and apparently wasn't seen as a problem...

Here all the examples of methods I could find where `EmbedsMany` returns synchronously, while the others (`HasMany`, `HasManyThrough`, `ReferencesMany`, `DataAccessObject`, ...) return promises (if they define them at all):

`at()`
`exists()`
`updateById()`
`updateById()`
`destroyById()`

These can easily be found by searching for `// sync` in the source code. I don't think this has caused concern or confusion so far?

Based on this observation, I think that naming these methods simply `get()` is the best we can do, and the most aligned with how things are currently named and implemented, including this naming discrepancy that's hard to fix at this point. Except for scopes of course, where I think we should name it `find()` as mentioned above.

@bajtos asked me to create a PR and mention him in it, so here it is. Please review.

### Related Issues

- #1127

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
