### PR TITLE
Catch err using Callback

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -2714,7 +2714,11 @@ DataAccessObject.updateAll = function(where, data, options, cb) {
         data = ctx.data;
         var inst = data;
         if (!(data instanceof Model)) {
-          inst = new Model(data, {applyDefaultValues: false});
+          try {
+            inst = new Model(data, {applyDefaultValues: false});
+          } catch (err) {
+            return cb(err);
+          }
         }
 
         if (doValidate === false) {
@@ -3023,12 +3027,17 @@ DataAccessObject.replaceById = function(id, data, options, cb) {
 
   var pkName = idName(this);
   if (!data[pkName]) data[pkName] = id;
+  try {
+    var Model = this;
+    var inst = new Model(data, {persisted: true});
+    var enforced = {};
 
-  var Model = this;
-  var inst = new Model(data, {persisted: true});
-  var enforced = {};
-  this.applyProperties(enforced, inst);
-  inst.setAttributes(enforced);
+    this.applyProperties(enforced, inst);
+    inst.setAttributes(enforced);
+  } catch (err) {
+    return cb(err);
+  }
+
   Model = this.lookupModel(data); // data-specific
   if (Model !== inst.constructor) inst = new Model(data);
   var strict = inst.__strict;

--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -559,6 +559,7 @@ describe('manipulation', function() {
         });
       });
     });
+
     it('should update one attribute', function(done) {
       person.updateAttribute('name', 'Paul Graham', function(err, p) {
         if (err) return done(err);
@@ -840,6 +841,16 @@ describe('manipulation', function() {
           should.exist(data.content);
           data.content.should.equal('b');
 
+          done();
+        });
+      });
+    });
+
+    it('should reject updated empty password with updateOrCreate', function(done) {
+      StubUser.create({password: 'abc123'}, function(err, createdUser) {
+        if (err) return done(err);
+        StubUser.updateOrCreate({id: createdUser.id, 'password': ''}, function(err, updatedUser) {
+          (err.message).should.match(/password cannot be empty/);
           done();
         });
       });
@@ -1333,6 +1344,16 @@ describe('manipulation', function() {
               found.password.should.equal('test-TEST');
               done();
             });
+          });
+        });
+      });
+
+      it('should reject updated empty password with replaceAttributes', function(done) {
+        StubUser.create({password: 'abc123'}, function(err, createdUser) {
+          if (err) return done(err);
+          createdUser.replaceAttributes({'password': ''}, function(err, updatedUser) {
+            (err.message).should.match(/password cannot be empty/);
+            done();
           });
         });
       });
@@ -2221,6 +2242,16 @@ describe('manipulation', function() {
             });
           });
         });
+
+    it('should reject updated empty password with updateAll', function(done) {
+      StubUser.create({password: 'abc123'}, function(err, createdUser) {
+        if (err) return done(err);
+        StubUser.updateAll({where: {id: createdUser.id}}, {'password': ''}, function(err, updatedUser) {
+          (err.message).should.match(/password cannot be empty/);
+          done();
+        });
+      });
+    });
 
     bdd.itIf(connectorCapabilities.updateWithoutId !== false,
       'should update all instances when the where condition is not provided', function(done) {


### PR DESCRIPTION
### Description

Some methods needs to catch the error using callback, otherwise it may create an error that cannot be caught..

Doing the catch in `setAttributes` did not work .. as well as some methods do not even use `setAttributes` as you can see in the pr. 
This pr is complemented by this one https://github.com/strongloop/loopback/pull/3570

#### Related issues

connect to https://github.com/strongloop/loopback-datasource-juggler/issues/1436

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
