### PR TITLE
fix scopeOnRealtedModel flag to set false when filter.scope is empty

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -97,8 +97,9 @@ ScopeDefinition.prototype.related = function(receiver, scopeParams, condOrRefres
     // run another query to apply filter on relatedModel(targetModel)
     // see github.com/strongloop/loopback-datasource-juggler/issues/166
     var scopeOnRelatedModel = params.collect &&
-      params.include.scope !== null &&
-      typeof params.include.scope === 'object';
+        params.include.scope !== null &&
+        typeof params.include.scope === 'object' &&
+        Object.keys(params.include.scope).length !== 0; // scope is not empty;
     if (scopeOnRelatedModel) {
       var filter = params.include;
       // The filter applied on relatedModel

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -676,5 +676,5 @@ function collectTargetIds(targetData, idPropertyName) {
  * @returns {String}
  */
 function idName(m) {
-  return m.definition.idName() || 'id';
+  return m ? m.definition.idName() : 'id';
 }


### PR DESCRIPTION
### Description
It validates `params.include.scope` to not coming empty, if so scopeOnRelatedModel is set to true
``` javascript
    // If there is a through model
    // run another query to apply filter on relatedModel(targetModel)
    // see github.com/strongloop/loopback-datasource-juggler/issues/166
    var scopeOnRelatedModel = params.collect &&
        params.include.scope !== null &&
        typeof params.include.scope === 'object' &&
        Object.keys(params.include.scope).length !== 0; // scope is not empty
```

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- Fixes #1429 

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
