### PR TITLE
Fix "manipulation" tests to correctly handle databases returning null instead of undefined

### DIFF
--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -1109,8 +1109,8 @@ describe('manipulation', function() {
                 p.id.should.eql(created.id);
                 p.should.not.have.property('_id');
                 p.title.should.equal('b');
-                p.should.have.property('content', undefined);
-                p.should.have.property('comments', undefined);
+                p.should.have.property('content').be.oneOf(null, undefined);
+                p.should.have.property('comments').be.oneOf(null, undefined);
 
                 return Post.findById(created.id)
                   .then(function(p) {
@@ -1140,8 +1140,8 @@ describe('manipulation', function() {
                 p.id.should.eql(created.id);
                 p.should.not.have.property('_id');
                 p.title.should.equal('b');
-                p.should.have.property('content', undefined);
-                p.should.have.property('comments', undefined);
+                p.should.have.property('content').be.oneOf(null, undefined);
+                p.should.have.property('comments').be.oneOf(null, undefined);
 
                 return Post.findById(created.id)
                   .then(function(p) {
@@ -1169,8 +1169,8 @@ describe('manipulation', function() {
               p.id.should.eql(post.id);
               p.should.not.have.property('_id');
               p.title.should.equal('b');
-              p.should.have.property('content', undefined);
-              p.should.have.property('comments', undefined);
+              p.should.have.property('content').be.oneOf(null, undefined);
+              p.should.have.property('comments').be.oneOf(null, undefined);
 
               Post.findById(post.id, function(err, p) {
                 if (err) return done(err);
@@ -1199,8 +1199,8 @@ describe('manipulation', function() {
               p.id.should.eql(post.id);
               p.should.not.have.property('_id');
               p.title.should.equal('b');
-              p.should.have.property('content', undefined);
-              p.should.have.property('comments', undefined);
+              p.should.have.property('content').be.oneOf(null, undefined);
+              p.should.have.property('comments').be.oneOf(null, undefined);
 
               Post.findById(post.id, function(err, p) {
                 if (err) return done(err);
@@ -1435,7 +1435,7 @@ describe('manipulation', function() {
                 should.exist(p);
                 p.should.be.instanceOf(Post);
                 p.title.should.equal('b');
-                p.should.have.property('content', undefined);
+                p.should.have.property('content').be.oneOf(null, undefined);
                 return Post.findById(postInstance.id)
                   .then(function(p) {
                     p.title.should.equal('b');
@@ -1455,7 +1455,7 @@ describe('manipulation', function() {
                 should.exist(p);
                 p.should.be.instanceOf(Post);
                 p.title.should.equal('b');
-                p.should.have.property('content', undefined);
+                p.should.have.property('content').be.oneOf(null, undefined);
                 return Post.findById(postInstance.id)
                   .then(function(p) {
                     p.title.should.equal('b');
@@ -1486,7 +1486,7 @@ describe('manipulation', function() {
           if (err) return done(err);
           p.replaceAttributes({title: 'b'}, function(err, p) {
             if (err) return done(err);
-            p.should.have.property('content', undefined);
+            p.should.have.property('content').be.oneOf(null, undefined);
             p.title.should.equal('b');
             done();
           });
@@ -1498,7 +1498,7 @@ describe('manipulation', function() {
           if (err) return done(err);
           p.replaceAttributes({title: 'b'}, {validate: false}, function(err, p) {
             if (err) return done(err);
-            p.should.have.property('content', undefined);
+            p.should.have.property('content').be.oneOf(null, undefined);
             p.title.should.equal('b');
             done();
           });


### PR DESCRIPTION
### Description
When fixing https://github.com/strongloop/loopback-connector-cassandra/issues/65 by loading data from db after update, this test still failed because of assertation. What is got from db is `content: null`, while the asseration is `undefined`. This change can make the tests more robust.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to https://github.com/strongloop/loopback-connector-cassandra/issues/65

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
