### PR TITLE
Allow passing null to base model ctor

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -74,7 +74,7 @@ ModelBaseClass.prototype._initProperties = function(data, options) {
   var self = this;
   var ctor = this.constructor;
 
-  if (typeof data !== 'undefined' && data.constructor &&
+  if (typeof data !== 'undefined' && data !== null && data.constructor &&
       typeof (data.constructor) !== 'function') {
     throw new Error(g.f('Property name "{{constructor}}" is not allowed in %s data', ctor.modelName));
   }

--- a/test/datatype.test.js
+++ b/test/datatype.test.js
@@ -170,6 +170,17 @@ describe('datatypes', function() {
     });
   });
 
+  it('handles null data', (done) => {
+    db = getSchema();
+    Model = db.define('MyModel', {
+      data: {type: 'string'},
+    });
+    db.automigrate(['Model'], function() {
+      let a = new Model(null);
+      done();
+    });
+  });
+
   describe('model option persistUndefinedAsNull', function() {
     var TestModel, isStrict;
     before(function(done) {


### PR DESCRIPTION
### Description

Redis connector will pass null back if entity is not found causing `data.constructor` to throw an error. Rather than updating the connector, I figured it's probably best to check for null as well since undefined is already being checked.

#### Related issues

- #1486

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
