### PR TITLE
Add support for custom defaultFns

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -300,27 +300,10 @@ ModelBaseClass.prototype._initProperties = function(data, options) {
     // Set default value using a named function
     if (applyDefaultValues && propVal === undefined) {
       var defn = properties[p].defaultFn;
-      switch (defn) {
-        case undefined:
-          break;
-        case 'guid':
-        case 'uuid':
-          // Generate a v1 (time-based) id
-          propVal = uuid.v1();
-          break;
-        case 'uuidv4':
-          // Generate a RFC4122 v4 UUID
-          propVal = uuid.v4();
-          break;
-        case 'now':
-          propVal = new Date();
-          break;
-        case 'shortid':
-          propVal = shortid.generate();
-          break;
-        default:
-          // TODO Support user-provided functions via a registry of functions
-          g.warn('Unknown default value provider %s', defn);
+      if (ctor.__valueProviders[defn]) {
+        propVal = ctor.__valueProviders[defn](self, ctor);
+      } else if (defn) {
+        g.warn('Unknown default value provider %s', defn);
       }
       // FIXME: We should coerce the value
       // will implement it after we refactor the PropertyDefinition
@@ -399,6 +382,26 @@ ModelBaseClass.getPropertyType = function(propName) {
 ModelBaseClass.prototype.getPropertyType = function(propName) {
   return this.constructor.getPropertyType(propName);
 };
+
+/**
+ * Add a new id generation factory to the model class.
+ * @param {String} key Reference name for the id generator
+ * @param {Function} factory The factory function for the id. Gets passed in the model instance.
+ */
+
+ModelBaseClass.registerValueProvider = function(key, factory) {
+  this.__valueProviders = this.__valueProviders || {};
+  this.__valueProviders[key] = factory;
+};
+
+/**
+ * Register some default value providers
+ */
+ModelBaseClass.registerValueProvider('guid', () => uuid.v1());
+ModelBaseClass.registerValueProvider('uuid', () => uuid.v1());
+ModelBaseClass.registerValueProvider('uuidv4', () => uuid.v4());
+ModelBaseClass.registerValueProvider('now', () => new Date());
+ModelBaseClass.registerValueProvider('shortid', () => shortid.generate());
 
 /**
  * Return string representation of class

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "eslint-config-loopback": "^8.0.0",
     "loopback-connector-throwing": "file:./test/fixtures/loopback-connector-throwing",
     "mocha": "^3.2.0",
+    "nanoid": "^0.2.2",
     "nyc": "^11.1.0",
     "should": "^8.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "eslint-config-loopback": "^8.0.0",
     "loopback-connector-throwing": "file:./test/fixtures/loopback-connector-throwing",
     "mocha": "^3.2.0",
-    "nanoid": "^0.2.2",
     "nyc": "^11.1.0",
     "should": "^8.4.0"
   },

--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -11,7 +11,6 @@ var async = require('async');
 var bdd = require('./helpers/bdd-if');
 var should = require('./init.js');
 var uid = require('./helpers/uid-generator');
-var nanoid = require('nanoid');
 
 var db, Person;
 var ValidationError = require('..').ValidationError;
@@ -2085,8 +2084,8 @@ describe('manipulation', function() {
       before(createModelWithCustomValueProvider);
 
       it('uses user-registered value providers', function() {
-        var NANOID_REGEXP = /^[0-9a-zA-Z_\~]{22}$/i;
-        modelInstance.nanoId.should.match(NANOID_REGEXP);
+        var RAND_REGEXP = /^[0-9a-f]+$/i;
+        modelInstance.rand.should.match(RAND_REGEXP);
       });
 
       it('passes the model instance into the value provider', function() {
@@ -2096,10 +2095,10 @@ describe('manipulation', function() {
       function createModelWithCustomValueProvider(cb) {
         ModelWithCustomProvider = db.define('ModelWithCustomProvider', {
           name: {type: String},
-          nanoId: {type: String, defaultFn: 'nanoid'},
+          rand: {type: String, defaultFn: 'rand'},
           slugId: {type: String, defaultFn: 'slug'},
         });
-        ModelWithCustomProvider.registerValueProvider('nanoid', () => nanoid());
+        ModelWithCustomProvider.registerValueProvider('rand', () => Math.random().toString(16).slice(2));
         ModelWithCustomProvider.registerValueProvider('slug', (instance) => {
           return instance.name.toLowerCase().replace(/ /g, '-');
         });

--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -2081,7 +2081,7 @@ describe('manipulation', function() {
 
     describe('custom value providers', function() {
       var ModelWithCustomProvider, modelInstance;
-      before(createModelWithCustomValueProvider);
+      before(modelWithValueProvider);
 
       it('uses user-registered value providers', function() {
         var RAND_REGEXP = /^[0-9a-f]+$/i;
@@ -2092,7 +2092,7 @@ describe('manipulation', function() {
         modelInstance.slugId.should.eql('test-instance');
       });
 
-      function createModelWithCustomValueProvider(cb) {
+      function modelWithValueProvider(cb) {
         ModelWithCustomProvider = db.define('ModelWithCustomProvider', {
           name: {type: String},
           rand: {type: String, defaultFn: 'rand'},

--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -2080,7 +2080,7 @@ describe('manipulation', function() {
     });
 
     describe('custom value providers', function() {
-      var ModelWithCustomProvider, modelInstance;
+      var CustomProviderModel, modelInstance;
       before(modelWithValueProvider);
 
       it('uses user-registered value providers', function() {
@@ -2093,18 +2093,18 @@ describe('manipulation', function() {
       });
 
       function modelWithValueProvider(cb) {
-        ModelWithCustomProvider = db.define('ModelWithCustomProvider', {
+        CustomProviderModel = db.define('CustomProviderModel', {
           name: {type: String},
           rand: {type: String, defaultFn: 'rand'},
           slugId: {type: String, defaultFn: 'slug'},
         });
-        ModelWithCustomProvider.registerValueProvider('rand', () => Math.random().toString(16).slice(2));
-        ModelWithCustomProvider.registerValueProvider('slug', (instance) => {
+        CustomProviderModel.registerValueProvider('rand', () => Math.random().toString(16).slice(2));
+        CustomProviderModel.registerValueProvider('slug', (instance) => {
           return instance.name.toLowerCase().replace(/ /g, '-');
         });
-        db.automigrate('ModelWithCustomProvider', function(err) {
+        db.automigrate('CustomProviderModel', function(err) {
           if (err) return cb(err);
-          ModelWithCustomProvider.create({name: 'Test Instance'}, function(err, instance) {
+          CustomProviderModel.create({name: 'Test Instance'}, function(err, instance) {
             if (err) return cb(err);
             modelInstance = instance;
             cb();


### PR DESCRIPTION
### Description
Allow defining custom value providers (`'defaultFn'`) by registering them on the model constructor. I have not removed `shortids` as a dependency as suggested in the issue to maintain backwards compatibility and prevent this from being a breaking change. 

cc @ai

#### Related issues
- closes #1502 
- connect to #1501 (for discussion)


### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
