### PR TITLE
feat: omit default fn for embeds many (2.x)

### DIFF
--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -2391,9 +2391,16 @@ RelationDefinition.embedsMany = function embedsMany(modelFrom, modelTo, params) 
     embed: true,
   });
 
-  modelFrom.dataSource.defineProperty(modelFrom.modelName, propertyName, {
-    type: [modelTo], default: function() { return []; },
-  });
+  var opts = Object.assign(
+    {},
+    params.options && params.options.omitDefaultEmbeddedItem ? {type: [modelTo]} :
+    {
+      type: [modelTo],
+      default: function() { return []; },
+    }
+  );
+
+  modelFrom.dataSource.defineProperty(modelFrom.modelName, propertyName, opts);
 
   if (typeof modelTo.dataSource.connector.generateId !== 'function') {
     modelFrom.validate(propertyName, function(err) {
@@ -2840,9 +2847,8 @@ EmbedsMany.prototype.create = function(targetModelData, options, cb) {
   targetModelData = targetModelData || {};
   cb = cb || utils.createPromiseCallback();
 
-  var embeddedList = this.embeddedList();
-
   var inst = this.callScopeMethod('build', targetModelData);
+  var embeddedList = this.embeddedList();
 
   var updateEmbedded = function(callback) {
     if (modelInstance.isNewRecord()) {
@@ -2895,6 +2901,7 @@ EmbedsMany.prototype.build = function(targetModelData) {
   var modelInstance = this.modelInstance;
   var forceId = this.definition.options.forceId;
   var persistent = this.definition.options.persistent;
+  var propertyName = this.definition.keyFrom;
   var connector = modelTo.dataSource.connector;
 
   var pk = this.definition.keyTo;
@@ -2928,8 +2935,10 @@ EmbedsMany.prototype.build = function(targetModelData) {
 
   if (this.definition.options.prepend) {
     embeddedList.unshift(inst);
+    modelInstance[propertyName] = embeddedList;
   } else {
     embeddedList.push(inst);
+    modelInstance[propertyName] = embeddedList;
   }
 
   this.prepareEmbeddedInstance(inst);


### PR DESCRIPTION
**Backport of #1532**

_In general, we don't backport new features to LTS versions because of stability reasons. Having said that, this particular change looks more like a bug fix to me, thus I think it's ok to add it to 2.x version too._

Related to https://github.com/strongloop/loopback/issues/2882

## Use case

- `Person` EmbeddsMany `Address`
- create a new person `let p = new Person({name: 'Jack', id: 1})`

## Current behaviour

The generated instance is `{name: 'Jack', id: 1, addresses: []}`

## Feature

In this PR I add a flag `omitDefaultEmbeddedItem`

### Flag off (default behaviour)

Same as current behaviour, the new person instance have an empty array property `addresses` 

### Flag on(user need to config it in model.json relations)

The new person instance is `{name: 'Jack', id: 1}`
Please note it doesn't have the embedded item.