### PR TITLE
drop support for node 0.10 / 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
   - "4"
   - "6"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "posttest": "npm run lint"
   },
   "engines": {
-    "node": ">= 0.6 <= 6"
+    "node": ">= 4 <= 6"
   },
   "devDependencies": {
     "async-iterators": "^0.2.2",


### PR DESCRIPTION
Drop support for Node 0.10/0.12 as it’s not supported by Node and tests
are failing since our dependencies no longer support Node 0.10/0.12

blocks #1540 