### PR TITLE
Call connector's findById if exists

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1329,6 +1329,10 @@ DataAccessObject.exists = function exists(id, options, cb) {
  * @param {Function} cb Callback called with (err, instance)
  */
 DataAccessObject.findById = function findById(id, filter, options, cb) {
+  var self = this;
+  var Model = this;
+  var connector = Model.getConnector();
+
   var connectionPromise = stillConnecting(this.getDataSource(), this, arguments);
   if (connectionPromise) {
     return connectionPromise;
@@ -1358,6 +1362,7 @@ DataAccessObject.findById = function findById(id, filter, options, cb) {
   cb = cb || utils.createPromiseCallback();
   options = options || {};
   filter = filter || {};
+  var modelName = self.modelName;
 
   assert(typeof filter === 'object', 'The filter argument must be an object');
   assert(typeof options === 'object', 'The options argument must be an object');
@@ -1377,6 +1382,11 @@ DataAccessObject.findById = function findById(id, filter, options, cb) {
     if (filter.fields) {
       query.fields = filter.fields;
     }
+  }
+
+  if (typeof connector.findById === 'function') {
+    connector.findById(modelName, id, options, cb);
+  } else {
     this.findOne(query, options, cb);
   }
   return cb.promise;

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1330,8 +1330,7 @@ DataAccessObject.exists = function exists(id, options, cb) {
  */
 DataAccessObject.findById = function findById(id, filter, options, cb) {
   var self = this;
-  var Model = this;
-  var connector = Model.getConnector();
+  var connector = self.getConnector();
 
   var connectionPromise = stillConnecting(this.getDataSource(), this, arguments);
   if (connectionPromise) {
@@ -1384,6 +1383,9 @@ DataAccessObject.findById = function findById(id, filter, options, cb) {
     }
   }
 
+  // mongodb: find(alias findById, PR on its way)
+  // sql: find(alias findById)
+  // couchdb2: findById
   if (typeof connector.findById === 'function') {
     connector.findById(modelName, id, options, cb);
   } else {


### PR DESCRIPTION
### Description

Currently, if I call **findById** on a model, it does not call the connector level function. The call trace is as following: `FindById -> FindOne -> Find -> All`. This PR calls the connector level **findById** function if it exists to optimize the query.

**Please note**: Test cases for this change needs to be added in CouchDB and/or other connectors that has **findById** function defined.

fixes https://github.com/strongloop/loopback-connector-couchdb2/issues/14
connect to strongloop/loopback-connector-cloudant#166