### PR TITLE
#1386 Allow empty values when allowBlank is true

### DIFF
--- a/lib/validations.js
+++ b/lib/validations.js
@@ -709,7 +709,7 @@ var defaultMessages = {
  */
 function nullCheck(attr, conf, err) {
   // First determine if attribute is defined
-  if (typeof this[attr] === 'undefined') {
+  if (typeof this[attr] === 'undefined' || this[attr] === '') {
     if (!conf.allowBlank) {
       err('blank');
     }

--- a/test/validations.test.js
+++ b/test/validations.test.js
@@ -755,6 +755,25 @@ describe('validations', function() {
         done();
       });
     });
+
+    it('passes with an empty value when allowBlank option is true', function(done) {
+      User.validatesInclusionOf('gender', {in: ['male', 'female'], allowBlank: true});
+      User.create({gender: ''}, done);
+    });
+
+    it('fails with an empty value when allowBlank option is false', function(done) {
+      User.validatesInclusionOf('gender', {in: ['male', 'female'], allowBlank: false});
+      User.create({gender: ''}, function(err) {
+        err.should.be.instanceOf(ValidationError);
+        getErrorDetails(err)
+          .should.equal('`gender` is blank (value: "").');
+        done();
+      });
+    });
+
+    function getErrorDetails(err) {
+      return err.message.replace(/^.*Details: /, '');
+    }
   });
 
   describe('exclusion', function() {


### PR DESCRIPTION
### Description

Allow empty values when allowBlank is true in conjuction with `model.validatesInclusionOf()`. Use case is detailed in related issue below.

#### Related issues

#1386 

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
