### PR TITLE
Added parent Instance to embedded models observers

### DIFF
--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -2286,7 +2286,9 @@ EmbedsOne.prototype.create = function(targetModelData, options, cb) {
   } else {
     var context = {
       Model: modelTo,
+      parentInstance: modelInstance,
       instance: inst,
+      parentInstance: modelInstance,
       options: options || {},
       hookState: {},
     };
@@ -2367,6 +2369,7 @@ EmbedsOne.prototype.update = function(targetModelData, options, cb) {
     var hookState = {};
     var context = {
       Model: modelTo,
+      parentInstance: modelInstance,
       currentInstance: embeddedInstance,
       data: data,
       options: options || {},
@@ -2425,6 +2428,7 @@ EmbedsOne.prototype.destroy = function(options, cb) {
 
   var context = {
     Model: modelTo,
+    parentInstance: modelInstance,
     instance: embeddedInstance,
     options: options || {},
     hookState: {},
@@ -2760,6 +2764,7 @@ EmbedsMany.prototype.updateById = function(fkId, data, options, cb) {
     var hookState = {};
     var context = {
       Model: modelTo,
+      parentInstance: modelInstance,
       currentInstance: inst,
       data: data,
       options: options,
@@ -2824,6 +2829,7 @@ EmbedsMany.prototype.destroyById = function(fkId, options, cb) {
   if (inst instanceof modelTo) {
     var context = {
       Model: modelTo,
+      parentInstance: modelInstance,
       instance: inst,
       options: options || {},
       hookState: {},
@@ -2954,6 +2960,7 @@ EmbedsMany.prototype.create = function(targetModelData, options, cb) {
     } else {
       var context = {
         Model: modelTo,
+        parentInstance: modelInstance,
         instance: inst,
         options: options || {},
         hookState: {},

--- a/test/operation-hooks.suite/embeds-many-create.suite.js
+++ b/test/operation-hooks.suite/embeds-many-create.suite.js
@@ -85,6 +85,16 @@ module.exports = function(dataSource, should, connectorCapabilities) {
             name: 'created',
             extra: undefined,
           },
+          parentInstance: {
+            embeddeds: [
+              {
+                id: instance.id,
+                name: 'created',
+                extra: undefined,
+              },
+            ],
+            id: ownerInstance.id,
+          },
           // TODO isNewInstance: true,
         }));
       });
@@ -144,6 +154,16 @@ module.exports = function(dataSource, should, connectorCapabilities) {
             id: instance.id,
             name: 'created',
             extra: undefined,
+          },
+          parentInstance: {
+            embeddeds: [
+              {
+                id: instance.id,
+                name: 'created',
+                extra: undefined,
+              },
+            ],
+            id: ownerInstance.id,
           },
           // TODO isNewInstance: true,
         }));

--- a/test/operation-hooks.suite/embeds-many-destroy.suite.js
+++ b/test/operation-hooks.suite/embeds-many-destroy.suite.js
@@ -100,6 +100,16 @@ module.exports = function(dataSource, should, connectorCapabilities) {
             name: 'created',
             extra: undefined,
           },
+          parentInstance: {
+            embeddeds: [
+              {
+                id: existingItem.id,
+                name: 'created',
+                extra: undefined,
+              },
+            ],
+            id: ownerInstance.id,
+          },
         }));
       });
     });
@@ -127,6 +137,10 @@ module.exports = function(dataSource, should, connectorCapabilities) {
             id: existingItem.id,
             name: 'created',
             extra: undefined,
+          },
+          parentInstance: {
+            embeddeds: [],
+            id: ownerInstance.id,
           },
         }));
       });

--- a/test/operation-hooks.suite/embeds-many-update-by-id.suite.js
+++ b/test/operation-hooks.suite/embeds-many-update-by-id.suite.js
@@ -103,6 +103,16 @@ module.exports = function(dataSource, should, connectorCapabilities) {
             name: 'created',
             extra: undefined,
           },
+          parentInstance: {
+            embeddeds: [
+              {
+                id: instance.id,
+                name: 'created',
+                extra: undefined,
+              },
+            ],
+            id: ownerInstance.id,
+          },
           data: {
             name: 'updated',
           },

--- a/test/operation-hooks.suite/embeds-one-create.suite.js
+++ b/test/operation-hooks.suite/embeds-one-create.suite.js
@@ -85,6 +85,14 @@ module.exports = function(dataSource, should, connectorCapabilities) {
             name: 'created',
             extra: undefined,
           },
+          parentInstance: {
+            embedded: {
+              id: instance.id,
+              name: 'created',
+              extra: undefined,
+            },
+            id: ownerInstance.id,
+          },
           // TODO isNewInstance: true,
         }));
       });
@@ -139,6 +147,14 @@ module.exports = function(dataSource, should, connectorCapabilities) {
             id: instance.id,
             name: 'created',
             extra: undefined,
+          },
+          parentInstance: {
+            embedded: {
+              id: instance.id,
+              name: 'created',
+              extra: undefined,
+            },
+            id: ownerInstance.id,
           },
           // TODO isNewInstance: true,
         }));

--- a/test/operation-hooks.suite/embeds-one-destroy.suite.js
+++ b/test/operation-hooks.suite/embeds-one-destroy.suite.js
@@ -90,6 +90,10 @@ module.exports = function(dataSource, should, connectorCapabilities) {
             name: 'created',
             extra: undefined,
           },
+          parentInstance: {
+            embedded: undefined,
+            id: ownerInstance.id,
+          },
         }));
       });
     });
@@ -117,6 +121,10 @@ module.exports = function(dataSource, should, connectorCapabilities) {
             id: existingItem.id,
             name: 'created',
             extra: undefined,
+          },
+          parentInstance: {
+            embedded: undefined,
+            id: ownerInstance.id,
           },
         }));
       });

--- a/test/operation-hooks.suite/embeds-one-update.suite.js
+++ b/test/operation-hooks.suite/embeds-one-update.suite.js
@@ -92,6 +92,14 @@ module.exports = function(dataSource, should, connectorCapabilities) {
             name: 'created',
             extra: undefined,
           },
+          parentInstance: {
+            embedded: {
+              id: instance.id,
+              name: 'created',
+              extra: undefined,
+            },
+            id: ownerInstance.id,
+          },
           data: {
             name: 'updated',
           },


### PR DESCRIPTION
### Description
This adds parentInstance to context when using observers on child models ('before save', 'before delete', ...)

#### Related issues
 - connect to #1606 
 - connect to strongloop/loopback#3235

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
