### PR TITLE
Clear cache after destroying related model (hasOne)

### DIFF
--- a/lib/relation-definition.js
+++ b/lib/relation-definition.js
@@ -1862,9 +1862,11 @@ HasOne.prototype.destroy = function(options, cb) {
     options = {};
   }
   cb = cb || utils.createPromiseCallback();
+  var self = this;
   var definition = this.definition;
   this.fetch(function(err, targetModel) {
     if (targetModel instanceof ModelBaseClass) {
+      self.resetCache();
       targetModel.destroy(options, cb);
     } else {
       cb(new Error(g.f('{{HasOne}} relation %s is empty', definition.name)));

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -3715,7 +3715,11 @@ describe('relations', function() {
         should.exist(supplier);
         supplier.account.destroy(function(err) {
           should.not.exist(e);
-          done();
+          supplier.account(function(err, act) {
+            if (err) return done(err);
+            should.not.exist(act);
+            done();
+          });
         });
       });
     });
@@ -3728,7 +3732,11 @@ describe('relations', function() {
             .then(function(account) {
               return supplier.account.destroy();
             })
-            .then(function(err) {
+            .then(function() {
+              return supplier.account();
+            })
+            .then(function(act) {
+              should.not.exist(act);
               done();
             });
         })


### PR DESCRIPTION
### Description

Related model is still accessible after its destruction in the `hasOne` relationship. I believe the cache should be cleared to avoid that. I've extended existing tests to demonstrate the problem.

Can someone please review? Maybe @bajtos ?

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
