### PR TITLE
Polyfill Number.isFinite() to support PhantomJS

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -451,6 +451,10 @@ function deepMergeProperty(base, extras) {
   return mergedProperty;
 }
 
+const numberIsFinite = Number.isFinite || function(value) {
+  return typeof value === 'number' && isFinite(value);
+};
+
 /**
  * Adds a property __rank to array elements of type object {}
  * If an inner element already has the __rank property it is not altered
@@ -461,7 +465,7 @@ function deepMergeProperty(base, extras) {
  * @return rankedArray The original array with newly ranked elements
  */
 function rankArrayElements(array, rank) {
-  if (!Array.isArray(array) || !Number.isFinite(rank))
+  if (!Array.isArray(array) || !numberIsFinite(rank))
     return array;
 
   array.forEach(function(el) {


### PR DESCRIPTION
### Description

When running `npm test` of `loopback` locally, I noticed a test failure when running on PhantomJS browser:

```
PhantomJS 2.1.1 (Mac OS X 0.0.0) app 
  "before each" hook for "can be read via `app.get(key)`" FAILED
	undefined is not a constructor (evaluating 'Number.isFinite(rank)')
```

This change is fixing the problem by adding a polyfill for `Number.isFinite()` function. The API was introduced as part of ES6/ES2015 spec and is not supported by PhantomJS.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- n/a

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)