### PR TITLE
Fix datasource not correctly retaining name value

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -364,18 +364,8 @@ DataSource.prototype.setup = function(name, settings) {
     debug('Settings: %j', this.settings);
   }
 
-  // Disconnected by default
-  this.connected = false;
-  this.connecting = false;
-
-  if (typeof connector === 'string') {
-    name = connector;
-    connector = undefined;
-  }
-  name = name || (connector && connector.name);
-  this.name = name;
-
-  if (typeof settings === 'object' && typeof settings.name === 'string' && name !== settings.name) {
+  if (typeof settings === 'object' && typeof settings.name === 'string' &&
+      typeof name === 'string' && name !== settings.name) {
     console.warn(
       'A datasource has a name of %j while a name of %j is specified in ' +
         'its settings. Please adjust your configuration so these names match. ' +
@@ -383,11 +373,27 @@ DataSource.prototype.setup = function(name, settings) {
       name, settings.name, name);
   }
 
+  // Disconnected by default
+  this.connected = false;
+  this.connecting = false;
+
+  this.name = name || (typeof this.settings.name === 'string' && this.settings.name);
+  if (typeof connector === 'string') {
+    name = connector;
+    connector = undefined;
+  }
+  name = name || (connector && connector.name);
+  if (typeof this.name !== 'string' || this.name.length === 0) {
+    this.name = name;
+  }
+
   if (name && !connector) {
     if (typeof name === 'object') {
       // The first argument might be the connector itself
       connector = name;
-      this.name = connector.name;
+      if (typeof this.name !== 'string' || this.name.length === 0) {
+        this.name = connector.name;
+      }
     } else {
       // The connector has not been resolved
       var result = DataSource._resolveConnector(name);
@@ -1445,7 +1451,7 @@ DataSource.prototype.discoverSchemas = function(tableName, options, cb) {
   cb = cb || utils.createPromiseCallback();
 
   var self = this;
-  var dbType = this.connector.name || this.name;
+  var dbType = this.connector.name;
 
   var nameMapper;
   if (options.nameMapper === null) {
@@ -1638,7 +1644,7 @@ DataSource.prototype.discoverSchemas = function(tableName, options, cb) {
  */
 DataSource.prototype.discoverSchemasSync = function(modelName, options) {
   var self = this;
-  var dbType = this.name || this.connector.name;
+  var dbType = this.connector.name;
 
   var columns = this.discoverModelPropertiesSync(modelName, options);
   if (!columns || columns.length === 0) {

--- a/test/datasource.test.js
+++ b/test/datasource.test.js
@@ -45,4 +45,38 @@ describe('DataSource', function() {
       });
     }).should.throw(/expected test error/);
   });
+
+  it('should retain the name assigned to it', function() {
+    var dataSource = new DataSource('ram', {
+      connector: 'memory',
+    });
+
+    dataSource.name.should.equal('ram');
+  });
+
+  it('should allow the name assigned to it to take precedence over the settings name', function() {
+    var dataSource = new DataSource('ram', {
+      name: 'temp',
+      connector: 'memory',
+    });
+
+    dataSource.name.should.equal('ram');
+  });
+
+  it('should retain the name from the settings if no name is assigned', function() {
+    var dataSource = new DataSource({
+      name: 'temp',
+      connector: 'memory',
+    });
+
+    dataSource.name.should.equal('temp');
+  });
+
+  it('should use the connector name if no name is provided', function() {
+    var dataSource = new DataSource({
+      connector: 'memory',
+    });
+
+    dataSource.name.should.equal('memory');
+  });
 });


### PR DESCRIPTION
### Description

Data source names are not correctly retained and assigned to the object instance in some cases.

Hopefully my changes are correct, I'm not super familiar with the code base so it would be helpful to have a second opinion. I can add extra test cases if needed, not sure what might be required, if anything.

#### Related issues

- connect to #1547
- see also https://github.com/strongloop/loopback-datasource-juggler/pull/1542

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
