### PR TITLE
Fix for issue #1475

### DIFF
--- a/lib/validations.js
+++ b/lib/validations.js
@@ -362,7 +362,8 @@ function validateFormat(attr, conf, err, options) {
   if (nullCheck.call(this, attr, conf, err)) return;
 
   if (typeof this[attr] === 'string' || typeof this[attr] === 'number') {
-    if (!conf['with'].test(this[attr])) {
+    let regex = new RegExp(conf['with']);
+    if (!regex.test(this[attr])) {
       err();
     }
   } else {

--- a/test/validations.test.js
+++ b/test/validations.test.js
@@ -836,6 +836,40 @@ describe('validations', function() {
       u.isValid().should.be.false();
     });
 
+    describe('validate format correctly on bulk creation with global flag enabled in RegExp', function() {
+      before(function(done) {
+        Employee.destroyAll(function(err) {
+          should.not.exist(err);
+          delete Employee.validations;
+          db.automigrate('Employee', function(err) {
+            should.not.exist(err);
+            Employee.create(empData, function(err, inst) {
+              should.not.exist(err);
+              should.exist(inst);
+              Employee.validatesFormatOf('name', {with: /^[a-z]+$/g, allowNull: false});
+              done();
+            });
+          });
+        });
+      });
+
+      it('succeeds when validate condition is met for all items', function(done) {
+        Employee.create([
+          {name: 'test'},
+          {name: 'test'},
+          {name: 'test'},
+          {name: 'test'},
+          {name: 'test'},
+          {name: 'test'},
+        ], (err, instances) => {
+          should.not.exist(err);
+          should.exist(instances);
+          instances.should.have.lengthOf(6);
+          done();
+        });
+      });
+    });
+
     describe('validate format on update', function() {
       before(function(done) {
         Employee.destroyAll(function(err) {


### PR DESCRIPTION
### Description
The RegExp is cloned before executing the test to ensure that every object is tested against a 'fresh' RegExp-instance. This is especially useful in cases where the RegExp contains a /g-modifier and bulk creates are performed. See the example from issue #1475.

#### Related issues
- solves #1475 

### Checklist
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)