### PR TITLE
Pass options in getAsync

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -130,7 +130,7 @@ ScopeDefinition.prototype.related = function(receiver, scopeParams, condOrRefres
           queryRelated.where[IdKey] = collectTargetIds(data, IdKey);
         }
 
-        relatedModel.find(queryRelated, cb);
+        relatedModel.find(queryRelated, options, cb);
       } else {
         cb(err, data);
       }

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -267,6 +267,58 @@ describe('relations', function() {
         }
       });
 
+      it('should fetch all scoped instances with getAsync with callback and options', function(done) {
+        Book.create(function(err, book) {
+          book.chapters.create({name: 'a'}, function() {
+            book.chapters.create({name: 'z'}, function() {
+              book.chapters.create({name: 'c'}, function() {
+                verify(book);
+              });
+            });
+          });
+        });
+        function verify(book) {
+          book.chapters({}, {options: 'options'}, function(err, ch) {
+            should.not.exist(err);
+            should.exist(ch);
+            ch.should.have.lengthOf(3);
+
+            book.chapters.getAsync({}, {options: 'options'}, function(e, c) {
+              should.not.exist(e);
+              should.exist(c);
+
+              done();
+            });
+          });
+        }
+      });
+
+      it('should fetch all scoped instances with getAsync with callback and no options', function(done) {
+        Book.create(function(err, book) {
+          book.chapters.create({name: 'a'}, function() {
+            book.chapters.create({name: 'z'}, function() {
+              book.chapters.create({name: 'c'}, function() {
+                verify(book);
+              });
+            });
+          });
+        });
+        function verify(book) {
+          book.chapters(function(err, ch) {
+            should.not.exist(err);
+            should.exist(ch);
+            ch.should.have.lengthOf(3);
+
+            book.chapters.getAsync(function(e, c) {
+              should.not.exist(e);
+              should.exist(c);
+
+              done();
+            });
+          });
+        }
+      });
+
       it('should find scoped record', function(done) {
         var id;
         Book.create(function(err, book) {


### PR DESCRIPTION
### Description

Pass options when getting scopped relations. It wasn't passed and broke our servers everytime we got concurent requests.

#### Related issues
connect to #1495 

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
