### PR TITLE
CODEOWNERS: move @lehni to Alumni section

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,5 +2,9 @@
 # Each line is a file pattern followed by one or more owners,
 # the last matching pattern has the most precendence.
 
-# Core team members from IBM and community maintainers
-* @kjdelisle @jannyHou @loay @b-admike @ssh24 @virkt25 @dhmlau @lehni @zbarbuto
+# Current maintainers
+* @kjdelisle @jannyHou @loay @b-admike @ssh24 @virkt25 @dhmlau @zbarbuto
+
+# Alumni
+#
+# @lehni


### PR DESCRIPTION
Effectively remove Jurg from the list of code owners assigned to review pull requests.
