### PR TITLE
[WIP] feature: 404 error for findById() if resource is not found

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1359,7 +1359,8 @@ DataAccessObject.findById = function findById(id, filter, options, cb) {
     }
   }
 
-  cb = cb || utils.createPromiseCallback();
+  // set strictFind to `true` for rejecting with a 404 error, else it will be resolved with a `null`
+  cb = cb || utils.createPromiseCallback(options && options.strictFind);
   options = options || {};
   filter = filter || {};
 
@@ -1381,7 +1382,20 @@ DataAccessObject.findById = function findById(id, filter, options, cb) {
     if (filter.fields) {
       query.fields = filter.fields;
     }
-    this.findOne(query, options, cb);
+    this.findOne(query, options, (err, data) => {
+      // WIP:
+      // Having to do this because even for LB4 queries, `cb` is set when calling
+      // `findById` for the first time, hence `createPromiseCallback()` is never called.
+      // `cb` is not set in the subsequent calls and `createPromiseCallback()` is called.
+      if (!options.strictFind) return cb(err, data);
+      if (data) {
+        cb(null, data);
+      } else {
+        var err404 = new Error('Not found');
+        err404.statusCode = 404;
+        cb(err404);
+      }
+    });
   }
   return cb.promise;
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -547,12 +547,17 @@ function sortObjectsByIds(idName, ids, objects, strict) {
   return heading.concat(tailing);
 };
 
-function createPromiseCallback() {
+// WIP:
+// If `strict` is true, reject `null` result with a 404 error
+function createPromiseCallback(strict) {
   var cb;
   var promise = new Promise(function(resolve, reject) {
     cb = function(err, data) {
       if (err) return reject(err);
-      return resolve(data);
+      if (!strict) return resolve(data);
+      var err404 = new Error('Not found');
+      err404.statusCode = 404;
+      reject(err404);
     };
   });
   cb.promise = promise;


### PR DESCRIPTION
404 error for findById() if resource is not found

### Description


#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to https://github.com/strongloop/loopback-datasource-juggler/issues/1619

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
