### PR TITLE
Add EventEmitter type information to DataSource type

### DIFF
--- a/types/datasource.d.ts
+++ b/types/datasource.d.ts
@@ -11,6 +11,7 @@ import {
   ModelDefinition,
   PropertyDefinition,
 } from './model';
+import {EventEmitter} from 'events';
 
 /**
  * LoopBack models can manipulate data via the DataSource object.
@@ -72,7 +73,7 @@ import {
  *   - new DataSource(connectorModule, {name: 'myDataSource})
  *   - new DataSource(connectorModule)
  */
-export declare class DataSource {
+export declare class DataSource extends EventEmitter {
   name: string;
   settings: Options;
 


### PR DESCRIPTION
### Description
This PR adds EventEmitter method type information to DataSource.
This is so that the TS compiler does not complain if we try to attach a listener to the datasource

#### Related issues
strongloop/loopback-next#1553

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
