### PR TITLE
fix: normalize include with boolean or number

### DIFF
--- a/lib/include.js
+++ b/lib/include.js
@@ -16,6 +16,8 @@ const uniq = utils.uniq;
 const idName = utils.idName;
 const debug = require('debug')('loopback:include');
 
+const DISALLOWED_TYPES = ['boolean', 'number', 'symbol', 'function'];
+
 /*!
  * Normalize the include to be an array
  * @param include
@@ -47,6 +49,9 @@ function normalizeInclude(include) {
       newInclude = newInclude.concat(subIncludes);
     }
     return newInclude;
+  } else if (DISALLOWED_TYPES.includes(typeof include)) {
+    debug('Ignoring invalid "include" value of type %s:', typeof include, include);
+    return [];
   } else {
     return include;
   }

--- a/test/include.test.js
+++ b/test/include.test.js
@@ -1254,6 +1254,43 @@ describe('include', function() {
     });
   });
 
+  it('should not throw on fetch User if include is boolean equals true', function(done) {
+    User.find({include: true}, function(err, users) {
+      if (err) return done(err);
+      should.exist(users);
+      users.should.not.be.empty();
+      done();
+    });
+  });
+
+  it('should not throw on fetch User if include is number', function(done) {
+    User.find({include: 1}, function(err, users) {
+      if (err) return done(err);
+      should.exist(users);
+      users.should.not.be.empty();
+      done();
+    });
+  });
+
+  it('should not throw on fetch User if include is symbol', function(done) {
+    User.find({include: Symbol('include')}, function(err, users) {
+      if (err) return done(err);
+      should.exist(users);
+      users.should.not.be.empty();
+      done();
+    });
+  });
+
+  it('should not throw on fetch User if include is function', function(done) {
+    const include = () => {};
+    User.find({include}, function(err, users) {
+      if (err) return done(err);
+      should.exist(users);
+      users.should.not.be.empty();
+      done();
+    });
+  });
+
   // Not implemented correctly, see: loopback-datasource-juggler/issues/166
   // fixed by DB optimization
   it('should support include scope on hasAndBelongsToMany', function(done) {


### PR DESCRIPTION
### Description

- On `{include: true}` or `{include: 1}` the lib crashes with
  "TypeError: includes.forEach is not a function".
- Fix by checking for boolean and number type and return empty array.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to #1580 {include: true} or {include: 1} throws TypeError

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
