### PR TITLE
Fix stalebot config to ignore "good first issue"

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -9,6 +9,7 @@ exemptLabels:
   - critical
   - p1
   - major
+  - "good first issue"
 # Label to use when marking an issue as stale
 staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
Prevent stalebot from auto-closing issues labelled as [good first issue
](https://github.com/strongloop/loopback-datasource-juggler/labels/good%20first%20issue). These issues are task for people who would like to start contributing to juggler, they should not be closed regardless of how long they have been opened.