### PR TITLE
Fix type definitions for PersistedModel API

### DIFF
--- a/types/common.d.ts
+++ b/types/common.d.ts
@@ -18,7 +18,7 @@ export type Options = AnyObject<any>;
 /**
  * Type alias for Node.js callback functions
  */
-export type Callback<T = any> = (err: any, result?: T) => void;
+export type Callback<T = any> = (err?: Error | null, result?: T) => void;
 
 /**
  * Return export type for promisified Node.js async methods.

--- a/types/common.d.ts
+++ b/types/common.d.ts
@@ -18,7 +18,7 @@ export type Options = AnyObject<any>;
 /**
  * Type alias for Node.js callback functions
  */
-export type Callback<T = any> = (err?: Error | null, result?: T) => void;
+export type Callback<T = any> = (err?: any | null, result?: T) => void;
 
 /**
  * Return export type for promisified Node.js async methods.

--- a/types/model.d.ts
+++ b/types/model.d.ts
@@ -246,4 +246,4 @@ export declare class ModelBuilder extends EventEmitter {
  * Union export type for model instance or plain object representing the model
  * instance
  */
-export type ModelData<T extends ModelBase = ModelBase> = T | AnyObject;
+export type ModelData<T extends ModelBase = ModelBase> = T | Partial<T>;

--- a/types/model.d.ts
+++ b/types/model.d.ts
@@ -243,7 +243,13 @@ export declare class ModelBuilder extends EventEmitter {
 }
 
 /**
+ * An extension of the built-in Partial<T> type which allows partial values
+ * in deeply nested properties too.
+ */
+export type DeepPartial<T> = { [P in keyof T]?: DeepPartial<T[P]>; };
+
+/**
  * Union export type for model instance or plain object representing the model
  * instance
  */
-export type ModelData<T extends ModelBase = ModelBase> = T | Partial<T>;
+export type ModelData<T extends ModelBase = ModelBase> = T | DeepPartial<T>;

