### PR TITLE
fix: update typescript declarations

### DIFF
--- a/types/connector.d.ts
+++ b/types/connector.d.ts
@@ -15,6 +15,7 @@ export interface Connector {
   disconnect(callback?: Callback): PromiseOrVoid; // Disconnect from the underlying system
   ping(callback?: Callback): PromiseOrVoid; // Ping the underlying system
   execute?(...args: any[]): Promise<any>;
+  [property: string]: any; // Other properties that vary by connectors
 }
 
 /**

--- a/types/persisted-model.d.ts
+++ b/types/persisted-model.d.ts
@@ -154,7 +154,7 @@ export declare class PersistedModel extends ModelBase {
     data: PersistedData,
     options?: Options,
     callback?: Callback<PersistedModel>,
-  ): PromiseOrVoid<PersistedModel>;
+  ): PromiseOrVoid<[PersistedModel, boolean]>;
 
   /**
    * Check whether a model instance exists in database.


### PR DESCRIPTION
### Description
Fix return type of PersistedModel's `findOrCreate` function so that it conforms to the return contract of connectors which support it (took mongodb and memory as examples). Also, add a string index signature to the `Connector` interface to allow checks for atomic functions.

Connect to https://github.com/strongloop/loopback-next/issues/1956. 


### Checklist


- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
