### PR TITLE
feat: omit default fn for embedsMany

### DIFF
--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -2471,8 +2471,10 @@ RelationDefinition.embedsMany = function embedsMany(modelFrom, modelToRef, param
 
   var opts = Object.assign(
     params.options && params.options.property ? params.options.property : {},
+    params.options && params.options.omitDefaultEmbeddedItem ? {type: [modelTo]} :
     {
-      type: [modelTo], default: function() { return []; },
+      type: [modelTo],
+      default: function() { return []; },
     }
   );
 
@@ -2920,9 +2922,8 @@ EmbedsMany.prototype.create = function(targetModelData, options, cb) {
   targetModelData = targetModelData || {};
   cb = cb || utils.createPromiseCallback();
 
-  var embeddedList = this.embeddedList();
-
   var inst = this.callScopeMethod('build', targetModelData);
+  var embeddedList = this.embeddedList();
 
   var updateEmbedded = function(callback) {
     if (modelInstance.isNewRecord()) {
@@ -2975,6 +2976,7 @@ EmbedsMany.prototype.build = function(targetModelData) {
   var modelInstance = this.modelInstance;
   var forceId = this.definition.options.forceId;
   var persistent = this.definition.options.persistent;
+  var propertyName = this.definition.keyFrom;
   var connector = modelTo.dataSource.connector;
 
   var pk = this.definition.keyTo;
@@ -3008,8 +3010,10 @@ EmbedsMany.prototype.build = function(targetModelData) {
 
   if (this.definition.options.prepend) {
     embeddedList.unshift(inst);
+    modelInstance[propertyName] = embeddedList;
   } else {
     embeddedList.push(inst);
+    modelInstance[propertyName] = embeddedList;
   }
 
   this.prepareEmbeddedInstance(inst);

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -5069,9 +5069,7 @@ describe('relations', function() {
         p.addressList.build({id: 'home', street: 'Home'});
         p.addressList.build({id: 'work', street: 'Work'});
         p.addresses.should.have.length(3);
-        p.save(function(err, p) {
-          done();
-        });
+        done();
       });
     });
 

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -5021,6 +5021,73 @@ describe('relations', function() {
     });
   });
 
+  describe('embedsMany - omit default value for embedded item', function() {
+    before(function(done) {
+      tmp = getTransientDataSource({defaultIdType: Number});
+      Person = db.define('Person', {name: String});
+      Address = tmp.define('Address', {street: String});
+      Address.validatesPresenceOf('street');
+
+      db.automigrate(['Person'], done);
+    });
+
+    it('can be declared', function(done) {
+      Person.embedsMany(Address, {
+        options: {
+          omitDefaultEmbeddedItem: true,
+          property: {
+            postgresql: {
+              dataType: 'json',
+            },
+          },
+        },
+      });
+      db.automigrate(['Person'], done);
+    });
+
+    it('should not set default value for embedded item', function() {
+      var p = new Person({name: 'Fred'});
+      p.should.have.property('addresses', undefined);
+    });
+
+    it('should create embedded items on scope', function(done) {
+      Person.create({name: 'Fred'}, function(err, p) {
+        p.addressList.create({street: 'Street 1'}, function(err, address) {
+          if (err) return done(err);
+          should.exist(address.id);
+          address.street.should.equal('Street 1');
+          p.addresses.should.be.array;
+          p.addresses.should.have.length(1);
+          done();
+        });
+      });
+    });
+
+    it('should build embedded items', function(done) {
+      Person.findOne(function(err, p) {
+        p.addresses.should.have.length(1);
+        p.addressList.build({id: 'home', street: 'Home'});
+        p.addressList.build({id: 'work', street: 'Work'});
+        p.addresses.should.have.length(3);
+        p.save(function(err, p) {
+          done();
+        });
+      });
+    });
+
+    it('should not create embedded from attributes - relation name', function(done) {
+      var addresses = [
+        {id: 'home', street: 'Home Street'},
+        {id: 'work', street: 'Work Street'},
+      ];
+      Person.create({name: 'Wilma', addressList: addresses}, function(err, p) {
+        if (err) return done(err);
+        p.should.have.property('addresses', undefined);
+        done();
+      });
+    });
+  });
+
   describe('embedsMany - numeric ids + forceId', function() {
     before(function(done) {
       tmp = getTransientDataSource();


### PR DESCRIPTION
Related to https://github.com/strongloop/loopback/issues/2882

## Use case

- `Person` EmbeddsMany `Address`
- create a new person `let p = new Person({name: 'Jack', id: 1})`

## Current behaviour

The generated instance is `{name: 'Jack', id: 1, addresses: []}`

## Feature

In this PR I add a flag `omitDefaultEmbeddedItem`

### Flag off (default behaviour)

Same as current behaviour, the new person instance have an empty array property `addresses` 

### Flag on(user need to config it in model.json relations)

The new person instance is `{name: 'Jack', id: 1}`
Please note it doesn't have the embedded item.