### PR TITLE
feat: remove a Model from all registries

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -801,6 +801,16 @@ DataSource.prototype.define = function defineClass(className, properties, settin
 };
 
 /**
+ * Remove a model from the registry.
+ *
+ * @param {String} modelName
+ */
+DataSource.prototype.deleteModelByName = function(modelName) {
+  this.modelBuilder.deleteModelByName(modelName);
+  delete this.connector._models[modelName];
+};
+
+/**
  * Mixin DataAccessObject methods.
  *
  * @param {Function} ModelCtor The model constructor

--- a/lib/model-builder.js
+++ b/lib/model-builder.js
@@ -806,6 +806,16 @@ ModelBuilder.prototype.copyModel = function copyModel(Master) {
   return Slave;
 };
 
+/**
+ * Remove a model from the registry.
+ *
+ * @param {String} modelName
+ */
+ModelBuilder.prototype.deleteModelByName = function(modelName) {
+  delete this.models[modelName];
+  delete this.definitions[modelName];
+};
+
 /*!
  * Define hidden property
  */

--- a/test/datasource.test.js
+++ b/test/datasource.test.js
@@ -154,4 +154,36 @@ describe('DataSource', function() {
     dataSource.name.should.equal('myDataSource');
     dataSource.connector.should.equal(mockConnector);
   });
+
+  describe('deleteModelByName()', () => {
+    it('removes the model from ModelBuilder registry', () => {
+      const ds = new DataSource('ds', {connector: 'memory'});
+
+      ds.createModel('TestModel');
+      Object.keys(ds.modelBuilder.models)
+        .should.containEql('TestModel');
+      Object.keys(ds.modelBuilder.definitions)
+        .should.containEql('TestModel');
+
+      ds.deleteModelByName('TestModel');
+
+      Object.keys(ds.modelBuilder.models)
+        .should.not.containEql('TestModel');
+      Object.keys(ds.modelBuilder.definitions)
+        .should.not.containEql('TestModel');
+    });
+
+    it('removes the model from connector registry', () => {
+      const ds = new DataSource('ds', {connector: 'memory'});
+
+      ds.createModel('TestModel');
+      Object.keys(ds.connector._models)
+        .should.containEql('TestModel');
+
+      ds.deleteModelByName('TestModel');
+
+      Object.keys(ds.connector._models)
+        .should.not.containEql('TestModel');
+    });
+  });
 });


### PR DESCRIPTION
### Description

Add API allowing consumers (e.g. LoopBack) to remove a Model from all
juggler registries:
 - ModelBuilder's models
 - ModelBuilder's definitions
 - Connector registry of models

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to strongloop/strong-remoting#444

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)