### PR TITLE
Part 1 of moving tx timeout and id to connector

### DIFF
--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -76,12 +76,17 @@ TransactionMixin.beginTransaction = function(options, cb) {
     var connector = this.getConnector();
     Transaction.begin(connector, options, function(err, transaction) {
       if (err) return cb(err);
-      if (transaction) {
+      // NOTE(lehni) As part of the process of moving the handling of
+      // transaction id and timeout from TransactionMixin.beginTransaction() to
+      // Transaction.begin() in loopback-connector, switch to only setting id
+      // and timeout if it wasn't taken care of already by Transaction.begin().
+      // Eventually, we can remove the following two if-blocks altogether.
+      if (!transaction.id) {
         // Set an informational transaction id
         transaction.id = uuid.v1();
       }
-      if (options.timeout) {
-        setTimeout(function() {
+      if (options.timeout && !transaction.timeout) {
+        transaction.timeout = setTimeout(function() {
           var context = {
             transaction: transaction,
             operation: 'timeout',


### PR DESCRIPTION
### Description

This simple PR is part one of moving the handling of transaction timeouts and ids from `loopback-datasource-juggler`'s [`TransactionMixin.beginTransaction()`](https://github.com/strongloop/loopback-datasource-juggler/blob/3b45c76d0fd3364c55a55720d685b5596fb578d1/lib/transaction.js#L73-L108) to `loopback-connector`'s [`Transaction.begin()`](https://github.com/strongloop/loopback-connector/blob/fd7d5db2c88295ed695162d906220f722a628293/lib/transaction.js#L66-L99), where it makes more sense and can be leveraged more easily by other parts of the code, e.g. the work I am doing in #1472. For a more detailed description of the motivation to do so, see https://github.com/strongloop/loopback-datasource-juggler/pull/1472#issuecomment-324613756

By itself, this does not change anything yet, it just adds support for moving / (duplicating for the time being) the functionality in `loopback-connector`, without calling the `timeout` observers twice.

As the comment in this PR suggests, we should keep this code around for quite a while and eventually remove it:

```js
// NOTE(lehni) As part of the process of moving the handling of
// transaction id and timeout from TransactionMixin.beginTransaction() to
// Transaction.begin() in loopback-connector, switch to only setting id
// and timeout if it wasn't taken care of already by Transaction.begin().
// Eventually, we can remove the following two if-blocks altogether.
```

I don't think additional tests are required.

#### Related issues

- strongloop/loopback-connector#116
- #1472

### Checklist

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
