### PR TITLE
non-native itemType constructor must be called with new

### DIFF
--- a/lib/list.js
+++ b/lib/list.js
@@ -65,7 +65,11 @@ function List(items, itemType, parent) {
 
   items.forEach(function(item, i) {
     if (itemType && !(item instanceof itemType)) {
-      arr[i] = itemType(item);
+      if (itemType.definition) {
+        arr[i] = new itemType(item);
+      } else {
+        arr[i] = itemType(item);
+      }
     } else {
       arr[i] = item;
     }


### PR DESCRIPTION
### Description

- Identified while working on `loopback4-example-shopping`. A list of models should be instantiated using the model constructor. 

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
