### PR TITLE
Use more meaningful names for dataSource and connector

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -329,28 +329,40 @@ DataSource.prototype.connect = function(callback) {
 };
 
 /**
- * Set up the data source
- * @param {String} name The name
+ * Set up the data source. The following styles are supported:
+ * ```js
+ * ds.setup('myDataSource', {connector: 'memory'}); // ds.name -> 'myDataSource'
+ * ds.setup('myDataSource', {name: 'myDataSource', connector: 'memory'}); // ds.name -> 'myDataSource'
+ * ds.setup('myDataSource', {name: 'anotherDataSource', connector: 'memory'}); // ds.name -> 'myDataSource' and a warning will be issued
+ * ds.setup({name: 'myDataSource', connector: 'memory'}); // ds.name -> 'myDataSource'
+ * ds.setup({connector: 'memory'}); // ds.name -> 'memory'
+ * ```
+ * @param {String} dsName The name of the datasource. If not set, use
+ * `settings.name`
  * @param {Object} settings The settings
  * @returns {*}
  * @private
  */
-DataSource.prototype.setup = function(name, settings) {
+DataSource.prototype.setup = function(dsName, settings) {
   var dataSource = this;
   var connector;
 
   // support single settings object
-  if (name && typeof name === 'object' && !settings) {
-    settings = name;
-    name = undefined;
+  if (dsName && typeof dsName === 'object' && !settings) {
+    // setup({name: 'myDataSource', connector: 'memory'})
+    settings = dsName;
+    dsName = undefined;
   }
 
   if (typeof settings === 'object') {
     if (settings.initialize) {
+      // Settings is the resolved connector instance
       connector = settings;
     } else if (settings.connector) {
+      // Use `connector`
       connector = settings.connector;
     } else if (settings.adapter) {
+      // `adapter` as alias for `connector`
       connector = settings.adapter;
     }
   }
@@ -365,44 +377,45 @@ DataSource.prototype.setup = function(name, settings) {
   }
 
   if (typeof settings === 'object' && typeof settings.name === 'string' &&
-      typeof name === 'string' && name !== settings.name) {
+      typeof dsName === 'string' && dsName !== settings.name) {
+    // setup('myDataSource', {name: 'anotherDataSource', connector: 'memory'});
+    // ds.name -> 'myDataSource' and a warning will be issued
     console.warn(
       'A datasource has a name of %j while a name of %j is specified in ' +
         'its settings. Please adjust your configuration so these names match. ' +
         '%j will be assigned as the actual datasource name.',
-      name, settings.name, name);
+      dsName, settings.name, dsName);
   }
 
   // Disconnected by default
   this.connected = false;
   this.connecting = false;
 
-  this.name = name || (typeof this.settings.name === 'string' && this.settings.name);
+  this.name = dsName || (typeof this.settings.name === 'string' && this.settings.name);
+
+  var connectorName;
   if (typeof connector === 'string') {
-    name = connector;
+    // Connector needs to be resolved by name
+    connectorName = connector;
     connector = undefined;
+  } else if ((typeof connector === 'object') && connector) {
+    connectorName = connector.name;
+  } else {
+    connectorName = dsName;
   }
-  name = name || (connector && connector.name);
-  if (typeof this.name !== 'string' || this.name.length === 0) {
-    this.name = name;
+  if (!this.name) {
+    // Fall back to connector name
+    this.name = connectorName;
   }
 
-  if (name && !connector) {
-    if (typeof name === 'object') {
-      // The first argument might be the connector itself
-      connector = name;
-      if (typeof this.name !== 'string' || this.name.length === 0) {
-        this.name = connector.name;
-      }
-    } else {
-      // The connector has not been resolved
-      var result = DataSource._resolveConnector(name);
-      connector = result.connector;
-      if (!connector) {
-        console.error(result.error);
-        this.emit('error', new Error(result.error));
-        return;
-      }
+  if ((!connector) && connectorName) {
+    // The connector has not been resolved
+    var result = DataSource._resolveConnector(connectorName);
+    connector = result.connector;
+    if (!connector) {
+      console.error(result.error);
+      this.emit('error', new Error(result.error));
+      return;
     }
   }
 
@@ -437,7 +450,7 @@ DataSource.prototype.setup = function(name, settings) {
     } catch (err) {
       if (err.message) {
         err.message = 'Cannot initialize connector ' +
-          JSON.stringify(connector.name || name)  + ': ' +
+          JSON.stringify(connector.name || dsName)  + ': ' +
           err.message;
       }
       throw err;


### PR DESCRIPTION
### Description

A clean up of https://github.com/strongloop/loopback-datasource-juggler/pull/1554

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
