### PR TITLE
fixes #1559

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1649,7 +1649,7 @@ function coerceArray(val) {
  * @private
  */
 DataAccessObject._processValue = function processValue(val, operator, DataType, options) {
-  const self = this;
+  var self = this;
   try {
     // Coerce val into an array if it resembles an array-like object
     val = coerceArray(val);
@@ -1658,7 +1658,7 @@ DataAccessObject._processValue = function processValue(val, operator, DataType, 
   }
 
   // Coerce the array items
-  let i;
+  var i;
   if (Array.isArray(val)) {
     for (i = 0; i < val.length; i++) {
       if (val[i] !== null && val[i] !== undefined) {
@@ -1669,7 +1669,7 @@ DataAccessObject._processValue = function processValue(val, operator, DataType, 
     }
   } else {
     if (val != null) {
-      const allowExtendedOperators = self._allowExtendedOperators(options);
+      var allowExtendedOperators = self._allowExtendedOperators(options);
       if (operator === null && val instanceof RegExp) {
         // Do nothing... handle it outside this function
       } else if (operator === 'regexp' && val instanceof RegExp) {

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1711,7 +1711,7 @@ DataAccessObject._coerce = function(where, options) {
   }
 
   var props = self.definition.properties;
-  let processValueCalled;
+  var processValueCalled;
   for (var p in where) {
     processValueCalled = false;
     // Handle logical operators
@@ -1776,7 +1776,7 @@ DataAccessObject._coerce = function(where, options) {
     var operator = null;
     var exp = val;
     if (val.constructor === Object) {
-      let fieldValue = {}; // init the object that will hold all operators present in the object
+      var fieldValue = {}; // init the object that will hold all operators present in the object
       for (var op in operators) {
         if (op in exp) {
           val = exp[op];

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1640,6 +1640,54 @@ function coerceArray(val) {
 }
 
 /*
+ * Process value given in order to be able to call this function for every operator available
+ * @param {*} val The value to process
+ * @param {String} operator
+ * @param {*} DataType The DataType retrieved for the provided value
+ * @param {Object} options
+ * @returns {Object} The processed value
+ * @private
+ */
+DataAccessObject._processValue = function processValue(val, operator, DataType, options) {
+  const self = this;
+  try {
+    // Coerce val into an array if it resembles an array-like object
+    val = coerceArray(val);
+  } catch (e) {
+    // NOOP when not coercable into an array.
+  }
+
+  // Coerce the array items
+  let i;
+  if (Array.isArray(val)) {
+    for (i = 0; i < val.length; i++) {
+      if (val[i] !== null && val[i] !== undefined) {
+        if (!(val[i] instanceof RegExp)) {
+          val[i] = DataType(val[i]);
+        }
+      }
+    }
+  } else {
+    if (val != null) {
+      const allowExtendedOperators = self._allowExtendedOperators(options);
+      if (operator === null && val instanceof RegExp) {
+        // Do nothing... handle it outside this function
+      } else if (operator === 'regexp' && val instanceof RegExp) {
+        // Do not coerce regex literals/objects
+      } else if ((operator === 'like' || operator === 'nlike' ||
+          operator === 'ilike' || operator === 'nilike') && val instanceof RegExp) {
+        // Do not coerce RegExp operator value
+      } else if (allowExtendedOperators && typeof val === 'object') {
+        // Do not coerce object values when extended operators are allowed
+      } else {
+        val = DataType(val);
+      }
+    }
+  }
+  return val;
+};
+
+/*
  * Coerce values based the property types
  * @param {Object} where The where clause
  * @options {Object} [options] Optional options to use.
@@ -1663,7 +1711,9 @@ DataAccessObject._coerce = function(where, options) {
   }
 
   var props = self.definition.properties;
+  let processValueCalled;
   for (var p in where) {
+    processValueCalled = false;
     // Handle logical operators
     if (p === 'and' || p === 'or' || p === 'nor') {
       var clauses = where[p];
@@ -1726,9 +1776,10 @@ DataAccessObject._coerce = function(where, options) {
     var operator = null;
     var exp = val;
     if (val.constructor === Object) {
+      let fieldValue = {}; // init the object that will hold all operators present in the object
       for (var op in operators) {
-        if (op in val) {
-          val = val[op];
+        if (op in exp) {
+          val = exp[op];
           operator = op;
           switch (operator) {
             case 'inq':
@@ -1773,54 +1824,29 @@ DataAccessObject._coerce = function(where, options) {
               }
               break;
           }
-          break;
-        }
-      }
-    }
-
-    try {
-      // Coerce val into an array if it resembles an array-like object
-      val = coerceArray(val);
-    } catch (e) {
-      // NOOP when not coercable into an array.
-    }
-
-    // Coerce the array items
-    if (Array.isArray(val)) {
-      for (var i = 0; i < val.length; i++) {
-        if (val[i] !== null && val[i] !== undefined) {
-          if (!(val[i] instanceof RegExp)) {
-            val[i] = DataType(val[i]);
+          // Continue building field operator object
+          if (operator === null && val instanceof RegExp) {
+            // Normalize {name: /A/} to {name: {regexp: /A/}}
+            operator = 'regexp';
+          }
+          val = self._processValue(val, operator, DataType, options);
+          processValueCalled = true;
+          // Rebuild {property: {operator: value}}
+          if (operator) {
+            fieldValue[operator] = val;
           }
         }
-      }
-    } else {
-      if (val != null) {
-        var allowExtendedOperators = self._allowExtendedOperators(options);
-        if (operator === null && val instanceof RegExp) {
-          // Normalize {name: /A/} to {name: {regexp: /A/}}
-          operator = 'regexp';
-        } else if (operator === 'regexp' && val instanceof RegExp) {
-          // Do not coerce regex literals/objects
-        } else if ((operator === 'like' || operator === 'nlike' ||
-            operator === 'ilike' || operator === 'nilike') && val instanceof RegExp) {
-          // Do not coerce RegExp operator value
-        } else if (allowExtendedOperators && typeof val === 'object') {
-          // Do not coerce object values when extended operators are allowed
-        } else {
-          val = DataType(val);
-        }
-      }
-    }
-    // Rebuild {property: {operator: value}}
-    if (operator) {
-      var value = {};
-      value[operator] = val;
+      } // end of browsing operators in expression
       if (exp.options) {
         // Keep options for operators
-        value.options = exp.options;
+        fieldValue.options = exp.options;
       }
-      val = value;
+      if (Object.keys(fieldValue).length > 0) { // Check that fieldValue was actually used
+        val = fieldValue;
+      }
+    }
+    if (!processValueCalled) {
+      val = self._processValue(val, operator, DataType, options);
     }
     where[p] = val;
   }

--- a/test/loopback-dl.test.js
+++ b/test/loopback-dl.test.js
@@ -1668,6 +1668,14 @@ describe('DataAccessObject', function() {
     (function() { model._normalize({filter: {x: undefined}}); }).should.throw(/`undefined` in query/);
   });
 
+  it('should correctly handle multiple operators on single property', function() {
+    const date1 = new Date(Date.now() - 10);
+    const date2 = new Date(Date.now());
+    filter = model._normalize({where: {date: {gte: date1.toISOString(), lte: date2.toISOString()}}});
+    // Check both operators kept and converted to date types
+    assert.deepEqual(filter, {where: {date: {gte: date1, lte: date2}}});
+  });
+
   it('does not coerce GeoPoint', function() {
     where = model._coerce({location: {near: {lng: 10, lat: 20}, maxDistance: 20}});
     assert.deepEqual(where, {location: {near: {lng: 10, lat: 20}, maxDistance: 20}});

--- a/test/loopback-dl.test.js
+++ b/test/loopback-dl.test.js
@@ -1669,8 +1669,8 @@ describe('DataAccessObject', function() {
   });
 
   it('should correctly handle multiple operators on single property', function() {
-    const date1 = new Date(Date.now() - 10);
-    const date2 = new Date(Date.now());
+    var date1 = new Date(Date.now() - 10);
+    var date2 = new Date(Date.now());
     filter = model._normalize({where: {date: {gte: date1.toISOString(), lte: date2.toISOString()}}});
     // Check both operators kept and converted to date types
     assert.deepEqual(filter, {where: {date: {gte: date1, lte: date2}}});


### PR DESCRIPTION
### Description
Allow single field in filter to hold more than one operators at the same time. 
Flow changed a little and an extra function created in order to reuse code needed in different places.
Not sure if this behavior complies with loopback logic of filters... I just faced this incompatibility with MongoDB querying where this behavior is supported.

Also a pull request must be submitted to looback-connector-mongodb because this is also missed there...
#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <https://github.com/strongloop/loopback-datasource-juggler/issues/1559>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
