### PR TITLE
Added missing error handling for persist operation hook callback when…

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -3131,6 +3131,7 @@ DataAccessObject.replaceById = function(id, data, options, cb) {
           options: options,
         };
         Model.notifyObserversOf('persist', ctx, function(err) {
+          if (err) return cb(err);
           invokeConnectorMethod(connector, 'replaceById', Model, [id, Model._forDB(context.data)],
             options, replaceCallback);
         });
@@ -3327,6 +3328,7 @@ function(data, options, cb) {
               options: options,
             };
             Model.notifyObserversOf('persist', ctx, function(err) {
+              if (err) return cb(err);
               invokeConnectorMethod(connector, 'updateAttributes', Model,
                 [getIdValue(Model, inst), Model._forDB(context.data)],
                 options, updateAttributesCallback);

--- a/test/persistence-hooks.suite.js
+++ b/test/persistence-hooks.suite.js
@@ -1489,6 +1489,16 @@ module.exports = function(dataSource, should, connectorCapabilities) {
         });
       });
 
+      it('emits error when `persist` hook fails', function(done) {
+        TestModel.observe('persist', nextWithError(expectedError));
+
+        TestModel.settings.updateOnLoad = true;
+        existingInstance.updateAttributes({name: 'test'}, function(err, instance) {
+          [err].should.eql([expectedError]);
+          done();
+        });
+      });
+
       it('triggers `loaded` hook', function(done) {
         TestModel.observe('loaded', ctxRecorder.recordAndNext());
         existingInstance.updateAttributes({name: 'changed'}, function(err) {


### PR DESCRIPTION
… updateAttributes is invoked

Added new unit test for updateAttributes persist operation hook

### Description


#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to #1530

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
