### PR TITLE
Fix patchAttributes for embedded document properties in MongoDB

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -3255,7 +3255,6 @@ function(data, options, cb) {
 
     function validateAndSave(err, data) {
       if (err) return cb(err);
-      data = removeUndefined(data);
       var doValidate = true;
       if (options.validate === undefined) {
         if (Model.settings.automaticValidation !== undefined) {
@@ -3290,7 +3289,7 @@ function(data, options, cb) {
           inst.trigger('update', function(done) {
             copyData(data, inst);
             var typedData = convertSubsetOfPropertiesByType(inst, data);
-            context.data = typedData;
+            context.data = removeUndefined(typedData);
 
             // Depending on the connector, the database response can
             // contain information about the updated record(s), but also

--- a/test/crud-with-options.test.js
+++ b/test/crud-with-options.test.js
@@ -23,6 +23,7 @@ describe('crud-with-options', function() {
       role: {type: String, index: true},
       order: {type: Number, index: true, sort: true},
       vip: {type: Boolean},
+      address: {type: {city: String, area: String}},
     });
     options = {};
     filter = {fields: ['name', 'id']};
@@ -145,7 +146,7 @@ describe('crud-with-options', function() {
 
     it('should allow promise-style findById',
       function(done) {
-        User.create({name: 'w', email: 'w@y.com'}).then(function(u) {
+        User.create({id: 15, name: 'w', email: 'w@y.com'}).then(function(u) {
           should.exist(u.id);
           return User.findById(u.id).then(function(u) {
             should.exist(u);
@@ -520,6 +521,24 @@ describe('crud-with-options', function() {
       });
     });
   });
+
+  describe('updateAttributes', function() {
+    beforeEach(seed);
+    it('preserves document properties not modified by the patch', function() {
+      return User.findOne({where: {name: 'John Lennon'}})
+        .then(function(user) {
+          return user.updateAttributes({address: {city: 'Volos'}});
+        })
+        .then(function() {
+          return User.findOne({where: {name: 'John Lennon'}}); // retrieve the user again from the db
+        })
+        .then(function(updatedUser) {
+          updatedUser.address.city.should.equal('Volos');
+          should(updatedUser.address.area).not.be.exactly(null);
+          should(updatedUser.address.area).be.undefined();
+        });
+    });
+  });
 });
 
 describe('upsertWithWhere', function() {
@@ -588,6 +607,7 @@ describe('upsertWithWhere', function() {
 function seed(done) {
   var beatles = [
     {
+      id: 0,
       seq: 0,
       name: 'John Lennon',
       email: 'john@b3atl3s.co.uk',
@@ -597,6 +617,7 @@ function seed(done) {
       vip: true,
     },
     {
+      id: 1,
       seq: 1,
       name: 'Paul McCartney',
       email: 'paul@b3atl3s.co.uk',
@@ -605,10 +626,10 @@ function seed(done) {
       order: 1,
       vip: true,
     },
-    {seq: 2, name: 'George Harrison', order: 5, vip: false},
-    {seq: 3, name: 'Ringo Starr', order: 6, vip: false},
-    {seq: 4, name: 'Pete Best', order: 4},
-    {seq: 5, name: 'Stuart Sutcliffe', order: 3, vip: true},
+    {id: 2, seq: 2, name: 'George Harrison', order: 5, vip: false},
+    {id: 3, seq: 3, name: 'Ringo Starr', order: 6, vip: false},
+    {id: 4, seq: 4, name: 'Pete Best', order: 4},
+    {id: 5, seq: 5, name: 'Stuart Sutcliffe', order: 3, vip: true},
   ];
 
   async.series([


### PR DESCRIPTION
### Description
Moved `removeUndefined` call to the proper location. This way when sending partial document updates in embedded documents, rest properties do not get converted to null in MongoDB

#### Related issues
<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to #1622 

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
