### PR TITLE
Report errors if where clause contains hidden properties

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -804,9 +804,9 @@ DataAccessObject.upsertWithWhere = function(where, data, options, cb) {
         function callConnector() {
           try {
             // Support an optional where object
-            var handleUndefined = Model._getSetting('normalizeUndefinedInQuery');
+            var normalizeUndefinedInQuery = Model._getSetting('normalizeUndefinedInQuery');
             // alter configuration of how sanitizeQuery handles undefined values
-            ctx.where = Model._sanitize(ctx.where, {handleUndefined: handleUndefined});
+            ctx.where = Model._sanitize(ctx.where, {normalizeUndefinedInQuery: normalizeUndefinedInQuery});
             ctx.where = Model._coerce(ctx.where, options);
             update = Model._sanitize(update);
             update = Model._coerce(update, options);
@@ -1579,9 +1579,9 @@ DataAccessObject._normalize = function(filter, options) {
       Object.keys(this.definition.properties), this.settings.strict);
   }
 
-  var handleUndefined = this._getSetting('normalizeUndefinedInQuery');
+  var normalizeUndefinedInQuery = this._getSetting('normalizeUndefinedInQuery');
   // alter configuration of how sanitizeQuery handles undefined values
-  filter = this._sanitize(filter, {handleUndefined: handleUndefined});
+  filter = this._sanitize(filter, {normalizeUndefinedInQuery: normalizeUndefinedInQuery});
   this._coerce(filter.where, options);
   return filter;
 };
@@ -2325,9 +2325,9 @@ DataAccessObject.destroyAll = function destroyAll(where, options, cb) {
     } else {
       try {
         // Support an optional where object
-        var handleUndefined = Model._getSetting('normalizeUndefinedInQuery');
+        var normalizeUndefinedInQuery = Model._getSetting('normalizeUndefinedInQuery');
         // alter configuration of how sanitizeQuery handles undefined values
-        where = Model._sanitize(where, {handleUndefined: handleUndefined});
+        where = Model._sanitize(where, {normalizeUndefinedInQuery: normalizeUndefinedInQuery});
         where = Model._coerce(where, options);
       } catch (err) {
         return process.nextTick(function() {
@@ -2480,9 +2480,9 @@ DataAccessObject.count = function(where, options, cb) {
   where = query.where;
 
   try {
-    var handleUndefined = Model._getSetting('normalizeUndefinedInQuery');
+    var normalizeUndefinedInQuery = Model._getSetting('normalizeUndefinedInQuery');
     // alter configuration of how sanitizeQuery handles undefined values
-    where = Model._sanitize(where, {handleUndefined: handleUndefined});
+    where = Model._sanitize(where, {normalizeUndefinedInQuery: normalizeUndefinedInQuery});
     where = this._coerce(where, options);
   } catch (err) {
     process.nextTick(function() {
@@ -2775,9 +2775,9 @@ DataAccessObject.updateAll = function(where, data, options, cb) {
   function doUpdate(where, data) {
     try {
       // Support an optional where object
-      var handleUndefined = Model._getSetting('normalizeUndefinedInQuery');
+      var normalizeUndefinedInQuery = Model._getSetting('normalizeUndefinedInQuery');
       // alter configuration of how sanitizeQuery handles undefined values
-      where = Model._sanitize(where, {handleUndefined: handleUndefined});
+      where = Model._sanitize(where, {normalizeUndefinedInQuery: normalizeUndefinedInQuery});
       where = Model._coerce(where, options);
       data = Model._sanitize(data);
       data = Model._coerce(data, options);

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1643,6 +1643,26 @@ function coerceArray(val) {
   return arrayVal;
 }
 
+DataAccessObject._getHiddenProperties = function() {
+  var settings = this.definition.settings || {};
+  var result = settings.hiddenProperties || settings.hidden;
+  if (typeof result === 'string') {
+    result = [result];
+  }
+  result = result || [];
+  return result;
+};
+
+DataAccessObject._getProtectedProperties = function() {
+  var settings = this.definition.settings || {};
+  var result = settings.protectedProperties || settings.protected;
+  if (typeof result === 'string') {
+    result = [result];
+  }
+  result = result || [];
+  return result;
+};
+
 /*
  * Coerce values based the property types
  * @param {Object} where The where clause
@@ -1658,6 +1678,13 @@ DataAccessObject._coerce = function(where, options) {
   }
 
   options = options || {};
+
+  // Check violation of keys
+  var prohibitedKeys = this._getHiddenProperties();
+  if (options.excludeProtectedProperties) {
+    prohibitedKeys = prohibitedKeys.concat(this._getProtectedProperties());
+  }
+  utils.validateKeys(where, prohibitedKeys);
 
   var err;
   if (typeof where !== 'object' || Array.isArray(where)) {

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1477,6 +1477,7 @@ DataAccessObject._getSetting = function(key) {
 };
 
 var operators = {
+  eq: '=',
   gt: '>',
   gte: '>=',
   lt: '<',
@@ -1818,6 +1819,7 @@ DataAccessObject._coerce = function(where, options) {
       // NOOP when not coercable into an array.
     }
 
+    var allowExtendedOperators = self._allowExtendedOperators(options);
     // Coerce the array items
     if (Array.isArray(val)) {
       for (var i = 0; i < val.length; i++) {
@@ -1829,7 +1831,6 @@ DataAccessObject._coerce = function(where, options) {
       }
     } else {
       if (val != null) {
-        var allowExtendedOperators = self._allowExtendedOperators(options);
         if (operator === null && val instanceof RegExp) {
           // Normalize {name: /A/} to {name: {regexp: /A/}}
           operator = 'regexp';
@@ -1841,12 +1842,28 @@ DataAccessObject._coerce = function(where, options) {
         } else if (allowExtendedOperators && typeof val === 'object') {
           // Do not coerce object values when extended operators are allowed
         } else {
+          if (!allowExtendedOperators) {
+            var extendedOperators = Object.keys(val).filter(function(k) {
+              return k[0] === '$';
+            });
+            if (extendedOperators.length) {
+              const msg = g.f('Operators "' + extendedOperators.join(', ') + '" are not allowed in query');
+              const err = new Error(msg);
+              err.code = 'OPERATOR_NOT_ALLOWED_IN_QUERY';
+              err.statusCode = 400;
+              err.details = {
+                operators: extendedOperators,
+                where: where,
+              };
+              throw err;
+            }
+          }
           val = DataType(val);
         }
       }
     }
     // Rebuild {property: {operator: value}}
-    if (operator) {
+    if (operator && operator !== 'eq') {
       var value = {};
       value[operator] = val;
       if (exp.options) {

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -26,7 +26,7 @@ var geo = require('./geo');
 var Memory = require('./connectors/memory').Memory;
 var utils = require('./utils');
 var fieldsToArray = utils.fieldsToArray;
-var removeUndefined = utils.removeUndefined;
+var sanitizeQueryOrData = utils.sanitizeQuery;
 var setScopeValuesFromWhere = utils.setScopeValuesFromWhere;
 var idEquals = utils.idEquals;
 var mergeQuery = utils.mergeQuery;
@@ -406,7 +406,7 @@ DataAccessObject.create = function(data, options, cb) {
     obj.trigger('create', function(createDone) {
       obj.trigger('save', function(saveDone) {
         var _idName = idName(Model);
-        var val = removeUndefined(obj.toObject(true));
+        var val = Model._sanitize(obj.toObject(true));
         function createCallback(err, id, rev) {
           if (id) {
             obj.__data[_idName] = id;
@@ -635,7 +635,7 @@ DataAccessObject.upsert = function(data, options, cb) {
         }
 
         function callConnector() {
-          update = removeUndefined(update);
+          update = Model._sanitize(update);
           context = {
             Model: Model,
             where: ctx.where,
@@ -805,10 +805,10 @@ DataAccessObject.upsertWithWhere = function(where, data, options, cb) {
           try {
             // Support an optional where object
             var handleUndefined = Model._getSetting('normalizeUndefinedInQuery');
-            // alter configuration of how removeUndefined handles undefined values
-            ctx.where = removeUndefined(ctx.where, handleUndefined);
+            // alter configuration of how sanitizeQuery handles undefined values
+            ctx.where = Model._sanitize(ctx.where, {handleUndefined: handleUndefined});
             ctx.where = Model._coerce(ctx.where, options);
-            update = removeUndefined(update);
+            update = Model._sanitize(update);
             update = Model._coerce(update, options);
           } catch (err) {
             return process.nextTick(function() {
@@ -989,7 +989,7 @@ DataAccessObject.replaceOrCreate = function replaceOrCreate(data, options, cb) {
           }, update, options);
 
           function callConnector() {
-            update = removeUndefined(update);
+            update = Model._sanitize(update);
             context = {
               Model: Model,
               where: where,
@@ -1170,7 +1170,7 @@ DataAccessObject.findOrCreate = function findOrCreate(query, data, options, cb) 
       });
     }
 
-    data = removeUndefined(data);
+    data = Model._sanitize(data);
     var context = {
       Model: Model,
       where: query.where,
@@ -1580,8 +1580,8 @@ DataAccessObject._normalize = function(filter, options) {
   }
 
   var handleUndefined = this._getSetting('normalizeUndefinedInQuery');
-  // alter configuration of how removeUndefined handles undefined values
-  filter = removeUndefined(filter, handleUndefined);
+  // alter configuration of how sanitizeQuery handles undefined values
+  filter = this._sanitize(filter, {handleUndefined: handleUndefined});
   this._coerce(filter.where, options);
   return filter;
 };
@@ -1664,6 +1664,18 @@ DataAccessObject._getProtectedProperties = function() {
   return result;
 };
 
+DataAccessObject._sanitize = function(query, options) {
+  options = options || {};
+
+  // Check violation of keys
+  var prohibitedKeys = this._getHiddenProperties();
+  if (options.excludeProtectedProperties) {
+    prohibitedKeys = prohibitedKeys.concat(this._getProtectedProperties());
+  }
+  return sanitizeQueryOrData(query,
+    Object.assign({prohibitedKeys: prohibitedKeys}, options));
+};
+
 /*
  * Coerce values based the property types
  * @param {Object} where The where clause
@@ -1674,18 +1686,10 @@ DataAccessObject._getProtectedProperties = function() {
  */
 DataAccessObject._coerce = function(where, options) {
   var self = this;
-  if (!where) {
+  if (where == null) {
     return where;
   }
-
   options = options || {};
-
-  // Check violation of keys
-  var prohibitedKeys = this._getHiddenProperties();
-  if (options.excludeProtectedProperties) {
-    prohibitedKeys = prohibitedKeys.concat(this._getProtectedProperties());
-  }
-  utils.validateKeys(where, prohibitedKeys);
 
   var err;
   if (typeof where !== 'object' || Array.isArray(where)) {
@@ -2322,8 +2326,8 @@ DataAccessObject.destroyAll = function destroyAll(where, options, cb) {
       try {
         // Support an optional where object
         var handleUndefined = Model._getSetting('normalizeUndefinedInQuery');
-        // alter configuration of how removeUndefined handles undefined values
-        where = removeUndefined(where, handleUndefined);
+        // alter configuration of how sanitizeQuery handles undefined values
+        where = Model._sanitize(where, {handleUndefined: handleUndefined});
         where = Model._coerce(where, options);
       } catch (err) {
         return process.nextTick(function() {
@@ -2477,8 +2481,8 @@ DataAccessObject.count = function(where, options, cb) {
 
   try {
     var handleUndefined = Model._getSetting('normalizeUndefinedInQuery');
-    // alter configuration of how removeUndefined handles undefined values
-    where = removeUndefined(where, handleUndefined);
+    // alter configuration of how sanitizeQuery handles undefined values
+    where = Model._sanitize(where, {handleUndefined: handleUndefined});
     where = this._coerce(where, options);
   } catch (err) {
     process.nextTick(function() {
@@ -2584,7 +2588,7 @@ DataAccessObject.prototype.save = function(options, cb) {
     function save() {
       inst.trigger('save', function(saveDone) {
         inst.trigger('update', function(updateDone) {
-          data = removeUndefined(data);
+          data = Model._sanitize(data);
           function saveCallback(err, unusedData, result) {
             if (err) {
               return cb(err, inst);
@@ -2772,10 +2776,10 @@ DataAccessObject.updateAll = function(where, data, options, cb) {
     try {
       // Support an optional where object
       var handleUndefined = Model._getSetting('normalizeUndefinedInQuery');
-      // alter configuration of how removeUndefined handles undefined values
-      where = removeUndefined(where, handleUndefined);
+      // alter configuration of how sanitizeQuery handles undefined values
+      where = Model._sanitize(where, {handleUndefined: handleUndefined});
       where = Model._coerce(where, options);
-      data = removeUndefined(data);
+      data = Model._sanitize(data);
       data = Model._coerce(data, options);
     } catch (err) {
       return process.nextTick(function() {
@@ -3108,7 +3112,7 @@ DataAccessObject.replaceById = function(id, data, options, cb) {
 
     function validateAndCallConnector(err, data) {
       if (err) return cb(err);
-      data = removeUndefined(data);
+      data = Model._sanitize(data);
       // update instance's properties
       inst.setAttributes(data);
 
@@ -3260,7 +3264,7 @@ function(data, options, cb) {
   if (data instanceof Model) {
     data = data.toObject(false);
   }
-  data = removeUndefined(data);
+  data = Model._sanitize(data);
 
   // Make sure id(s) cannot be changed
   var idNames = Model.definition.idNames();
@@ -3333,7 +3337,7 @@ function(data, options, cb) {
           inst.trigger('update', function(done) {
             copyData(data, inst);
             var typedData = convertSubsetOfPropertiesByType(inst, data);
-            context.data = removeUndefined(typedData);
+            context.data = Model._sanitize(typedData);
 
             // Depending on the connector, the database response can
             // contain information about the updated record(s), but also

--- a/lib/include.js
+++ b/lib/include.js
@@ -204,6 +204,12 @@ Inclusion.include = function(objects, include, options, cb) {
    * @param cb
    */
   function findWithForeignKeysByPage(model, filter, fkName, pageSize, options, cb) {
+    try {
+      model._coerce(filter.where, {excludeProtectedProperties: true});
+    } catch (e) {
+      return cb(e);
+    }
+
     var foreignKeys = [];
     if (filter.where[fkName]) {
       foreignKeys = filter.where[fkName].inq;

--- a/lib/include.js
+++ b/lib/include.js
@@ -205,7 +205,8 @@ Inclusion.include = function(objects, include, options, cb) {
    */
   function findWithForeignKeysByPage(model, filter, fkName, pageSize, options, cb) {
     try {
-      model._coerce(filter.where, {excludeProtectedProperties: true});
+      model._sanitize(filter.where, {excludeProtectedProperties: true});
+      model._coerce(filter.where);
     } catch (e) {
       return cb(e);
     }

--- a/lib/include_utils.js
+++ b/lib/include_utils.js
@@ -5,6 +5,8 @@
 
 'use strict';
 
+var g = require('strong-globalize')();
+
 module.exports.buildOneToOneIdentityMapWithOrigKeys = buildOneToOneIdentityMapWithOrigKeys;
 module.exports.buildOneToManyIdentityMapWithOrigKeys = buildOneToManyIdentityMapWithOrigKeys;
 module.exports.join = join;
@@ -15,7 +17,7 @@ const util = require('util');
 function getId(obj, idName) {
   var id = obj && obj[idName];
   if (id == null) {
-    const msg = util.format('ID property "%s" is missing for included item: %j. ' +
+    const msg = g.f('ID property "%s" is missing for included item: %j. ' +
       'Please make sure `fields` include "%s" if it\'s present in the `filter`',
     idName, obj, idName);
     const err = new Error(msg);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -32,6 +32,7 @@ exports.validateKeys = validateKeys;
 var g = require('strong-globalize')();
 var traverse = require('traverse');
 var assert = require('assert');
+var debug = require('debug')('loopback:juggler:utils');
 
 function safeRequire(module) {
   try {
@@ -362,11 +363,13 @@ function validateKeys(where, prohibitedKeys) {
     return x;
   });
   if (offendingKeys.length) {
-    const msg = 'Properties "' + offendingKeys.join(', ') + '" are not allowed in query';
+    const msg = 'Invalid properties are used in query';
     const err = new Error(msg);
     err.code = 'PROPERTY_NOT_ALLOWED_IN_QUERY';
     err.statusCode = 400;
-    err.details = {properties: offendingKeys, where: where};
+    err.details = {where: where};
+    debug('Hidden or protected properties %j are used in query: %j',
+      offendingKeys, where, err);
     throw err;
   }
   return result;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -306,7 +306,7 @@ function selectFields(fields) {
  * Sanitize the query object
  * @param query {object} The query object
  * @param options
- * @property handleUndefined {String} either "nullify", "throw" or "ignore" (default: "ignore")
+ * @property normalizeUndefinedInQuery {String} either "nullify", "throw" or "ignore" (default: "ignore")
  * @property prohibitedKeys {String[]} An array of prohibited keys to be removed
  * @returns {*}
  */
@@ -318,11 +318,11 @@ function sanitizeQuery(query, options) {
   options = options || {};
   if (typeof options === 'string') {
     // Keep it backward compatible
-    options = {handleUndefined: options};
+    options = {normalizeUndefinedInQuery: options};
   }
   const prohibitedKeys = options.prohibitedKeys;
   const offendingKeys = [];
-  const handleUndefined = options.handleUndefined;
+  const normalizeUndefinedInQuery = options.normalizeUndefinedInQuery;
   const maxDepth = options.maxDepth || 10;
   // WARNING: [rfeng] Use map() will cause mongodb to produce invalid BSON
   // as traverse doesn't transform the ObjectId correctly
@@ -351,7 +351,7 @@ function sanitizeQuery(query, options) {
      * Handle undefined values
      */
     if (x === undefined) {
-      switch (handleUndefined) {
+      switch (normalizeUndefinedInQuery) {
         case 'nullify':
           this.update(null);
           break;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -27,6 +27,7 @@ exports.collectTargetIds = collectTargetIds;
 exports.idName = idName;
 exports.rankArrayElements = rankArrayElements;
 exports.idsHaveDuplicates = idsHaveDuplicates;
+exports.validateKeys = validateKeys;
 
 var g = require('strong-globalize')();
 var traverse = require('traverse');
@@ -302,7 +303,7 @@ function selectFields(fields) {
 }
 
 /**
- * Remove undefined values from the queury object
+ * Remove undefined values from the query object
  * @param query
  * @param handleUndefined {String} either "nullify", "throw" or "ignore" (default: "ignore")
  * @returns {exports.map|*}
@@ -337,6 +338,38 @@ function removeUndefined(query, handleUndefined) {
 
     return x;
   });
+}
+
+/**
+ * Check the where clause to report prohibited keys
+ * @param {object} where Where object
+ * @param {string[]} [prohibitedKeys] An array of prohibited keys
+ */
+function validateKeys(where, prohibitedKeys) {
+  if (!prohibitedKeys || prohibitedKeys.length === 0) return where;
+  if (typeof where !== 'object' || where === null) {
+    return where;
+  }
+  prohibitedKeys = prohibitedKeys || [];
+  const offendingKeys = [];
+  // WARNING: [rfeng] Use traverse.map() will cause mongodb to produce invalid BSON
+  // as traverse doesn't transform the ObjectId correctly. Instead we have to use
+  // traverse(where).forEach(...)
+  const result = traverse(where).forEach(function(x) {
+    if (prohibitedKeys.indexOf(this.key) !== -1) {
+      offendingKeys.push(this.key);
+    }
+    return x;
+  });
+  if (offendingKeys.length) {
+    const msg = 'Properties "' + offendingKeys.join(', ') + '" are not allowed in query';
+    const err = new Error(msg);
+    err.code = 'PROPERTY_NOT_ALLOWED_IN_QUERY';
+    err.statusCode = 400;
+    err.details = {properties: offendingKeys, where: where};
+    throw err;
+  }
+  return result;
 }
 
 var url = require('url');
@@ -505,7 +538,7 @@ function defineCachedRelations(obj) {
 
 /**
  * Check if the argument is plain object
- * @param {*) obj The obj value
+ * @param {*} obj The obj value
  * @returns {boolean}
  */
 function isPlainObject(obj) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,7 +7,7 @@
 exports.safeRequire = safeRequire;
 exports.fieldsToArray = fieldsToArray;
 exports.selectFields = selectFields;
-exports.removeUndefined = removeUndefined;
+exports.sanitizeQuery = sanitizeQuery;
 exports.parseSettings = parseSettings;
 exports.mergeSettings = exports.deepMerge = deepMerge;
 exports.deepMergeProperty = deepMergeProperty;
@@ -27,7 +27,6 @@ exports.collectTargetIds = collectTargetIds;
 exports.idName = idName;
 exports.rankArrayElements = rankArrayElements;
 exports.idsHaveDuplicates = idsHaveDuplicates;
-exports.validateKeys = validateKeys;
 
 var g = require('strong-globalize')();
 var traverse = require('traverse');
@@ -304,18 +303,53 @@ function selectFields(fields) {
 }
 
 /**
- * Remove undefined values from the query object
- * @param query
- * @param handleUndefined {String} either "nullify", "throw" or "ignore" (default: "ignore")
- * @returns {exports.map|*}
+ * Sanitize the query object
+ * @param query {object} The query object
+ * @param options
+ * @property handleUndefined {String} either "nullify", "throw" or "ignore" (default: "ignore")
+ * @property prohibitedKeys {String[]} An array of prohibited keys to be removed
+ * @returns {*}
  */
-function removeUndefined(query, handleUndefined) {
+function sanitizeQuery(query, options) {
+  debug('Sanitizing query object: %j', query);
   if (typeof query !== 'object' || query === null) {
     return query;
   }
+  options = options || {};
+  if (typeof options === 'string') {
+    // Keep it backward compatible
+    options = {handleUndefined: options};
+  }
+  const prohibitedKeys = options.prohibitedKeys;
+  const offendingKeys = [];
+  const handleUndefined = options.handleUndefined;
+  const maxDepth = options.maxDepth || 10;
   // WARNING: [rfeng] Use map() will cause mongodb to produce invalid BSON
   // as traverse doesn't transform the ObjectId correctly
-  return traverse(query).forEach(function(x) {
+  const result = traverse(query).forEach(function(x) {
+    /**
+     * Security risk if the client passes in a very deep where object
+     */
+    if (this.level > maxDepth || this.circular) {
+      const msg = g.f('The query object is too deep or circular');
+      const err = new Error(msg);
+      err.statusCode = 400;
+      err.code = 'WHERE_OBJECT_TOO_DEEP';
+      throw err;
+    }
+    /**
+     * Make sure prohibited keys are removed from the query to prevent
+     * sensitive values from being guessed
+     */
+    if (prohibitedKeys && prohibitedKeys.indexOf(this.key) !== -1) {
+      offendingKeys.push(this.key);
+      this.remove();
+      return;
+    }
+
+    /**
+     * Handle undefined values
+     */
     if (x === undefined) {
       switch (handleUndefined) {
         case 'nullify':
@@ -323,7 +357,6 @@ function removeUndefined(query, handleUndefined) {
           break;
         case 'throw':
           throw new Error(g.f('Unexpected `undefined` in query'));
-          break;
         case 'ignore':
         default:
           this.remove();
@@ -339,44 +372,20 @@ function removeUndefined(query, handleUndefined) {
 
     return x;
   });
-}
 
-/**
- * Check the where clause to report prohibited keys
- * @param {object} where Where object
- * @param {string[]} [prohibitedKeys] An array of prohibited keys
- */
-function validateKeys(where, prohibitedKeys) {
-  if (!prohibitedKeys || prohibitedKeys.length === 0) return where;
-  if (typeof where !== 'object' || where === null) {
-    return where;
-  }
-  prohibitedKeys = prohibitedKeys || [];
-  const offendingKeys = [];
-  // WARNING: [rfeng] Use traverse.map() will cause mongodb to produce invalid BSON
-  // as traverse doesn't transform the ObjectId correctly. Instead we have to use
-  // traverse(where).forEach(...)
-  const result = traverse(where).forEach(function(x) {
-    if (prohibitedKeys.indexOf(this.key) !== -1) {
-      offendingKeys.push(this.key);
-    }
-    return x;
-  });
   if (offendingKeys.length) {
-    const msg = 'Invalid properties are used in query';
-    const err = new Error(msg);
-    err.code = 'PROPERTY_NOT_ALLOWED_IN_QUERY';
-    err.statusCode = 400;
-    err.details = {where: where};
-    debug('Hidden or protected properties %j are used in query: %j',
-      offendingKeys, where, err);
-    throw err;
+    console.error(
+      g.f(
+        'Potential security alert: hidden/protected properties %j are used in query.',
+        offendingKeys
+      )
+    );
   }
   return result;
 }
 
-var url = require('url');
-var qs = require('qs');
+const url = require('url');
+const qs = require('qs');
 
 /**
  * Parse a URL into a settings object

--- a/test/allow-extended-operators.test.js
+++ b/test/allow-extended-operators.test.js
@@ -67,50 +67,59 @@ describe('allowExtendedOperators', () => {
     }
   }
 
+  function assertOperatorNotAllowed(err) {
+    should.exist(err);
+    err.message.should.match(/Operators "\$exists" are not allowed in query/);
+    err.code.should.equal('OPERATOR_NOT_ALLOWED_IN_QUERY');
+    err.statusCode.should.equal(400);
+    err.details.should.have.property('operators');
+    err.details.should.have.property('where');
+  }
+
   describe('dataSource.settings.allowExtendedOperators', () => {
     context('DAO.find()', () => {
-      it('converts extended operators to string value by default', () => {
+      it('reports invalid operator by default', () => {
         const TestModel = createTestModel();
-        return TestModel.find(extendedQuery()).then((results) => {
-          should(results[0].value).eql('[object Object]');
+        return TestModel.find(extendedQuery()).catch(err => {
+          assertOperatorNotAllowed(err);
         });
       });
 
       it('preserves extended operators with allowExtendedOperators set', () => {
         const TestModel = createTestModel({allowExtendedOperators: true});
-        return TestModel.find(extendedQuery()).then((results) => {
+        return TestModel.find(extendedQuery()).then(results => {
           should(results[0].value).eql({$exists: true});
         });
       });
 
       it('`Model.settings.allowExtendedOperators` override data source settings - ' +
-        'converts extended operators', () => {
+        'reports invalid operator', () => {
         const TestModel = createTestModel({allowExtendedOperators: true}, {allowExtendedOperators: false});
-        return TestModel.find(extendedQuery()).then((results) => {
-          should(results[0].value).eql('[object Object]');
+        return TestModel.find(extendedQuery()).catch(err => {
+          assertOperatorNotAllowed(err);
         });
       });
 
       it('`Model.settings.allowExtendedOperators` override data source settings - ' +
         'preserves extended operators', () => {
         const TestModel = createTestModel({allowExtendedOperators: false}, {allowExtendedOperators: true});
-        return TestModel.find(extendedQuery()).then((results) => {
+        return TestModel.find(extendedQuery()).then(results => {
           should(results[0].value).eql({$exists: true});
         });
       });
 
       it('`options.allowExtendedOperators` override data source settings - ' +
-        'converts extended operators', () => {
+        'reports invalid operator', () => {
         const TestModel = createTestModel({allowExtendedOperators: true});
-        return TestModel.find(extendedQuery(), {allowExtendedOperators: false}).then((results) => {
-          should(results[0].value).eql('[object Object]');
+        return TestModel.find(extendedQuery(), {allowExtendedOperators: false}).catch(err => {
+          assertOperatorNotAllowed(err);
         });
       });
 
       it('`options.allowExtendedOperators` override data source settings - ' +
         'preserves extended operators', () => {
         const TestModel = createTestModel({allowExtendedOperators: false});
-        return TestModel.find(extendedQuery(), {allowExtendedOperators: true}).then((results) => {
+        return TestModel.find(extendedQuery(), {allowExtendedOperators: true}).then(results => {
           should(results[0].value).eql({$exists: true});
         });
       });
@@ -168,37 +177,37 @@ describe('allowExtendedOperators', () => {
     context('DAO.find()', () => {
       it('preserves extended operators with allowExtendedOperators set', () => {
         const TestModel = createTestModel({}, {allowExtendedOperators: true});
-        return TestModel.find(extendedQuery()).then((results) => {
+        return TestModel.find(extendedQuery()).then(results => {
           should(results[0].value).eql({$exists: true});
         });
       });
 
       it('`dataSource.settings.allowExtendedOperators` honor Model settings - ' +
-        'converts extended operators', () => {
+        'reports invalid operator', () => {
         const TestModel = createTestModel({allowExtendedOperators: true}, {allowExtendedOperators: false});
-        return TestModel.find(extendedQuery()).then((results) => {
-          should(results[0].value).eql('[object Object]');
+        return TestModel.find(extendedQuery()).catch(err => {
+          assertOperatorNotAllowed(err);
         });
       });
 
       it('`dataSource.settings.allowExtendedOperators` honor Model settings - ' +
         'preserves extended operators', () => {
         const TestModel = createTestModel({allowExtendedOperators: false}, {allowExtendedOperators: true});
-        return TestModel.find(extendedQuery()).then((results) => {
+        return TestModel.find(extendedQuery()).then(results => {
           should(results[0].value).eql({$exists: true});
         });
       });
 
       it('`options.allowExtendedOperators` override Model settings - converts extended operators', () => {
         const TestModel = createTestModel({allowExtendedOperators: true});
-        return TestModel.find(extendedQuery(), {allowExtendedOperators: false}).then((results) => {
-          should(results[0].value).eql('[object Object]');
+        return TestModel.find(extendedQuery(), {allowExtendedOperators: false}).catch(err => {
+          assertOperatorNotAllowed(err);
         });
       });
 
       it('`options.allowExtendedOperators` Model settings - preserves extended operators', () => {
         const TestModel = createTestModel({allowExtendedOperators: false});
-        return TestModel.find(extendedQuery(), {allowExtendedOperators: true}).then((results) => {
+        return TestModel.find(extendedQuery(), {allowExtendedOperators: true}).then(results => {
           should(results[0].value).eql({$exists: true});
         });
       });
@@ -255,7 +264,7 @@ describe('allowExtendedOperators', () => {
     context('DAO.find()', () => {
       it('preserves extended operators with allowExtendedOperators set', () => {
         const TestModel = createTestModel();
-        return TestModel.find(extendedQuery(), {allowExtendedOperators: true}).then((results) => {
+        return TestModel.find(extendedQuery(), {allowExtendedOperators: true}).then(results => {
           should(results[0].value).eql({$exists: true});
         });
       });
@@ -263,15 +272,15 @@ describe('allowExtendedOperators', () => {
       it('`dataSource.settings.allowExtendedOperators` honor options settings - ' +
         'converts extended operators', () => {
         const TestModel = createTestModel({allowExtendedOperators: true});
-        return TestModel.find(extendedQuery(), {allowExtendedOperators: false}).then((results) => {
-          should(results[0].value).eql('[object Object]');
+        return TestModel.find(extendedQuery(), {allowExtendedOperators: false}).catch(err => {
+          assertOperatorNotAllowed(err);
         });
       });
 
       it('`dataSource.settings.allowExtendedOperators` honor options settings - ' +
         'preserves extended operators', () => {
         const TestModel = createTestModel({allowExtendedOperators: false});
-        return TestModel.find(extendedQuery(), {allowExtendedOperators: true}).then((results) => {
+        return TestModel.find(extendedQuery(), {allowExtendedOperators: true}).then(results => {
           should(results[0].value).eql({$exists: true});
         });
       });
@@ -279,15 +288,15 @@ describe('allowExtendedOperators', () => {
       it('`Model.settings.allowExtendedOperators` honor options settings - ' +
         'converts extended operators', () => {
         const TestModel = createTestModel({}, {allowExtendedOperators: true});
-        return TestModel.find(extendedQuery(), {allowExtendedOperators: false}).then((results) => {
-          should(results[0].value).eql('[object Object]');
+        return TestModel.find(extendedQuery(), {allowExtendedOperators: false}).catch(err => {
+          assertOperatorNotAllowed(err);
         });
       });
 
       it('`Model.settings.allowExtendedOperators` honor options settings - ' +
         'preserves extended operators', () => {
         const TestModel = createTestModel({}, {allowExtendedOperators: false});
-        return TestModel.find(extendedQuery(), {allowExtendedOperators: true}).then((results) => {
+        return TestModel.find(extendedQuery(), {allowExtendedOperators: true}).then(results => {
           should(results[0].value).eql({$exists: true});
         });
       });

--- a/test/model-definition.test.js
+++ b/test/model-definition.test.js
@@ -332,10 +332,9 @@ describe('ModelDefinition class', function() {
 
   function assertPropertyNotAllowed(err) {
     should.exist(err);
-    err.message.should.match(/Properties "secret" are not allowed in query/);
+    err.message.should.match(/Invalid properties are used in query/);
     err.code.should.equal('PROPERTY_NOT_ALLOWED_IN_QUERY');
     err.statusCode.should.equal(400);
-    err.details.should.have.property('properties');
     err.details.should.have.property('where');
   }
 

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -78,7 +78,7 @@ describe('util.sanitizeQuery', function() {
     should.deepEqual(sanitizeQuery(q5, 'nullify'), {where: {x: 1, y: null}});
 
     q5 = {where: {x: 1, y: undefined}};
-    should.deepEqual(sanitizeQuery(q5, {handleUndefined: 'nullify'}), {where: {x: 1, y: null}});
+    should.deepEqual(sanitizeQuery(q5, {normalizeUndefinedInQuery: 'nullify'}), {where: {x: 1, y: null}});
 
     var q6 = {where: {x: 1, y: undefined}};
     (function() { sanitizeQuery(q6, 'throw'); }).should.throw(/`undefined` in query/);


### PR DESCRIPTION
### Description

If we allow hidden properties to be part of the query condition, there is security risk for brute-force guessing.

It also checks circular and deep objects to avoid DoS attack.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
