### PR TITLE
[SEMVER-MAJOR] Switch from Bluebird to native Promise

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -30,7 +30,6 @@ exports.rankArrayElements = rankArrayElements;
 var g = require('strong-globalize')();
 var traverse = require('traverse');
 var assert = require('assert');
-var Promise = require('bluebird');
 
 function safeRequire(module) {
   try {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
   },
   "dependencies": {
     "async": "^2.6.0",
-    "bluebird": "^3.1.1",
     "debug": "^3.1.0",
     "depd": "^1.0.0",
     "inflection": "^1.6.0",

--- a/test/async-observer.test.js
+++ b/test/async-observer.test.js
@@ -6,7 +6,6 @@
 
 var ModelBuilder = require('../').ModelBuilder;
 var should = require('./init');
-var Promise = require('bluebird');
 
 describe('async observer', function() {
   var TestModel;

--- a/test/kvao/_helpers.js
+++ b/test/kvao/_helpers.js
@@ -1,10 +1,9 @@
 'use strict';
 
-var Promise = require('bluebird');
-
 exports.givenCacheItem = givenCacheItem;
 exports.givenKeys = givenKeys;
 exports.givenModel = givenModel;
+exports.delay = delay;
 
 function givenCacheItem(dataSourceFactory) {
   const modelProperties = {
@@ -34,3 +33,9 @@ function givenKeys(Model, keys, cb) {
   }
   return p;
 };
+
+function delay(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/test/kvao/expire.suite.js
+++ b/test/kvao/expire.suite.js
@@ -3,7 +3,6 @@
 var bdd = require('../helpers/bdd-if');
 var should = require('should');
 var helpers = require('./_helpers');
-var Promise = require('bluebird');
 
 module.exports = function(dataSourceFactory, connectorCapabilities) {
   // While we support millisecond precision, for the purpose of tests
@@ -35,14 +34,14 @@ module.exports = function(dataSourceFactory, connectorCapabilities) {
     it('sets key ttl - Promise API', function() {
       return CacheItem.set('a-key', 'a-value')
         .then(function() { return CacheItem.expire('a-key', ttlPrecision); })
-        .delay(2 * ttlPrecision)
+        .then(() => helpers.delay(2 * ttlPrecision))
         .then(function() { return CacheItem.get('a-key'); })
         .then(function(value) { should.equal(value, null); });
     });
 
     it('returns error when expiring a key that has expired', function() {
       return Promise.resolve(CacheItem.set('expired-key', 'a-value', ttlPrecision))
-        .delay(2 * ttlPrecision)
+        .then(() => helpers.delay(2 * ttlPrecision))
         .then(function() { return CacheItem.expire('expired-key', 1000); })
         .then(
           function() { throw new Error('expire() should have failed'); },

--- a/test/kvao/get-set.suite.js
+++ b/test/kvao/get-set.suite.js
@@ -2,7 +2,6 @@
 
 var should = require('should');
 var helpers = require('./_helpers');
-var Promise = require('bluebird');
 
 module.exports = function(dataSourceFactory, connectorCapabilities) {
   var TTL_PRECISION = connectorCapabilities.ttlPrecision;
@@ -69,7 +68,7 @@ module.exports = function(dataSourceFactory, connectorCapabilities) {
 
     it('honours options.ttl', function() {
       return CacheItem.set('a-key', 'a-value', {ttl: TTL_PRECISION})
-        .delay(2 * TTL_PRECISION)
+        .then(() => helpers.delay(2 * TTL_PRECISION))
         .then(function() { return CacheItem.get('a-key'); })
         .then(function(value) { should.equal(value, null); });
     });
@@ -84,7 +83,7 @@ module.exports = function(dataSourceFactory, connectorCapabilities) {
     describe('set', function() {
       it('converts numeric options arg to options.ttl', function() {
         return CacheItem.set('a-key', 'a-value', TTL_PRECISION)
-          .delay(2 * TTL_PRECISION)
+          .then(() => helpers.delay(2 * TTL_PRECISION))
           .then(function() { return CacheItem.get('a-key'); })
           .then(function(value) { should.equal(value, null); });
       });
@@ -94,7 +93,7 @@ module.exports = function(dataSourceFactory, connectorCapabilities) {
           .then(function() {
             return CacheItem.set('a-key', 'another-value'); // no TTL
           })
-          .delay(2 * TTL_PRECISION)
+          .then(() => helpers.delay(2 * TTL_PRECISION))
           .then(function() { return CacheItem.get('a-key'); })
           .then(function(value) { should.equal(value, 'another-value'); });
       });

--- a/test/kvao/iterate-keys.suite.js
+++ b/test/kvao/iterate-keys.suite.js
@@ -3,9 +3,7 @@
 var asyncIterators = require('async-iterators');
 var bdd = require('../helpers/bdd-if');
 var helpers = require('./_helpers');
-var Promise = require('bluebird');
 var should = require('should');
-var toArray = Promise.promisify(asyncIterators.toArray);
 
 module.exports = function(dataSourceFactory, connectorCapabilities) {
   var canIterateKeys = connectorCapabilities.canIterateKeys !== false;
@@ -52,3 +50,15 @@ module.exports = function(dataSourceFactory, connectorCapabilities) {
     };
   });
 };
+
+// A promisified version of asyncIterators.toArray
+// Node.js 8.x does not have util.promisify function,
+// we are adding promise support manually here
+function toArray(iter) {
+  return new Promise((resolve, reject) => {
+    asyncIterators.toArray(iter, (err, result) => {
+      if (err) reject(err);
+      else resolve(result);
+    });
+  });
+}

--- a/test/kvao/keys.suite.js
+++ b/test/kvao/keys.suite.js
@@ -2,7 +2,6 @@
 
 var bdd = require('../helpers/bdd-if');
 var helpers = require('./_helpers');
-var Promise = require('bluebird');
 var should = require('should');
 
 module.exports = function(dataSourceFactory, connectorCapabilities) {

--- a/test/kvao/ttl.suite.js
+++ b/test/kvao/ttl.suite.js
@@ -3,7 +3,6 @@
 var bdd = require('../helpers/bdd-if');
 var should = require('should');
 var helpers = require('./_helpers');
-var Promise = require('bluebird');
 
 module.exports = function(dataSourceFactory, connectorCapabilities) {
   var TTL_PRECISION = connectorCapabilities.ttlPrecision;
@@ -28,7 +27,7 @@ module.exports = function(dataSourceFactory, connectorCapabilities) {
         return Promise.resolve(
           CacheItem.set('a-key', 'a-value', {ttl: INITIAL_TTL})
         )
-          .delay(SMALL_DELAY)
+          .then(() => helpers.delay(SMALL_DELAY))
           .then(function() { return CacheItem.ttl('a-key'); })
           .then(function(ttl) { ttl.should.be.within(1, INITIAL_TTL); });
       });
@@ -55,7 +54,7 @@ module.exports = function(dataSourceFactory, connectorCapabilities) {
       return Promise.resolve(
         CacheItem.set('expired-key', 'a-value', {ttl: TTL_PRECISION})
       )
-        .delay(2 * TTL_PRECISION)
+        .then(() => helpers.delay(2 * TTL_PRECISION))
         .then(function() {
           return CacheItem.ttl('expired-key');
         })

--- a/test/operation-hooks.suite/embeds-many-destroy.suite.js
+++ b/test/operation-hooks.suite/embeds-many-destroy.suite.js
@@ -5,7 +5,6 @@
 
 'use strict';
 
-var Promise = require('bluebird');
 var ValidationError = require('../..').ValidationError;
 
 var contextTestHelpers = require('../helpers/context-test-helpers');

--- a/test/operation-hooks.suite/embeds-many-update-by-id.suite.js
+++ b/test/operation-hooks.suite/embeds-many-update-by-id.suite.js
@@ -5,7 +5,6 @@
 
 'use strict';
 
-var Promise = require('bluebird');
 var ValidationError = require('../..').ValidationError;
 
 var contextTestHelpers = require('../helpers/context-test-helpers');


### PR DESCRIPTION
If we want to start writing `async` functions using `await` statements then we must remove Bluebird from our public API. This pull request is doing exactly that.

This is a breaking change. Juggler methods are no longer returning instances of Bluebird Promise, but return a native Promise instead.

As a result, API consumers can no longer use sugar APIs provided by Bluebird, e.g. `spread`, `delay`, etc.

Migration guide: rewrite your code from `.then()` style into `async` functions using `await` statements.