### PR TITLE
Fix for nestRemoting a model that has a referencesMany relation

### DIFF
--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -3190,6 +3190,9 @@ RelationDefinition.referencesMany = function referencesMany(modelFrom, modelToRe
   var removeFunc = scopeMethods.remove;
   modelFrom.prototype['__unlink__' + relationName] = removeFunc;
 
+  var existsFunc = scopeMethods.exists;
+  modelFrom.prototype['__exists__' + relationName] = existsFunc;
+
   scopeMethods.create = scopeMethod(definition, 'create');
   scopeMethods.build = scopeMethod(definition, 'build');
 


### PR DESCRIPTION
### Description
This is a fix for using nestRemoting to a model that has referencesMany relation. 

#### Related issues
 - connect to strongloop/loopback#3778

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
