### PR TITLE
Forward-port fix for "inverse polymorphic hasmany" from 2.x to master

### DIFF
--- a/lib/include.js
+++ b/lib/include.js
@@ -412,10 +412,13 @@ Inclusion.include = function(objects, include, options, cb) {
         inq: uniq(sourceIds),
       };
       if (polymorphic) {
+        var throughModel = polymorphic.invert ?
+          relation.modelTo :
+          relation.modelFrom;
         // handle polymorphic hasMany (reverse) in which case we need to filter
         // by discriminator to filter other types
         throughFilter.where[polymorphic.discriminator] =
-          relation.modelFrom.definition.name;
+          throughModel.definition.name;
       }
 
       // 1st DB Call of 2-step process. Get through model objects first

--- a/test/model-inheritance.test.js
+++ b/test/model-inheritance.test.js
@@ -73,7 +73,7 @@ describe('Model class inheritance', function() {
         relations: {patch: true},
       };
 
-        // saving original getMergePolicy method
+      // saving original getMergePolicy method
       let originalGetMergePolicy = base.getMergePolicy;
 
       // the injected getMergePolicy method captures the provided configureModelMerge option

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -2738,6 +2738,40 @@ describe('relations', function() {
     });
   });
 
+  describe('polymorphic hasMany with inverse relation', function() {
+    /**
+     * This tests for whether an inverse relation can
+     * be defined on a polymorphic hasMany property
+     */
+    before(function(done) {
+      Picture = db.define('Picture', {name: String});
+      Author = db.define('Author', {name: String});
+      PictureLink = db.define('PictureLink', {});
+      Author.hasMany(Picture, {through: PictureLink, polymorphic: 'imageable', invert: true});
+      Picture.hasMany(Author, {through: PictureLink, polymorphic: 'imageable'});
+
+      db.automigrate(['Picture', 'Author', 'PictureLink'], done);
+    });
+
+    it('should return records for models through an inverted hasMany relationship', function(done) {
+      Author.create({name: 'John Doe'}, function(err, author) {
+        if (err) return done(err);
+
+        author.pictures.create({name: 'John Doe picture'}, function(err, pic) {
+          if (err) return done(err);
+
+          Author.findOne({include: 'pictures'}, function(err, author) {
+            if (err) return done(err);
+
+            author.pictures().length.should.eql(1);
+            author.pictures()[0].name.should.eql('John Doe picture');
+            done();
+          });
+        });
+      });
+    });
+  });
+
   describe('polymorphic hasAndBelongsToMany through', function() {
     var idArticle, idEmployee;
 


### PR DESCRIPTION
### Description

This PR provides a patch for the polymorphic hasMany Inverse relation for 3.x. The the fix was proposed and merged into 2.x with this PR #1080. This PR makes this fix available in 3.x.

#### Related issues
- Issue #1079