### PR TITLE
Pass on options in embedded model destroyById() and destroyAll()

### DIFF
--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -2832,7 +2832,7 @@ EmbedsMany.prototype.destroyById = function(fkId, options, cb) {
       if (index > -1) embeddedList.splice(index, 1);
       if (typeof cb !== 'function') return;
       modelInstance.updateAttribute(propertyName,
-        embeddedList, function(err) {
+        embeddedList, options, function(err) {
           if (err) return cb(err);
           modelTo.notifyObserversOf('after delete', context, function(err) {
             cb(err);
@@ -2871,7 +2871,7 @@ EmbedsMany.prototype.destroyAll = function(where, options, cb) {
 
   if (typeof cb === 'function') {
     modelInstance.updateAttribute(propertyName,
-      embeddedList, function(err) {
+      embeddedList, options, function(err) {
         cb(err);
       });
   } else {


### PR DESCRIPTION
The options argument isn't passed on to `updateAttribute` and thus options isn't present in subsequent operational hooks.

### Description


#### Related issues

- connect to #1525

### Checklist

- [ ] New tests added or existing tests modified to cover all changes
- [X] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
