### PR TITLE
Add support for Node.js 8.x and 10.x, drop 4.x [2.x]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - "4"
   - "6"
+  - "8"
+  - "10"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "posttest": "npm run lint"
   },
   "engines": {
-    "node": ">= 4 <= 6"
+    "node": ">=6"
   },
   "devDependencies": {
     "async-iterators": "^0.2.2",

--- a/test/loopback-dl.test.js
+++ b/test/loopback-dl.test.js
@@ -1852,24 +1852,15 @@ describe('ModelBuilder processing json files', function() {
     customer.should.have.property('bio', undefined);
 
     // The properties are defined at prototype level
-    assert.equal(Object.keys(customer).filter(function(k) {
+    should(Object.keys(customer).filter(function(k) {
       // Remove internal properties
       return k.indexOf('__') === -1;
-    }).length, 0);
-    var count = 0;
-    for (var p in customer) {
-      if (p.indexOf('__') === 0) {
-        continue;
-      }
-      if (typeof customer[p] !== 'function') {
-        count++;
-      }
-    }
-    assert.equal(count, 7); // Please note there is an injected id from User prototype
-    assert.equal(Object.keys(customer.toObject()).filter(function(k) {
+    })).have.length(0);
+
+    should(Object.keys(customer.toObject()).filter(function(k) {
       // Remove internal properties
       return k.indexOf('__') === -1;
-    }).length, 6);
+    })).have.length(6);
 
     done(null, customer);
   });


### PR DESCRIPTION
This builts on top of and supersedes #1545, please read the discussion there to learn more about the problems of the test that I am modifying in this pull request.

 - Support for Node.js 8.x and 10.x is added because it's pretty much for free and people are already using LB 2.x on those versions
 - Support for Node.js 4.x is dropped because it's no longer supported by the Node.js project.

cc @billinghamj  @joe-at-startupmedia 
#
### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)