### PR TITLE
update: dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "depd": "^1.0.0",
     "inflection": "^1.6.0",
     "lodash": "^4.17.4",
-    "loopback-connector": "^4.4.0",
+    "loopback-connector": "^4.5.1",
     "minimatch": "^3.0.3",
     "qs": "^6.5.0",
     "shortid": "^2.2.6",


### PR DESCRIPTION
what to do next:

- release a new version 3.23.1
- update `loopback-connector-remote` to use `"loopback-datasource-juggler": "^3.23.1"`
- release a new patch version `loopback-connector-remote@3.4.1`
- update `loopback` to use `"loopback-connector-remote": "^3.4.1"`
