### PR TITLE
Fix bug with bson objects in utils uniq function

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -566,8 +566,10 @@ function uniq(a) {
     return uniqArray;
   }
   assert(Array.isArray(a), 'array argument is required');
-  for (var i = 0, n = a.length; i < n; i++) {
-    if (a.indexOf(a[i]) === i) {
+  var comparableA = a.map(
+    item => item.hasOwnProperty('_bsontype') ? item.toString() : item);
+  for (var i = 0, n = comparableA.length; i < n; i++) {
+    if (comparableA.indexOf(comparableA[i]) === i) {
       uniqArray.push(a[i]);
     }
   }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "async-iterators": "^0.2.2",
+    "bson": "^1.0.4",
     "coveralls": "^2.13.1",
     "eslint": "^3.12.2",
     "eslint-config-loopback": "^8.0.0",

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -6,6 +6,7 @@
 'use strict';
 var should = require('./init.js');
 var utils = require('../lib/utils');
+var ObjectID = require('bson').ObjectID;
 var fieldsToArray = utils.fieldsToArray;
 var removeUndefined = utils.removeUndefined;
 var deepMerge = utils.deepMerge;
@@ -424,6 +425,15 @@ describe('util.uniq', function() {
     b.should.eql(['a', 'b']);
   });
 
+  it('should dedupe an array with duplicate bson entries', function() {
+    var idOne = new ObjectID('59f9ec5dc7d59a00042f7c62');
+    var idTwo = new ObjectID('59f9ec5dc7d59a00042f7c63');
+    var a = [idOne, idTwo, new ObjectID('59f9ec5dc7d59a00042f7c62'),
+      new ObjectID('59f9ec5dc7d59a00042f7c62')];
+    var b = uniq(a);
+    b.should.eql([idOne, idTwo]);
+  });
+
   it('should dedupe an array without duplicate number entries', function() {
     var a = [1, 3, 2];
     var b = uniq(a);
@@ -434,6 +444,15 @@ describe('util.uniq', function() {
     var a = ['a', 'c', 'b'];
     var b = uniq(a);
     b.should.eql(['a', 'c', 'b']);
+  });
+
+  it('should dedupe an array without duplicate bson entries', function() {
+    var idOne = new ObjectID('59f9ec5dc7d59a00042f7c62');
+    var idTwo = new ObjectID('59f9ec5dc7d59a00042f7c63');
+    var idThree = new ObjectID('59f9ec5dc7d59a00042f7c64');
+    var a = [idOne, idTwo, idThree];
+    var b = uniq(a);
+    b.should.eql([idOne, idTwo, idThree]);
   });
 
   it('should allow null/undefined array', function() {


### PR DESCRIPTION
### Description

The uniq function does currently not work when the database is mongodb. In the case of mongodb, the function will receive an array of bson object of bson type ObjectID. The indexOf function in uniq will return a different index for the same mongodb ID, as it is wrapped in the ObjectID. This results in an array that has duplicate mongodb IDs. This commit first transforms any ObjectID in the given array to a string representation. We can then use indexOf to return unique items.

Replaces PR: https://github.com/strongloop/loopback-datasource-juggler/pull/1418

#### Related issues

- connect to #1466

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
