### PR TITLE
Fix DateString throwing error

### DIFF
--- a/lib/date-string.js
+++ b/lib/date-string.js
@@ -53,6 +53,13 @@ function DateString(value) {
     return new DateString(value);
   }
 
+  if (value instanceof DateString) {
+    return Object.assign(
+      new DateString(value.when),
+      value
+    );
+  }
+
   if (typeof(value) !== 'string') {
     throw new Error('Input must be a string');
   }

--- a/test/date-string.test.js
+++ b/test/date-string.test.js
@@ -25,6 +25,16 @@ describe('DateString', function() {
       date.toString().should.eql(theDate);
     });
 
+    it('should support a previous DateString object', function() {
+      var theDate = '2015-01-01';
+      var oldInstance = new DateString(theDate);
+      var newInstance = new DateString(oldInstance);
+      oldInstance.should.not.equal(newInstance);
+      newInstance.should.not.eql(null);
+      newInstance.when.should.eql(theDate);
+      newInstance.toString().should.eql(theDate);
+    });
+
     testValidInput('should allow date with time', '2015-01-01 02:00:00');
     testValidInput('should allow full UTC datetime', '2015-06-30T20:00:00.000Z');
     testValidInput('should allow date with UTC offset', '2015-01-01 20:00:00 GMT-5');


### PR DESCRIPTION
### Description
The issue happens when using PersistedModel.upsert or PersistedModel.upsertWithWhere methods - that for some reason instance values twice - with model that uses DateString type

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)