### PR TITLE
Add nyc coverage, report data to coveralls.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@ docs/man
 npm-debug.log
 .project
 test/memory.json
+.nyc_output
 
 

--- a/.nycrc
+++ b/.nycrc
@@ -1,0 +1,6 @@
+{
+  "exclude":  [
+    "test/**/*.js"
+  ],
+  "cache": true
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ language: node_js
 node_js:
   - "4"
   - "6"
+
+after_success: npm run coverage

--- a/package.json
+++ b/package.json
@@ -26,16 +26,19 @@
     "depd": "./lib/browser.depd.js"
   },
   "scripts": {
+    "coverage": "nyc report --reporter=text-lcov | coveralls",
     "lint": "eslint .",
-    "test": "mocha",
+    "test": "nyc mocha",
     "posttest": "npm run lint"
   },
   "devDependencies": {
     "async-iterators": "^0.2.2",
+    "coveralls": "^2.13.1",
     "eslint": "^3.12.2",
     "eslint-config-loopback": "^8.0.0",
     "loopback-connector-throwing": "file:./test/fixtures/loopback-connector-throwing",
     "mocha": "^3.2.0",
+    "nyc": "^11.1.0",
     "should": "^8.4.0"
   },
   "dependencies": {


### PR DESCRIPTION
Apply the changes from https://github.com/strongloop/loopback/pull/3165

 - Modify `npm test` to run all tests with code coverage enabled via `nyc`
 - Add a new script `npm run coverage` to report the coverage to coveralls.io
 - Add a Travis hook `after_success` to run the npm script reporting the coverage


/cc @strongloop/loopback-devs @strongloop/loopback-maintainers 