### PR TITLE
fix: allow `new DataSource(connector, settings)`

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -89,6 +89,21 @@ var slice = Array.prototype.slice;
  * @property {String} password Database password.
  * @property {String} database Name of the database to use.
  * @property {Boolean} debug Display debugging information. Default is false.
+ *
+ * The constructor allows the following styles:
+ *
+ * 1. new DataSource(dataSourceName, settings). For example:
+ *   - new DataSource('myDataSource', {connector: 'memory'});
+ *   - new DataSource('myDataSource', {name: 'myDataSource', connector: 'memory'});
+ *   - new DataSource('myDataSource', {name: 'anotherDataSource', connector: 'memory'});
+ *
+ * 2. new DataSource(settings). For example:
+ *   - new DataSource({name: 'myDataSource', connector: 'memory'});
+ *   - new DataSource({connector: 'memory'});
+ *
+ * 3. new DataSource(connectorModule, settings). For example:
+ *   - new DataSource(connectorModule, {name: 'myDataSource})
+ *   - new DataSource(connectorModule)
  */
 function DataSource(name, settings, modelBuilder) {
   if (!(this instanceof DataSource)) {
@@ -347,11 +362,17 @@ DataSource.prototype.setup = function(dsName, settings) {
   var dataSource = this;
   var connector;
 
-  // support single settings object
-  if (dsName && typeof dsName === 'object' && !settings) {
-    // setup({name: 'myDataSource', connector: 'memory'})
-    settings = dsName;
-    dsName = undefined;
+  // First argument is an `object`
+  if (dsName && typeof dsName === 'object') {
+    if (settings === undefined) {
+      // setup({name: 'myDataSource', connector: 'memory'})
+      settings = dsName;
+      dsName = undefined;
+    } else {
+      // setup(connector, {name: 'myDataSource', host: 'localhost'})
+      connector = dsName;
+      dsName = undefined;
+    }
   }
 
   if (typeof dsName !== 'string') {

--- a/test/datasource.test.js
+++ b/test/datasource.test.js
@@ -137,4 +137,21 @@ describe('DataSource', function() {
     dataSource.name.should.equal('myDataSource');
     dataSource.connector.should.equal(mockConnector);
   });
+
+  /**
+   * new DataSource(connectorInstance, settings)
+   */
+  it('should accept resolved connector and settings', function() {
+    var mockConnector = {
+      name: 'loopback-connector-mock',
+      initialize: function(ds, cb) {
+        ds.connector = mockConnector;
+        return cb(null);
+      },
+    };
+    var dataSource = new DataSource(mockConnector, {name: 'myDataSource'});
+
+    dataSource.name.should.equal('myDataSource');
+    dataSource.connector.should.equal(mockConnector);
+  });
 });


### PR DESCRIPTION
### Description

One more edge case to keep it backward compatible.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
