### PR TITLE
feat(datasource): set named datasource with settings option

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -335,14 +335,14 @@ DataSource.prototype.connect = function(callback) {
  * @returns {*}
  * @private
  */
-DataSource.prototype.setup = function(name, settings) {
+DataSource.prototype.setup = function(connectorName, settings) {
   var dataSource = this;
   var connector;
 
   // support single settings object
-  if (name && typeof name === 'object' && !settings) {
-    settings = name;
-    name = undefined;
+  if (connectorName && typeof connectorName === 'object' && !settings) {
+    settings = connectorName;
+    connectorName = undefined;
   }
 
   if (typeof settings === 'object') {
@@ -369,28 +369,29 @@ DataSource.prototype.setup = function(name, settings) {
   this.connecting = false;
 
   if (typeof connector === 'string') {
-    name = connector;
+    connectorName = connector;
     connector = undefined;
   }
-  name = name || (connector && connector.name);
-  this.name = name;
+  connectorName = connectorName || (connector && connector.name);
+  this.connectorName = connectorName;
+  this.name = this.settings.name || this.connectorName;
 
-  if (typeof settings === 'object' && typeof settings.name === 'string' && name !== settings.name) {
+  if (typeof settings === 'object' && typeof settings.name === 'string' && connectorName !== settings.name) {
     console.warn(
       'A datasource has a name of %j while a name of %j is specified in ' +
         'its settings. Please adjust your configuration so these names match. ' +
         '%j will be assigned as the actual datasource name.',
-      name, settings.name, name);
+      connectorName, settings.name, connectorName);
   }
 
-  if (name && !connector) {
-    if (typeof name === 'object') {
+  if (connectorName && !connector) {
+    if (typeof connectorName === 'object') {
       // The first argument might be the connector itself
-      connector = name;
-      this.name = connector.name;
+      connector = connectorName;
+      this.connectorName = connector.name;
     } else {
       // The connector has not been resolved
-      var result = DataSource._resolveConnector(name);
+      var result = DataSource._resolveConnector(connectorName);
       connector = result.connector;
       if (!connector) {
         console.error(result.error);
@@ -431,7 +432,7 @@ DataSource.prototype.setup = function(name, settings) {
     } catch (err) {
       if (err.message) {
         err.message = 'Cannot initialize connector ' +
-          JSON.stringify(connector.name || name)  + ': ' +
+          JSON.stringify(connector.name || connectorName)  + ': ' +
           err.message;
       }
       throw err;
@@ -1445,7 +1446,7 @@ DataSource.prototype.discoverSchemas = function(tableName, options, cb) {
   cb = cb || utils.createPromiseCallback();
 
   var self = this;
-  var dbType = this.connector.name || this.name;
+  var dbType = this.connector.name || this.connectorName;
 
   var nameMapper;
   if (options.nameMapper === null) {
@@ -1638,7 +1639,7 @@ DataSource.prototype.discoverSchemas = function(tableName, options, cb) {
  */
 DataSource.prototype.discoverSchemasSync = function(modelName, options) {
   var self = this;
-  var dbType = this.name || this.connector.name;
+  var dbType = this.connectorName || this.connector.name;
 
   var columns = this.discoverModelPropertiesSync(modelName, options);
   if (!columns || columns.length === 0) {

--- a/test/datasource.test.js
+++ b/test/datasource.test.js
@@ -45,4 +45,16 @@ describe('DataSource', function() {
       });
     }).should.throw(/expected test error/);
   });
+
+  it('should set the correct name for datasource', function() {
+    var ds1 = new DataSource({name: 'dsname1', connector: 'memory'});
+    should(ds1.name).equal('dsname1');
+    var ds2 = new DataSource('memory', {name: 'dsname2', connector: 'memory'});
+    should(ds2.name).equal('dsname2');
+  });
+
+  it('should use connector name as a fallback', function() {
+    var ds = new DataSource({connector: 'memory'});
+    should(ds.name).equal('memory');
+  });
 });


### PR DESCRIPTION
This pull request attempts to set an the appropriate name for the datasource.
In the existing code, `this.name` refers to the connector name.
In this PR, that name is changed to `this.connectorName`, while keeping the `DataSource`'s methods unchanged to the outside. 
That `.name` is now `settings.name || connector.name` and is used to find the datasource within an application context.
Related comments can be found here:
https://github.com/strongloop/loopback-next/pull/966#discussion_r166274557
@bajtos do you have any suggestion on this?