### PR TITLE
Correct syntax error in dao.js script for persist hook call in updateAttributes and replaceById methods.

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -3086,6 +3086,8 @@ DataAccessObject.replaceById = function(id, data, options, cb) {
           if (err) return cb(err);
           if (typeof connector.generateContextData === 'function') {
             context = connector.generateContextData(context, data);
+          } else {
+            context.data = data;
           }
           var ctx = {
             Model: Model,
@@ -3279,6 +3281,8 @@ function(data, options, cb) {
               if (err) return cb(err);
               if (typeof connector.generateContextData === 'function') {
                 context = connector.generateContextData(context, data);
+              } else {
+                context.data = data;
               }
               var ctx = {
                 Model: Model,

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -3132,7 +3132,7 @@ DataAccessObject.replaceById = function(id, data, options, cb) {
         };
         Model.notifyObserversOf('persist', ctx, function(err) {
           if (err) return cb(err);
-          invokeConnectorMethod(connector, 'replaceById', Model, [id, Model._forDB(context.data)],
+          invokeConnectorMethod(connector, 'replaceById', Model, [id, Model._forDB(ctx.data)],
             options, replaceCallback);
         });
       }
@@ -3330,7 +3330,7 @@ function(data, options, cb) {
             Model.notifyObserversOf('persist', ctx, function(err) {
               if (err) return cb(err);
               invokeConnectorMethod(connector, 'updateAttributes', Model,
-                [getIdValue(Model, inst), Model._forDB(context.data)],
+                [getIdValue(Model, inst), Model._forDB(ctx.data)],
                 options, updateAttributesCallback);
             });
           }, data, cb);


### PR DESCRIPTION
### Description

There is a syntaxe error in updateAttributes and replaceById methods for the Model.notifyObserversOf persist call.

The context past to the Model._forDB() method are not the context that are return by the persist hook.

There is a mixup between the variable 'ctx' returned by the 'persist' hook and the variable 'context' that correspond to the above code block.

This syntax error prevent any modification of the data in the 'persist' hook from being taken into account when updateAttributes and replaceById methods are used. 

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
