### PR TITLE
Add setters to belongsTo and hasOne relations

### DIFF
--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -1344,6 +1344,7 @@ RelationDefinition.belongsTo = function(modelFrom, modelToRef, params) {
         deprecated(g.f('BelongsTo method "getAsync()" is deprecated, use "get()" instead.'));
         return this.get.apply(this, arguments);
       };
+      relationMethod.set = relation.set.bind(relation);
       relationMethod.update = relation.update.bind(relation);
       relationMethod.destroy = relation.destroy.bind(relation);
       if (!polymorphic) {
@@ -1469,12 +1470,6 @@ BelongsTo.prototype.destroy = function(options, cb) {
  */
 BelongsTo.prototype.related = function(condOrRefresh, options, cb) {
   var self = this;
-  var modelFrom = this.definition.modelFrom;
-  var modelTo = this.definition.modelTo;
-  var pk = this.definition.keyTo;
-  var fk = this.definition.keyFrom;
-  var modelInstance = this.modelInstance;
-  var discriminator;
   var scopeQuery = null;
   var newValue;
 
@@ -1497,25 +1492,19 @@ BelongsTo.prototype.related = function(condOrRefresh, options, cb) {
     scopeQuery = condOrRefresh;
   }
 
-  if (typeof this.definition.polymorphic === 'object') {
-    discriminator = this.definition.polymorphic.discriminator;
-  }
-
   var cachedValue;
   if (!condOrRefresh) {
     cachedValue = self.getCache();
   }
   if (newValue) { // acts as setter
-    modelInstance[fk] = newValue[pk];
-
-    if (discriminator) {
-      modelInstance[discriminator] = newValue.constructor.modelName;
-    }
-
-    this.definition.applyProperties(modelInstance, newValue);
-
-    self.resetCache(newValue);
+    self.set(newValue);
   } else if (typeof cb === 'function') { // acts as async getter
+    var modelInstance = this.modelInstance;
+    var definition = this.definition;
+    var modelFrom = definition.modelFrom;
+    var modelTo = definition.modelTo;
+    var polymorphic = definition.polymorphic;
+    var discriminator = typeof polymorphic === 'object' && polymorphic.discriminator;
     if (discriminator) {
       var modelToName = modelInstance[discriminator];
       if (typeof modelToName !== 'string') {
@@ -1529,6 +1518,8 @@ BelongsTo.prototype.related = function(condOrRefresh, options, cb) {
     }
 
     if (cachedValue === undefined || !(cachedValue instanceof ModelBaseClass)) {
+      var pk = definition.keyTo;
+      var fk = definition.keyFrom;
       var query = {where: {}};
       query.where[pk] = modelInstance[fk];
 
@@ -1537,7 +1528,7 @@ BelongsTo.prototype.related = function(condOrRefresh, options, cb) {
         return process.nextTick(cb);
       }
 
-      this.definition.applyScope(modelInstance, query);
+      definition.applyScope(modelInstance, query);
 
       if (scopeQuery) mergeQuery(query, scopeQuery);
 
@@ -1559,7 +1550,7 @@ BelongsTo.prototype.related = function(condOrRefresh, options, cb) {
           cb(null, inst);
         } else {
           err = new Error(g.f('Key mismatch: %s.%s: %s, %s.%s: %s',
-            self.definition.modelFrom.modelName, fk, modelInstance[fk],
+            definition.modelFrom.modelName, fk, modelInstance[fk],
             modelTo.modelName, pk, inst[pk]));
           err.statusCode = 400;
           cb(err);
@@ -1573,9 +1564,27 @@ BelongsTo.prototype.related = function(condOrRefresh, options, cb) {
   } else if (condOrRefresh === undefined) { // acts as sync getter
     return cachedValue;
   } else { // setter
-    modelInstance[fk] = newValue;
-    self.resetCache();
+    self.set(newValue);
   }
+};
+
+/**
+ * Define a synchronous setter method for the belongsTo relation to set values
+ * on the target model instance
+ *
+ * @param value The new value to be set
+ */
+BelongsTo.prototype.set = function(value) {
+  var modelInstance = this.modelInstance;
+  var definition = this.definition;
+  var polymorphic = definition.polymorphic;
+  var discriminator = typeof polymorphic === 'object' && polymorphic.discriminator;
+  modelInstance[definition.keyFrom] = value ? value[definition.keyTo] : value;
+  if (discriminator && value) {
+    modelInstance[discriminator] = value.constructor.modelName;
+  }
+  definition.applyProperties(modelInstance, value);
+  this.resetCache(value);
 };
 
 /**
@@ -1721,6 +1730,7 @@ RelationDefinition.hasOne = function(modelFrom, modelToRef, params) {
         deprecated(g.f('HasOne method "getAsync()" is deprecated, use "get()" instead.'));
         return this.get.apply(this, arguments);
       };
+      relationMethod.set = relation.set.bind(relation);
       relationMethod.create = relation.create.bind(relation);
       relationMethod.build = relation.build.bind(relation);
       relationMethod.update = relation.update.bind(relation);
@@ -1929,11 +1939,6 @@ HasMany.prototype.build = HasOne.prototype.build = function(targetModelData) {
  */
 HasOne.prototype.related = function(condOrRefresh, options, cb) {
   var self = this;
-  var modelTo = this.definition.modelTo;
-  var fk = this.definition.keyTo;
-  var pk = this.definition.keyFrom;
-  var definition = this.definition;
-  var modelInstance = this.modelInstance;
   var newValue;
 
   if ((condOrRefresh instanceof ModelBaseClass) &&
@@ -1957,11 +1962,14 @@ HasOne.prototype.related = function(condOrRefresh, options, cb) {
     cachedValue = self.getCache();
   }
   if (newValue) { // acts as setter
-    newValue[fk] = modelInstance[pk];
-    self.resetCache(newValue);
   } else if (typeof cb === 'function') { // acts as async getter
     if (cachedValue === undefined) {
       var query = {where: {}};
+      var definition = this.definition;
+      var modelInstance = this.modelInstance;
+      var fk = definition.keyTo;
+      var pk = definition.keyFrom;
+      var modelTo = definition.modelTo;
       query.where[fk] = modelInstance[pk];
       definition.applyScope(modelInstance, query);
       modelTo.findOne(query, options, function(err, inst) {
@@ -1978,7 +1986,7 @@ HasOne.prototype.related = function(condOrRefresh, options, cb) {
           cb(null, inst);
         } else {
           err = new Error(g.f('Key mismatch: %s.%s: %s, %s.%s: %s',
-            self.definition.modelFrom.modelName, pk, modelInstance[pk],
+            definition.modelFrom.modelName, pk, modelInstance[pk],
             modelTo.modelName, fk, inst[fk]));
           err.statusCode = 400;
           cb(err);
@@ -1991,9 +1999,19 @@ HasOne.prototype.related = function(condOrRefresh, options, cb) {
     }
   } else if (condOrRefresh === undefined) { // acts as sync getter
     return cachedValue;
-  } else { // setter
-    newValue[fk] = modelInstance[pk];
-    self.resetCache();
+  }
+};
+
+/**
+ * Define a synchronous setter method for the hasOne relation to set values on
+ * the target model instance
+ *
+ * @param value The new value to be set
+ */
+HasOne.prototype.set = function(value) {
+  if (value) {
+    value[this.definition.keyTo] = this.modelInstance[this.definition.keyFrom];
+    this.resetCache(value);
   }
 };
 


### PR DESCRIPTION
### Description

As discussed with @bajtos in https://github.com/strongloop/loopback-datasource-juggler/pull/1424#issuecomment-317033577: Since `belongsTo` and `hasOne` relations now have getters, they should also have setters in favor of using the relation methods directly.

I would like to make a general case against these relation methods, as it appears to me to be a problematic / confusing design choice to have relation methods (e.g. `myInstance.someRelation()`) with nested methods on them (`myInstance.someRelation.get()`).

Adding `set()` in symmetry to `get()` brings us one step closer to not having to call the relation methods themselves at all, and perhaps one day allowing us to convert these relation methods to relation objects that could be based on a normal underlying class, allowing for a lot of code cleanup around the handling of relations.

It remains to be discussed how cached values would be handled then. At the moment, they are returned both by `myInstance.someRelation()` as well as `myInstance.someRelation.getCache()`...

This PR isn't finished. Tests are needed, and a general discussion should be had about the way forward. I am also raising this in light of work on LB4.

#### Related issues

- #1424

### Checklist

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
