### PR TITLE
castPropertyValue: throw on malformed types

### DIFF
--- a/lib/connectors/memory.js
+++ b/lib/connectors/memory.js
@@ -350,9 +350,17 @@ Memory.prototype.fromDb = function(model, data) {
   if (!data) return null;
   data = deserialize(data);
   var props = this._models[model].properties;
-  for (var key in data) {
-    data[key] = this._castPropertyValue(key, data[key], props);
+  try {
+    for (var key in data) {
+      data[key] = this._castPropertyValue(key, data[key], props);
+    }
+  } catch (err) {
+    // Modify error message and re-throw
+    err.message = g.f('Unable to convert to instance of "%s": %s', model,
+      err);
+    throw err;
   }
+
   return data;
 };
 
@@ -370,7 +378,15 @@ Memory.prototype._castPropertyValue = function(prop, val, props) {
 
   var isArray = Array.isArray(props[prop].type);
   var propType = isArray ? props[prop].type[0] : props[prop].type;
-
+  if (!propType || !propType.name) {
+    if (isArray)
+      throw new Error(g.f(
+        'Property definition "%s" did not specify any sub-types!', prop));
+    else
+      throw new Error(g.f(
+        'Property definition "%s" was null or undefined!', prop
+      ));
+  }
   switch (propType.name) {
     case 'Date':
       val = new Date(val.toString().replace(/GMT.*$/, 'GMT'));
@@ -383,7 +399,9 @@ Memory.prototype._castPropertyValue = function(prop, val, props) {
       break;
     case 'ModelConstructor':
       for (var subProp in val) {
-        val[subProp] = this._castPropertyValue(subProp, val[subProp], propType.definition.properties);
+        if (propType.definition && propType.definition.properties)
+          val[subProp] = this._castPropertyValue(subProp, val[subProp],
+            propType.definition.properties);
       }
       break;
   }


### PR DESCRIPTION
### Description
Property types defined using empty arrays or objects is not documented behaviour: 
http://loopback.io/doc/en/lb2/LoopBack-types.html#overview
http://loopback.io/doc/en/lb2/LoopBack-types.html#array-types
http://loopback.io/doc/en/lb2/LoopBack-types.html#object-types

This unexpected usage, combined with changes made to the Memory connector in #1361 throws unhandled errors when attempting to parse results from the Memory datasource.

This PR fixes this by clarifying these errors, as well as providing additional test coverage.

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
