### PR TITLE
fix: accelerate unique id checking

### DIFF
--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -17,6 +17,7 @@ var defineScope = require('./scope.js').defineScope;
 var g = require('strong-globalize')();
 var mergeQuery = utils.mergeQuery;
 var idEquals = utils.idEquals;
+var idsHaveDuplicates = utils.idsHaveDuplicates;
 var ModelBaseClass = require('./model.js');
 var applyFilter = require('./connectors/memory').applyFilter;
 var ValidationError = require('./validations.js').ValidationError;
@@ -2502,10 +2503,7 @@ RelationDefinition.embedsMany = function embedsMany(modelFrom, modelToRef, param
     modelFrom.validate(propertyName, function(err) {
       var embeddedList = this[propertyName] || [];
       var ids = embeddedList.map(function(m) { return m[idName] && m[idName].toString(); }); // mongodb
-      var uniqueIds = ids.filter(function(id, pos) {
-        return utils.findIndexOf(ids, id, idEquals) === pos;
-      });
-      if (ids.length !== uniqueIds.length) {
+      if (idsHaveDuplicates(ids)) {
         this.errors.add(propertyName, 'contains duplicate `' + idName + '`', 'uniqueness');
         err(false);
       }
@@ -3155,10 +3153,7 @@ RelationDefinition.referencesMany = function referencesMany(modelFrom, modelToRe
 
   modelFrom.validate(relationName, function(err) {
     var ids = this[fk] || [];
-    var uniqueIds = ids.filter(function(id, pos) {
-      return utils.findIndexOf(ids, id, idEquals) === pos;
-    });
-    if (ids.length !== uniqueIds.length) {
+    if (idsHaveDuplicates(ids)) {
       var msg = 'contains duplicate `' + modelTo.modelName + '` instance';
       this.errors.add(relationName, msg, 'uniqueness');
       err(false);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -713,7 +713,7 @@ function idsHaveDuplicates(ids) {
         break;
       }
     }
-    if (hasDuplicates === undefined && uniqueIds.length === ids.length) {
+    if (hasDuplicates === undefined && uniqueIds.size === ids.length) {
       hasDuplicates = false;
     }
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -26,6 +26,7 @@ exports.findIndexOf = findIndexOf;
 exports.collectTargetIds = collectTargetIds;
 exports.idName = idName;
 exports.rankArrayElements = rankArrayElements;
+exports.idsHaveDuplicates = idsHaveDuplicates;
 
 var g = require('strong-globalize')();
 var traverse = require('traverse');
@@ -684,4 +685,49 @@ function collectTargetIds(targetData, idPropertyName) {
  */
 function idName(m) {
   return m.definition.idName() || 'id';
+}
+
+/**
+ * Check a list of IDs to see if there are any duplicates.
+ *
+ * @param {Array} The array of IDs to check
+ * @returns {boolean} If any duplicates were found
+ */
+function idsHaveDuplicates(ids) {
+  // use Set if available and all ids are of string or number type
+  var hasDuplicates = undefined;
+  var i, j;
+  if (typeof Set === 'function') {
+    var uniqueIds = new Set();
+    for (i = 0; i < ids.length; ++i) {
+      var idType = typeof ids[i];
+      if (idType === 'string' || idType === 'number') {
+        if (uniqueIds.has(ids[i])) {
+          hasDuplicates = true;
+          break;
+        } else {
+          uniqueIds.add(ids[i]);
+        }
+      } else {
+        // ids are not all string/number that can be checked via Set, stop and do the slow test
+        break;
+      }
+    }
+    if (hasDuplicates === undefined && uniqueIds.length === ids.length) {
+      hasDuplicates = false;
+    }
+  }
+  if (hasDuplicates === undefined) {
+    // fast check was inconclusive or unavailable, do the slow check
+    // can still optimize this by doing 1/2 N^2 instead of the full N^2
+    for (i = 0; i < ids.length && hasDuplicates === undefined; ++i) {
+      for (j = 0; j < i; ++j) {
+        if (idEquals(ids[i], ids[j])) {
+          hasDuplicates = true;
+          break;
+        }
+      }
+    }
+  }
+  return hasDuplicates === true;
 }

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -559,3 +559,35 @@ describe('util.hasRegExpFlags', function() {
     });
   });
 });
+
+describe('util.idsHaveDuplicates', function() {
+  context('with string IDs', function() {
+    it('should be true with a duplicate present', function() {
+      utils.idsHaveDuplicates(['a', 'b', 'a']).should.be.ok;
+    });
+
+    it('should be false when no duplicates are present', function() {
+      utils.idsHaveDuplicates(['a', 'b', 'c']).should.not.be.ok;
+    });
+  });
+
+  context('with numeric IDs', function() {
+    it('should be true with a duplicate present', function() {
+      utils.idsHaveDuplicates([1, 2, 1]).should.be.ok;
+    });
+
+    it('should be false when no duplicates are present', function() {
+      utils.idsHaveDuplicates([1, 2, 3]).should.not.be.ok;
+    });
+  });
+
+  context('with complex IDs', function() {
+    it('should be true with a duplicate present', function() {
+      utils.idsHaveDuplicates(['a', 'b', 'a'].map(id => ({id}))).should.be.ok;
+    });
+
+    it('should be false when no duplicates are present', function() {
+      utils.idsHaveDuplicates(['a', 'b', 'c'].map(id => ({id}))).should.not.be.ok;
+    });
+  });
+});


### PR DESCRIPTION
### Description

Saving (very) large objects with loopback can result in node spinning for a long time (>50s in my case) on a single statement checking the uniquness of a list of IDs of child objects.  This causes lots of issues, including connection timeouts, and service heartbeat / health-check failures.

The implementation of this uniquenss check is currently a naieve and extremely inefficient O(N^2) one, which can be trivially accelerated for common ID datatypes.

#### Related issues

N/A

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
