### PR TITLE
Allow hidden/protected props as an object

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1646,22 +1646,32 @@ function coerceArray(val) {
 
 DataAccessObject._getHiddenProperties = function() {
   var settings = this.definition.settings || {};
-  var result = settings.hiddenProperties || settings.hidden;
+  var result = settings.hiddenProperties || settings.hidden || [];
   if (typeof result === 'string') {
     result = [result];
   }
-  result = result || [];
-  return result;
+  if (Array.isArray(result)) {
+    return result;
+  } else {
+    // See https://github.com/strongloop/loopback-datasource-juggler/issues/1646
+    // `ModelBaseClass` normalize the properties to an object such as `{secret: true}`
+    return Object.keys(result);
+  }
 };
 
 DataAccessObject._getProtectedProperties = function() {
   var settings = this.definition.settings || {};
-  var result = settings.protectedProperties || settings.protected;
+  var result = settings.protectedProperties || settings.protected || [];
   if (typeof result === 'string') {
     result = [result];
   }
-  result = result || [];
-  return result;
+  if (Array.isArray(result)) {
+    return result;
+  } else {
+    // See https://github.com/strongloop/loopback-datasource-juggler/issues/1646
+    // `ModelBaseClass` normalize the properties to an object such as `{secret: true}`
+    return Object.keys(result);
+  }
 };
 
 DataAccessObject._sanitize = function(query, options) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -551,7 +551,7 @@ ModelBaseClass.prototype.toObject = function(onlySchema, removeHidden, removePro
 /**
  * Checks if property is protected.
  * @param {String} propertyName Property name
- * @returns  {Boolean} true or false if proptected or not.
+ * @returns  {Boolean} true or false if protected or not.
  */
 ModelBaseClass.isProtectedProperty = function(propertyName) {
   var Model = this;

--- a/test/model-definition.test.js
+++ b/test/model-definition.test.js
@@ -338,26 +338,46 @@ describe('ModelDefinition class', function() {
 
   describe('hidden properties', function() {
     var Child;
-    beforeEach(givenChildren);
 
-    it('should be removed if used in where', function() {
-      return Child.find({
-        where: {secret: 'guess'},
-      }).then(assertHiddenPropertyIsIgnored);
+    describe('with hidden array', function() {
+      beforeEach(function() { givenChildren(); });
+
+      it('should be removed if used in where', function() {
+        return Child.find({
+          where: {secret: 'guess'},
+        }).then(assertHiddenPropertyIsIgnored);
+      });
+
+      it('should be removed if used in where.and', function() {
+        return Child.find({
+          where: {and: [{secret: 'guess'}]},
+        }).then(assertHiddenPropertyIsIgnored);
+      });
     });
 
-    it('should be removed if used in where.and', function() {
-      return Child.find({
-        where: {and: [{secret: 'guess'}]},
-      }).then(assertHiddenPropertyIsIgnored);
+    describe('with hidden object', function() {
+      beforeEach(function() { givenChildren({hiddenProperties: {secret: true}}); });
+
+      it('should be removed if used in where', function() {
+        return Child.find({
+          where: {secret: 'guess'},
+        }).then(assertHiddenPropertyIsIgnored);
+      });
+
+      it('should be removed if used in where.and', function() {
+        return Child.find({
+          where: {and: [{secret: 'guess'}]},
+        }).then(assertHiddenPropertyIsIgnored);
+      });
     });
 
     /**
      * Create two children with a hidden property, one with a matching
      * value, the other with a non-matching value
      */
-    function givenChildren() {
-      Child = memory.createModel('child', {}, {hidden: ['secret']});
+    function givenChildren(hiddenProps) {
+      hiddenProps = hiddenProps || {hidden: ['secret']};
+      Child = memory.createModel('child', {}, hiddenProps);
       return Child.create([{
         name: 'childA',
         secret: 'secret',


### PR DESCRIPTION
### Description

Model settings hidden/protected properties can be an array or object, such as:

- hidden: ['secret']
- hidden: {secret: true}

#### Related issues

#1646 

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
