### PR TITLE
Fix crash app when include is number

### DIFF
--- a/lib/include.js
+++ b/lib/include.js
@@ -47,7 +47,7 @@ function normalizeInclude(include) {
     }
     return newInclude;
   } else {
-    return include;
+    return [include];
   }
 }
 


### PR DESCRIPTION
### Description

When include parameter is number, boolean (ex: {"include": 1}), the server will crash