### PR TITLE
[SEMVER-MAJOR] Start 4.0 development, drop support for Node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - "6"
   - "8"
   - "10"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback-datasource-juggler",
-  "version": "3.24.0",
+  "version": "4.0.0-alpha.1",
   "publishConfig": {
     "export-tests": true
   },
@@ -15,7 +15,7 @@
     "ORM"
   ],
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
As part of LoopBack 4.0 GA release, I am proposing to publish a 4.0 release of juggler as Current, move juggler@3.x into Active LTS and move strong-remoting@3.x into Active LTS (with no Current release line). My argument is that loopback@3.x is moving to Active LTS and we don't want loopback@3.x to receive new features from the juggler/remoting dependency, as new features are more likely to introduce unintended problems. Instead, I'd like to have everything under LoopBack 3.x umbrella in Active LTS to clearly communicate those versions are considered as stable and suitable for wide use.

We don't have bandwidth to do backwards-incompatible cleanup while we are making a new major version of juggler. But! We can still drop support for Node.js 6.x as part of this release, this will allow us to start migrating the code base to async/await style without necessarily breaking backwards compatibility.