### PR TITLE
WIP: Should not return error when property of type array is set to object …

### DIFF
--- a/lib/list.js
+++ b/lib/list.js
@@ -32,9 +32,13 @@ function List(items, itemType, parent) {
 
   items = items || [];
   if (!Array.isArray(items)) {
-    const err = new Error(g.f('Items must be an array: %j', items));
-    err.statusCode = 400;
-    throw err;
+    try {
+      items = Object.keys(items).map(key => items[key]);
+    } catch (e) {
+      var err = new Error(util.format('Items must be an array or object: %j. Error: %j', items, e));
+      err.statusCode = 400;
+      throw err;
+    }
   }
 
   if (!itemType) {

--- a/test/datatype.test.js
+++ b/test/datatype.test.js
@@ -41,15 +41,15 @@ describe('datatypes', function() {
       done();
     });
 
-  it('should return 400 when property of type array is set to object value',
+  it('should not return error when property of type array is set to object value',
     function(done) {
       var myModel = db.define('myModel', {
         list: {type: ['object']},
       });
 
       (function() {
-        myModel.create({list: {key: 'This string will crash the server'}});
-      }).should.throw({statusCode: 400});
+        myModel.create({list: {key: 'This string wont crash the server'}});
+      }).should.not.throw({statusCode: 400});
 
       done();
     });


### PR DESCRIPTION
Convert object to array on datajungler and not throw error with wrong type of data

### Description

If we create a model with object and we pass a object on a request, datajungler can't convert it and crashes the server.
The solution here is convert the object to array and return the keys.

#### Related issues

- #111