### PR TITLE
Fix update validation callback

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -2701,7 +2701,7 @@ DataAccessObject.updateAll = function(where, data, options, cb) {
           if (valid) {
             doUpdate(ctx.where, ctx.data);
           } else {
-            cb(new ValidationError(inst), inst);
+            cb(new ValidationError(inst));
           }
         }, options);
       });

--- a/test/validations.test.js
+++ b/test/validations.test.js
@@ -437,6 +437,7 @@ describe('validations', function() {
         Employee.updateAll({where: {id: 1}}, {name: 'Foo-new'},
           function(err, emp) {
             should.exist(err);
+            should.not.exist(emp);
             should.equal(err.statusCode, 422);
             should.equal(err.details.messages.age[0], 'can\'t be blank');
             done();
@@ -495,6 +496,7 @@ describe('validations', function() {
         Employee.updateAll({where: {id: 1}}, {name: 'Foo-new', age: 5},
           function(err, emp) {
             should.exist(err);
+            should.not.exist(emp);
             should.equal(err.statusCode, 422);
             should.equal(err.details.messages.name[0], 'can\'t be set');
             done();
@@ -751,6 +753,7 @@ describe('validations', function() {
         Employee.updateAll({where: {id: 1}}, {name: 'Bar', age: 5},
           function(err, emp) {
             should.exist(err);
+            should.not.exist(emp);
             should.equal(err.statusCode, 422);
             should.equal(err.details.messages.name[0], 'is not unique');
             done();
@@ -825,6 +828,7 @@ describe('validations', function() {
         Employee.updateAll({where: {id: 1}}, {name: '45foo', age: 5},
           function(err, emp) {
             should.exist(err);
+            should.not.exist(emp);
             should.equal(err.statusCode, 422);
             should.equal(err.details.messages.name[0], 'is invalid');
             done();
@@ -931,6 +935,7 @@ describe('validations', function() {
         Employee.updateAll({where: {id: 1}}, {age: {someAge: 5}},
           function(err, emp) {
             should.exist(err);
+            should.not.exist(emp);
             should.equal(err.statusCode, 422);
             should.equal(err.details.messages.age[0], 'is not a number');
             done();
@@ -1047,6 +1052,7 @@ describe('validations', function() {
         Employee.updateAll({where: {id: 1}}, {name: 'Foo-new2', age: 5},
           function(err, emp) {
             should.exist(err);
+            should.not.exist(emp);
             should.equal(err.statusCode, 422);
             should.equal(err.details.messages.name[0], 'is not included in ' +
             'the list');
@@ -1145,6 +1151,7 @@ describe('validations', function() {
         Employee.updateAll({where: {id: 1}}, {name: 'Bob', age: 5},
           function(err, emp) {
             should.exist(err);
+            should.not.exist(emp);
             should.equal(err.statusCode, 422);
             should.equal(err.details.messages.name[0], 'is reserved');
             done();
@@ -1194,6 +1201,7 @@ describe('validations', function() {
         Employee.updateAll({where: {id: 1}}, {name: 'Bob', age: 5},
           function(err, emp) {
             should.exist(err);
+            should.not.exist(emp);
             should.equal(err.statusCode, 422);
             should.equal(err.details.messages.name[0], 'too short');
             done();


### PR DESCRIPTION
### Description

Previously it would return the object to be updated as a part of the callback even though the data was not updated. This PR makes sure only the **error** is returned if a validation error is caught.
