### PR TITLE
Remove test

### DIFF
--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -820,15 +820,6 @@ describe('relations', function() {
             done();
           });
         });
-        it('returns empty result when filtering with wrong id key', function(done) {
-          var wrongWhereFilter = {where: {wrongIdKey: samplePatientId}};
-          physician.patients(wrongWhereFilter, function(err, ch) {
-            if (err) return done(err);
-            should.exist(ch);
-            ch.should.have.lengthOf(0);
-            done();
-          });
-        });
         it('returns patients where id in an array', function(done) {
           var idArr = [];
           var whereFilter;


### PR DESCRIPTION
Related to https://github.com/strongloop/loopback-datasource-juggler/pull/1480

filter with undefined property returns all result not empty, since connectors ignore the property when build query.

Code details see https://github.com/strongloop/loopback-connector/commit/eba7e680598705a778cd9d5abd64bd4a9962d0e4