--- a/types/persisted-model.d.ts
+++ b/types/persisted-model.d.ts
@@ -38,8 +38,14 @@ export declare class PersistedModel extends ModelBase {
   static create(
     data: PersistedData,
     options?: Options,
-    callback?: Callback<PersistedData>,
-  ): PromiseOrVoid<PersistedData>;
+    callback?: Callback<PersistedModel>,
+  ): PromiseOrVoid<PersistedModel>;
+
+  static create(
+    data: PersistedData[],
+    options?: Options,
+    callback?: Callback<PersistedModel[]>,
+  ): PromiseOrVoid<PersistedModel[]>;
 
   /**
    * Update or insert a model instance
@@ -51,20 +57,20 @@ export declare class PersistedModel extends ModelBase {
   static upsert(
     data: PersistedData,
     options?: Options,
-    callback?: Callback<PersistedData>,
-  ): PromiseOrVoid<PersistedData>;
+    callback?: Callback<PersistedModel>,
+  ): PromiseOrVoid<PersistedModel>;
 
   static updateOrCreate(
     data: PersistedData,
     options?: Options,
-    callback?: Callback<PersistedData>,
-  ): PromiseOrVoid<PersistedData>;
+    callback?: Callback<PersistedModel>,
+  ): PromiseOrVoid<PersistedModel>;
 
   static patchOrCreate(
     data: PersistedData,
     options?: Options,
-    callback?: Callback<PersistedData>,
-  ): PromiseOrVoid<PersistedData>;
+    callback?: Callback<PersistedModel>,
+  ): PromiseOrVoid<PersistedModel>;
 
   /**
    * Update or insert a model instance based on the search criteria.
@@ -86,15 +92,15 @@ export declare class PersistedModel extends ModelBase {
     where: Where,
     data: PersistedData,
     options?: Options,
-    callback?: Callback<PersistedData>,
-  ): PromiseOrVoid<PersistedData>;
+    callback?: Callback<PersistedModel>,
+  ): PromiseOrVoid<PersistedModel>;
 
   static patchOrCreateWithWhere(
     where: Where,
     data: PersistedData,
     options?: Options,
-    callback?: Callback<PersistedData>,
-  ): PromiseOrVoid<PersistedData>;
+    callback?: Callback<PersistedModel>,
+  ): PromiseOrVoid<PersistedModel>;
 
   /**
    * Replace or insert a model instance; replace existing record if one is found,
@@ -110,8 +116,8 @@ export declare class PersistedModel extends ModelBase {
   static replaceOrCreate(
     data: PersistedData,
     options?: Options,
-    callback?: Callback<PersistedData>,
-  ): PromiseOrVoid<PersistedData>;
+    callback?: Callback<PersistedModel>,
+  ): PromiseOrVoid<PersistedModel>;
 
   /**
    * Finds one record matching the optional filter object. If not found, creates
@@ -147,8 +153,8 @@ export declare class PersistedModel extends ModelBase {
     filter: Filter,
     data: PersistedData,
     options?: Options,
-    callback?: Callback<PersistedData>,
-  ): PromiseOrVoid<PersistedData>;
+    callback?: Callback<PersistedModel>,
+  ): PromiseOrVoid<PersistedModel>;
 
   /**
    * Check whether a model instance exists in database.
@@ -183,7 +189,7 @@ export declare class PersistedModel extends ModelBase {
     filter?: Filter,
     options?: Options,
     callback?: Callback<boolean>,
-  ): PromiseOrVoid<PersistedData>;
+  ): PromiseOrVoid<PersistedModel>;
 
   /**
    * Find all model instances that match `filter` specification.
@@ -215,8 +221,8 @@ export declare class PersistedModel extends ModelBase {
   static find(
     filter?: Filter,
     options?: Options,
-    callback?: Callback<PersistedData>,
-  ): PromiseOrVoid<PersistedData[]>;
+    callback?: Callback<PersistedModel>,
+  ): PromiseOrVoid<PersistedModel[]>;
 
   /**
    * Find one model instance that matches `filter` specification.
@@ -246,8 +252,8 @@ export declare class PersistedModel extends ModelBase {
   static findOne(
     filter?: Filter,
     options?: Options,
-    callback?: Callback<PersistedData>,
-  ): PromiseOrVoid<PersistedData>;
+    callback?: Callback<PersistedModel>,
+  ): PromiseOrVoid<PersistedModel>;
 
   /**
    * Destroy all model instances that match the optional `where` specification.
@@ -362,8 +368,8 @@ export declare class PersistedModel extends ModelBase {
     id: any,
     data: PersistedData,
     options?: Options,
-    callback?: Callback<PersistedData>,
-  ): PromiseOrVoid<PersistedData>;
+    callback?: Callback<PersistedModel>,
+  ): PromiseOrVoid<PersistedModel>;
 
   /**
    * Return the number of records that match the optional "where" filter.
@@ -479,8 +485,8 @@ export declare class PersistedModel extends ModelBase {
    */
   reload(
     options?: Options,
-    callback?: Callback<PersistedData>,
-  ): PromiseOrVoid<PersistedData>;
+    callback?: Callback<PersistedModel>,
+  ): PromiseOrVoid<PersistedModel>;
 
   /**
    * Set the correct `id` property for the `PersistedModel`. Uses the `setId` method if the model is attached to


### PR DESCRIPTION
- Callback's first argument is an optional Error now. Was: required `any`.

- PersistedModel methods return `PersistedModel` now. Before this change, methods were returning `PersistedData` (`PersistedModel | AnyObject`). The problem with `AnyObject` is that it does not contain any `PersistedModel` instance data and cannot be assigned to functions expecting `Partial<PersistedModel>`. As a result, consumers of this API were forced to either cast the result to `PersistedModel` (which feels wrong) or deal with the `AnyObject` case (which never happen at runtime).

- Fix definition of `ModelData<T>` to `T | Partial<T>`. Before this change, `ModelData` allowed any values not related to the actual model at all, for example arrays.

These problems were discovered while working on https://github.com/strongloop/loopback-next/pull/1475. The fixes presented in this pull request seem to be backwards compatible, at least as far as loopback-next tests are concerned.