### PR TITLE
Fix tests to ensure upward compatibility w/ should@10

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1769,7 +1769,7 @@ DataAccessObject._coerce = function(where, options) {
               val = utils.toRegExp(val);
               if (val instanceof Error) {
                 val.statusCode = 400;
-                throw err;
+                throw val;
               }
               break;
           }

--- a/lib/list.js
+++ b/lib/list.js
@@ -96,6 +96,19 @@ List.prototype.toObject = function(onlySchema, removeHidden, removeProtected) {
   return items;
 };
 
+/**
+ * Convert itself to a plain array.
+ *
+ * Some modules such as `should` checks prototype for comparison
+ */
+List.prototype.toArray = function() {
+  var items = [];
+  this.forEach(function(item) {
+    items.push(item);
+  });
+  return items;
+};
+
 List.prototype.toJSON = function() {
   return this.toObject(true);
 };

--- a/test/basic-querying.test.js
+++ b/test/basic-querying.test.js
@@ -1032,13 +1032,12 @@ describe('basic-querying', function() {
     it('should return an error for invalid data types', function(done) {
       // `undefined` is not tested because the `removeUndefined` function
       // in `lib/dao.js` removes it before coercion
-      invalidDataTypes.forEach(function(invalidDataType) {
-        User.find({where: {name: {regexp: invalidDataType}}}, function(err,
-            users) {
+      async.each(invalidDataTypes, function(v, cb) {
+        User.find({where: {name: {regexp: v}}}, function(err, users) {
           should.exist(err);
+          cb();
         });
-      });
-      done();
+      }, done);
     });
   });
 });

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -4418,7 +4418,7 @@ describe('relations', function() {
       p.passport.toObject().should.eql({name: 'Anonymous'});
       p.passportItem().should.equal(p.passport);
       p.passportItem(function(err, passport) {
-        err.should.not.exist();
+        should.not.exist(err);
         passport.should.equal(p.passport);
       });
     });
@@ -6040,8 +6040,8 @@ describe('relations', function() {
       Category.findOne(function(err, cat) {
         cat.jobs.reverse(function(err, ids) {
           var expected = [job3.id, job2.id];
-          ids.should.eql(expected);
-          cat.jobIds.should.eql(expected);
+          ids.toArray().should.eql(expected);
+          cat.jobIds.toArray().should.eql(expected);
           done();
         });
       });
@@ -6152,7 +6152,7 @@ describe('relations', function() {
     'should find items on scope with promises', function(done) {
       Category.findOne()
       .then(function(cat) {
-        cat.jobIds.should.eql([job2.id]);
+        cat.jobIds.toArray().should.eql([job2.id]);
         return cat.jobs.find();
       })
       .then(function(jobs) {
@@ -6352,8 +6352,8 @@ describe('relations', function() {
         return cat.jobs.reverse()
         .then(function(ids) {
           var expected = [job3.id, job2.id];
-          ids.should.eql(expected);
-          cat.jobIds.should.eql(expected);
+          ids.toArray().should.eql(expected);
+          cat.jobIds.toArray().should.eql(expected);
           done();
         });
       })
@@ -6382,9 +6382,9 @@ describe('relations', function() {
         .then(function() {
           var expected = [job3.id];
           if (connectorCapabilities.adhocSort !== false) {
-            cat.jobIds.should.eql(expected);
+            cat.jobIds.toArray().should.eql(expected);
           } else {
-            cat.jobIds.should.containDeep(expected);
+            cat.jobIds.toArray().should.containDeep(expected);
           }
           return Job.exists(job2.id);
         })

--- a/test/validations.test.js
+++ b/test/validations.test.js
@@ -848,7 +848,7 @@ describe('validations', function() {
       User.validatesFormatOf('name', {with: /[a-z][A-Z]*$/, message: CUSTOM_MESSAGE});
       var u = new User({name: 'invalid name string 123'});
       u.isValid().should.be.false();
-      u.errors.should.eql({
+      u.errors.should.containEql({
         name: [CUSTOM_MESSAGE],
         codes: {
           name: ['format'],
@@ -972,14 +972,14 @@ describe('validations', function() {
       User.validatesNumericalityOf('age');
       var user = new User({age: 'notanumber'});
       user.isValid().should.be.false();
-      user.errors.should.eql({age: ['is not a number']});
+      user.errors.should.containEql({age: ['is not a number']});
     });
 
     it('fails when given undefined values', function() {
       User.validatesNumericalityOf('age');
       var user = new User({});
       user.isValid().should.be.false();
-      user.errors.should.eql({age: ['is blank']});
+      user.errors.should.containEql({age: ['is blank']});
     });
 
     it('skips undefined values when allowBlank option is true', function() {
@@ -992,14 +992,14 @@ describe('validations', function() {
       User.validatesNumericalityOf('age', {allowBlank: true});
       var user = new User({age: 'test'});
       user.isValid().should.be.false();
-      user.errors.should.eql({age: ['is not a number']});
+      user.errors.should.containEql({age: ['is not a number']});
     });
 
     it('fails when given null values', function() {
       User.validatesNumericalityOf('age');
       var user = new User({age: null});
       user.isValid().should.be.false();
-      user.errors.should.eql({age: ['is null']});
+      user.errors.should.containEql({age: ['is null']});
     });
 
     it('passes when given null values when allowNull option is true', function() {
@@ -1353,7 +1353,7 @@ describe('validations', function() {
       });
       var u = new User({email: 'hello'});
       Boolean(u.isValid()).should.be.false();
-      u.errors.should.eql({email: ['Cannot be `hello`']});
+      u.errors.should.containEql({email: ['Cannot be `hello`']});
       u.errors.codes.should.eql({email: ['invalid-email']});
     });
 
@@ -1470,7 +1470,7 @@ describe('validations', function() {
       User.validatesDateOf('updatedAt');
       var u = new User({updatedAt: 'invalid date string'});
       u.isValid().should.not.be.true();
-      u.errors.should.eql({
+      u.errors.should.containEql({
         updatedAt: ['is not a valid date'],
         codes: {
           updatedAt: ['date'],
@@ -1494,7 +1494,7 @@ describe('validations', function() {
       });
       var u = new AnotherUser({updatedAt: 'invalid date string'});
       u.isValid().should.not.be.true();
-      u.errors.should.eql({
+      u.errors.should.containEql({
         updatedAt: ['is not a valid date'],
         codes: {
           updatedAt: ['date'],
@@ -1507,7 +1507,7 @@ describe('validations', function() {
       User.validatesDateOf('updatedAt', {message: CUSTOM_MESSAGE});
       var u = new User({updatedAt: 'invalid date string'});
       u.isValid().should.not.be.true();
-      u.errors.should.eql({
+      u.errors.should.containEql({
         updatedAt: [CUSTOM_MESSAGE],
         codes: {
           updatedAt: ['date'],


### PR DESCRIPTION
### Description

Fix code and tests to be compatible with `should@10.x` which checks prototypes for comparison.
The extra step exposes some issues in our code:

- Invalid value for `regexp` operator error is not thrown correctly
- List (extends from Array) cannot be compared against plain array
- Validation errors 

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
