### PR TITLE
Allow new transaction method in postgresql

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -2229,6 +2229,11 @@ DataSource.prototype.transaction = function(execute, options, cb) {
       // retrieved again in determineOptions() in dao.js, as well as referenced
       // in transaction.commit() and transaction.rollback() below.
       transaction.currentTransaction = tx;
+
+      // Some connectors like Postgresql expose loobpack-connector as a property on the tx
+      if (!tx.observe && tx.connector) {
+        tx = tx.connector;
+      }
       // Handle timeout and pass it on as an error.
       tx.observe('timeout', function(context, next) {
         const err = new Error(g.f('Transaction is rolled back due to timeout'));


### PR DESCRIPTION
### Description

@lehni I'd like to get your opinion on this one. The new way of handling transactions that you added was not working for me using `loopback-connector-postgresql`. `tx.observe` was not a function so it was throwing an error.

Inspecting the transaction object you have a few properties, one of which is `connector` which points to `loopback-connector` allowing you to observe timeouts.


### Related Issues

- #1494