### PR TITLE
Allow customizing embedded relation property

### DIFF
--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -2045,7 +2045,10 @@ RelationDefinition.embedsOne = function(modelFrom, modelToRef, params) {
     methods: params.methods,
   });
 
-  var opts = {type: modelTo};
+  var opts = Object.assign(
+    params.options && params.options.property ? params.options.property : {},
+    {type: modelTo}
+  );
 
   if (params.default === true) {
     opts.default = function() { return new modelTo(); };
@@ -2441,9 +2444,14 @@ RelationDefinition.embedsMany = function embedsMany(modelFrom, modelToRef, param
     embed: true,
   });
 
-  modelFrom.dataSource.defineProperty(modelFrom.modelName, propertyName, {
-    type: [modelTo], default: function() { return []; },
-  });
+  var opts = Object.assign(
+    params.options && params.options.property ? params.options.property : {},
+    {
+      type: [modelTo], default: function() { return []; },
+    }
+  );
+
+  modelFrom.dataSource.defineProperty(modelFrom.modelName, propertyName, opts);
 
   if (typeof modelTo.dataSource.connector.generateId !== 'function') {
     modelFrom.validate(propertyName, function(err) {

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -4283,13 +4283,20 @@ describe('relations', function() {
       );
       Address = tmp.define('Address', {street: String}, {idInjection: false});
       Other = db.define('Other', {name: String});
-    });
-
-    it('can be declared using embedsOne method', function(done) {
       Person.embedsOne(Passport, {
         default: {name: 'Anonymous'}, // a bit contrived
         methods: {check: function() { return true; }},
+        options: {
+          property: {
+            postgresql: {
+              columnName: 'passport_item',
+            },
+          },
+        },
       });
+    });
+
+    it('can be declared using embedsOne method', function(done) {
       Person.embedsOne(Address); // all by default
       db.automigrate(['Person'], done);
     });
@@ -4301,6 +4308,11 @@ describe('relations', function() {
       p.passportItem.create.should.be.a.function;
       p.passportItem.build.should.be.a.function;
       p.passportItem.destroy.should.be.a.function;
+    });
+
+    it('respects property options on the embedded property', function() {
+      Person.definition.properties.passport.should.have.property('postgresql');
+      Person.definition.properties.passport.postgresql.should.eql({columnName: 'passport_item'});
     });
 
     it('should setup a custom method on accessor', function() {
@@ -4704,7 +4716,15 @@ describe('relations', function() {
     });
 
     it('can be declared', function(done) {
-      Person.embedsMany(Address);
+      Person.embedsMany(Address, {
+        options: {
+          property: {
+            postgresql: {
+              dataType: 'json',
+            },
+          },
+        },
+      });
       db.automigrate(['Person'], done);
     });
 
@@ -4731,6 +4751,11 @@ describe('relations', function() {
           done();
         });
       });
+    });
+
+    it('respects property options on the embedded property', function() {
+      Person.definition.properties.addresses.should.have.property('postgresql');
+      Person.definition.properties.addresses.postgresql.should.eql({dataType: 'json'});
     });
 
     it('should create embedded items on scope', function(done) {


### PR DESCRIPTION
### Description

Having very little control over embedded properties can be frustrating. My two use-cases for this feature are demonstrated in the tests I have added but basically boils down to setting datasource options on the property.

Cleaner solution would be to make `property` support the property options I suppose but it would be more of a breaking change.

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
