### PR TITLE
Add warning for datasources with mismatched names

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -375,6 +375,14 @@ DataSource.prototype.setup = function(name, settings) {
   name = name || (connector && connector.name);
   this.name = name;
 
+  if (typeof settings === 'object' && typeof settings.name === 'string' && name !== settings.name) {
+    console.warn(
+      'A datasource has a name of %j while a name of %j is specified in ' +
+        'its settings. Please adjust your configuration so these names match. ' +
+        '%j will be assigned as the actual datasource name.',
+      name, settings.name, name);
+  }
+
   if (name && !connector) {
     if (typeof name === 'object') {
       // The first argument might be the connector itself


### PR DESCRIPTION
### Description

As discussed [here](https://github.com/strongloop/loopback/pull/3733), @bajtos requested I add a warning for datasource objects which have a different name from what is specified in the corresponding settings object. Please let me know if any adjustments are required. Thanks!

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to strongloop/loopback#3732

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
