### PR TITLE
fix: add more tests to verify new DataSource()

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -354,10 +354,16 @@ DataSource.prototype.setup = function(dsName, settings) {
     dsName = undefined;
   }
 
+  if (typeof dsName !== 'string') {
+    dsName = undefined;
+  }
+
   if (typeof settings === 'object') {
     if (settings.initialize) {
       // Settings is the resolved connector instance
       connector = settings;
+      // Set settings to undefined to avoid confusion
+      settings = undefined;
     } else if (settings.connector) {
       // Use `connector`
       connector = settings.connector;
@@ -381,10 +387,9 @@ DataSource.prototype.setup = function(dsName, settings) {
     // setup('myDataSource', {name: 'anotherDataSource', connector: 'memory'});
     // ds.name -> 'myDataSource' and a warning will be issued
     console.warn(
-      'A datasource has a name of %j while a name of %j is specified in ' +
-        'its settings. Please adjust your configuration so these names match. ' +
-        '%j will be assigned as the actual datasource name.',
-      dsName, settings.name, dsName);
+      'A datasource is created with name %j, which is different from the name in settings (%j). ' +
+      'Please adjust your configuration to ensure these names match.',
+      dsName, settings.name);
   }
 
   // Disconnected by default
@@ -450,7 +455,7 @@ DataSource.prototype.setup = function(dsName, settings) {
     } catch (err) {
       if (err.message) {
         err.message = 'Cannot initialize connector ' +
-          JSON.stringify(connector.name || dsName)  + ': ' +
+          JSON.stringify(connectorName)  + ': ' +
           err.message;
       }
       throw err;

--- a/test/datasource.test.js
+++ b/test/datasource.test.js
@@ -46,37 +46,95 @@ describe('DataSource', function() {
     }).should.throw(/expected test error/);
   });
 
+  /**
+   * new DataSource(dsName, settings) without settings.name
+   */
   it('should retain the name assigned to it', function() {
-    var dataSource = new DataSource('ram', {
+    var dataSource = new DataSource('myDataSource', {
       connector: 'memory',
     });
 
-    dataSource.name.should.equal('ram');
+    dataSource.name.should.equal('myDataSource');
   });
 
+  /**
+   * new DataSource(dsName, settings)
+   */
   it('should allow the name assigned to it to take precedence over the settings name', function() {
-    var dataSource = new DataSource('ram', {
-      name: 'temp',
+    var dataSource = new DataSource('myDataSource', {
+      name: 'defaultDataSource',
       connector: 'memory',
     });
 
-    dataSource.name.should.equal('ram');
+    dataSource.name.should.equal('myDataSource');
   });
 
+  /**
+   * new DataSource(settings) with settings.name
+   */
   it('should retain the name from the settings if no name is assigned', function() {
     var dataSource = new DataSource({
-      name: 'temp',
+      name: 'defaultDataSource',
       connector: 'memory',
     });
 
-    dataSource.name.should.equal('temp');
+    dataSource.name.should.equal('defaultDataSource');
   });
 
+  /**
+   * new DataSource(undefined, settings)
+   */
+  it('should retain the name from the settings if name is undefined', function() {
+    var dataSource = new DataSource(undefined, {
+      name: 'defaultDataSource',
+      connector: 'memory',
+    });
+
+    dataSource.name.should.equal('defaultDataSource');
+  });
+
+  /**
+   * new DataSource(settings) without settings.name
+   */
   it('should use the connector name if no name is provided', function() {
     var dataSource = new DataSource({
       connector: 'memory',
     });
 
     dataSource.name.should.equal('memory');
+  });
+
+  /**
+   * new DataSource(connectorInstance)
+   */
+  it('should accept resolved connector', function() {
+    var mockConnector = {
+      name: 'loopback-connector-mock',
+      initialize: function(ds, cb) {
+        ds.connector = mockConnector;
+        return cb(null);
+      },
+    };
+    var dataSource = new DataSource(mockConnector);
+
+    dataSource.name.should.equal('loopback-connector-mock');
+    dataSource.connector.should.equal(mockConnector);
+  });
+
+  /**
+   * new DataSource(dsName, connectorInstance)
+   */
+  it('should accept resolved connector', function() {
+    var mockConnector = {
+      name: 'loopback-connector-mock',
+      initialize: function(ds, cb) {
+        ds.connector = mockConnector;
+        return cb(null);
+      },
+    };
+    var dataSource = new DataSource('myDataSource', mockConnector);
+
+    dataSource.name.should.equal('myDataSource');
+    dataSource.connector.should.equal(mockConnector);
   });
 });


### PR DESCRIPTION
### Description

This is a follow-up to https://github.com/strongloop/loopback-datasource-juggler/pull/1555

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
