### PR TITLE
Fix basic-querying

### DIFF
--- a/test/basic-querying.test.js
+++ b/test/basic-querying.test.js
@@ -52,7 +52,7 @@ describe('basic-querying', function() {
     (db.adapter.name != 'informix') && (db.adapter.name != 'cassandra');
     if (connectorCapabilities.geoPoint) userModelDef.addressLoc = {type: 'GeoPoint'};
     User = db.define('User', userModelDef);
-    db.automigrate(['User'], done);
+    db.automigrate(done);
   });
 
   describe('ping', function() {

--- a/test/basic-querying.test.js
+++ b/test/basic-querying.test.js
@@ -52,7 +52,7 @@ describe('basic-querying', function() {
     (db.adapter.name != 'informix') && (db.adapter.name != 'cassandra');
     if (connectorCapabilities.geoPoint) userModelDef.addressLoc = {type: 'GeoPoint'};
     User = db.define('User', userModelDef);
-    db.automigrate(done);
+    db.automigrate(['User'], done);
   });
 
   describe('ping', function() {

--- a/test/datatype.test.js
+++ b/test/datatype.test.js
@@ -172,10 +172,10 @@ describe('datatypes', function() {
 
   it('handles null data', (done) => {
     db = getSchema();
-    Model = db.define('MyModel', {
+    Model = db.define('HandleNullModel', {
       data: {type: 'string'},
     });
-    db.automigrate(['Model'], function() {
+    db.automigrate(['HandleNullModel'], function() {
       let a = new Model(null);
       done();
     });


### PR DESCRIPTION
connect to strongloop-internal/scrum-apex#331
### Description

Fix the current test failures[part 1].

### Problem

some connector like postgresql & oracle uses same model name `MyModel` and results in conflict when `automigrate`: creating existing schema `public`