### PR TITLE
Also ignore empty string for parsing object/array

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -345,13 +345,16 @@ ModelBaseClass.prototype._initProperties = function(data, options) {
       if (type.prototype instanceof ModelBaseClass) {
         if (!(self.__data[p] instanceof type) &&
             typeof self.__data[p] === 'object' &&
-            self.__data[p] !== null) {
+            self.__data[p] !== null &&
+            self.__data[p] !== '') {
           self.__data[p] = new type(self.__data[p]);
         }
       } else if (type.name === 'Array' || Array.isArray(type)) {
         if (!(self.__data[p] instanceof List) &&
             self.__data[p] !== undefined &&
-            self.__data[p] !== null) {
+            self.__data[p] !== null &&
+            self.__data[p] !== ''
+           ) {
           self.__data[p] = List(self.__data[p], type, self);
         }
       }


### PR DESCRIPTION
### Description
Some datasources such as MySQL could use empty string as default value of TEXT field, representing nothing there (same as NULL), it should be treated the same way. Without this, the datasource-juggler could crash.

