### PR TITLE
[ FEATURE ? ] Allow multiple observer

### DIFF
--- a/lib/observer.js
+++ b/lib/observer.js
@@ -154,7 +154,7 @@ ObserverMixin.notifyObserversOf = function(operation, context, callback) {
     if (err) return callback(err, context);
     if (!observers || !observers.length) return callback(null, context);
 
-    async.eachSeries(
+    async.mapSeries(
       observers,
       function notifySingleObserver(fn, next) {
         var retval = fn(context, next);


### PR DESCRIPTION

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Description
Hi, 
if I write two observer on the same Model only the first is executed
> Input
```js
Model.observe('before save', (ctx, next) => {
    console.log('Model before save hook 1 ', ctx.instance, ctx.hookState);
    ctx.hookState.hook1 = true;
    ctx.instance.hook1 = true;
    next()
  });

  Model.observe('before save', (ctx, next) => {
    console.log('Model before save hook 2', ctx.instance, ctx.hookState);
    ctx.hookState.hook2 = true
    ctx.instance.hook2 = true
    next()
  });
```
> Output
```sh
Model before save hook 1  { content: 'foo', date: 2018-03-16T00:29:46.010Z } {}
```


#### Related issues
Update eachSeries by mapSeries allow me to create multiple same oberver for the same model, 
Multiple observer is usefull when i create mixins using Model.observe :)
### Input

```js
Model.observe('before save', (ctx, next) => {
    console.log('Model before save hook 1 ', ctx.instance, ctx.hookState);
    ctx.hookState.hook1 = true;
    ctx.instance.hook1 = true;
    next()
  });

  Model.observe('before save', (ctx, next) => {
    console.log('Model before save hook 2', ctx.instance, ctx.hookState);
    ctx.hookState.hook2 = true
    ctx.instance.hook2 = true
    next()
  });

  Model.observe('before save', (ctx, next) => {
    console.log('Model before save hook 3', ctx.instance, ctx.hookState);
    ctx.hookState.hook3 = true;
    ctx.instance.hook3 = true;
    next();
  });

Model.observe('after save', (ctx, next) => {
    console.log('Model after save hook ', ctx.instance, ctx.hookState);
    next();
  });
```

### Output
```sh
Model before save hook 1  { content: 'foo', date: 2018-03-16T00:29:46.010Z } {}
Model before save hook 2 { content: 'foo', date: 2018-03-16T00:29:46.010Z } { hook1: true }
Model before save hook 3 { content: 'foo', date: 2018-03-16T00:29:46.010Z } { hook1: true, hook2: true }
Model after save hook { content: 'foo',  date: 2018-03-16T00:29:46.010Z,  id: 5aab0ffa4175eb3fc479c3d0 } { hook1: true, hook2: true, hook3: true }
```

but i don't understand why ctx.instance in after save not contain { hook1: true, hook2: true, hook3: true } ? but the data it's been saved in database !

Thanks for your awesome work !


### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
