### PR TITLE
Solves issues with node v8 compatability as well as fixes a test that…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ language: node_js
 node_js:
   - "4"
   - "6"
+  - "8"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "posttest": "npm run lint"
   },
   "engines": {
-    "node": ">= 4 <= 6"
+    "node": ">=4.0.0"
   },
   "devDependencies": {
     "async-iterators": "^0.2.2",

--- a/test/loopback-dl.test.js
+++ b/test/loopback-dl.test.js
@@ -1865,7 +1865,7 @@ describe('ModelBuilder processing json files', function() {
         count++;
       }
     }
-    assert.equal(count, 7); // Please note there is an injected id from User prototype
+    assert.equal(count, 6); // Please note that customerId replaces an injected id
     assert.equal(Object.keys(customer.toObject()).filter(function(k) {
       // Remove internal properties
       return k.indexOf('__') === -1;


### PR DESCRIPTION
… incorrectly expects id injection #1544 #1545

### Description

Add support for v8 in travis.yml and matches engines specific of loopback 2.x repo.
Because customerId was injected, idInjection is set to false in the model-builder and as a result
the remaining property count is 6, not 7.

#### Related issues

 #1544 #1545

### Checklist


- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
