### PR TITLE
Fix createModelClassCtor instanceof + new for models named “data” or “options”

### DIFF
--- a/lib/model-builder.js
+++ b/lib/model-builder.js
@@ -656,41 +656,19 @@ ModelBuilder.prototype.define = function defineClass(className, properties, sett
 };
 
 function createModelClassCtor(name, ModelBaseClass) {
-  // A simple sanitization to handle most common characters
-  // that are used in model names but cannot be used as a function/class name.
-  // Note that the rules for valid JS indentifiers are way too complex,
-  // implementing a fully spec-compliant sanitization is not worth the effort.
-  // See https://mathiasbynens.be/notes/javascript-identifiers-es6
+  // Backwards-compatible replacements of common characters.
+  // https://github.com/strongloop/loopback-datasource-juggler/pull/1534
   name = name.replace(/[-.:]/g, '_');
-  let constructor;
 
-  try {
-    // It is not possible to access closure variables like "ModelBaseClass"
-    // from a dynamically defined function. The solution is to
-    // create a dynamically defined factory function that accepts
-    // closure variables as arguments.
-    const factory = new Function('ModelBaseClass', `
-      // every class can receive hash of data as optional param
-      return function constructor(data, options) {
-        if (!(this instanceof constructor)) {
-          return new constructor(data, options);
-        }
-        if (constructor.settings.unresolved) {
-          throw new Error(g.f('Model %s is not defined.', ${JSON.stringify(name)}));
-        }
-        ModelBaseClass.apply(this, arguments);
-      };`);
-
-    constructor = factory(ModelBaseClass);
-  } catch (err) {
-    // modelName is not a valid function/class name, e.g. 'grand-child'
-    // and our simple sanitization was not good enough.
-    // Falling back to legacy 'ModelConstructor' name.
-    if (err.name === 'SyntaxError') {
-      return createModelClassCtor('ModelConstructor', ModelBaseClass);
-    } else {
-      throw err;
+  // every class can receive hash of data as optional param
+  function constructor(data, options) {
+    if (!(this instanceof constructor)) {
+      return new constructor(data, options);
     }
+    if (constructor.settings.unresolved) {
+      throw new Error(g.f('Model %s is not defined.', name));
+    }
+    ModelBaseClass.apply(this, arguments);
   }
 
   Object.defineProperty(constructor, 'name', {

--- a/lib/model-builder.js
+++ b/lib/model-builder.js
@@ -662,6 +662,7 @@ function createModelClassCtor(name, ModelBaseClass) {
   // implementing a fully spec-compliant sanitization is not worth the effort.
   // See https://mathiasbynens.be/notes/javascript-identifiers-es6
   name = name.replace(/[-.:]/g, '_');
+  let constructor;
 
   try {
     // It is not possible to access closure variables like "ModelBaseClass"
@@ -670,17 +671,17 @@ function createModelClassCtor(name, ModelBaseClass) {
     // closure variables as arguments.
     const factory = new Function('ModelBaseClass', `
       // every class can receive hash of data as optional param
-      return function ${name}(data, options) {
-        if (!(this instanceof ${name})) {
-          return new ${name}(data, options);
+      return function constructor(data, options) {
+        if (!(this instanceof constructor)) {
+          return new constructor(data, options);
         }
-        if (${name}.settings.unresolved) {
+        if (constructor.settings.unresolved) {
           throw new Error(g.f('Model %s is not defined.', ${JSON.stringify(name)}));
         }
         ModelBaseClass.apply(this, arguments);
       };`);
 
-    return factory(ModelBaseClass);
+    constructor = factory(ModelBaseClass);
   } catch (err) {
     // modelName is not a valid function/class name, e.g. 'grand-child'
     // and our simple sanitization was not good enough.
@@ -691,6 +692,13 @@ function createModelClassCtor(name, ModelBaseClass) {
       throw err;
     }
   }
+
+  Object.defineProperty(constructor, 'name', {
+    configurable: true,
+    value: name,
+  });
+
+  return constructor;
 }
 
 // DataType for Date

--- a/test/model-builder.test.js
+++ b/test/model-builder.test.js
@@ -42,9 +42,9 @@ describe('ModelBuilder', () => {
         MyModel.should.have.property('name', 'local_User');
       });
 
-      it('falls back to legacy "ModelConstructor" in other cases', () => {
+      it('falls back to provided name in other cases', () => {
         const MyModel = builder.define('Grand\tchild');
-        MyModel.should.have.property('name', 'ModelConstructor');
+        MyModel.should.have.property('name', 'Grand\tchild');
       });
 
       it('supports model names that match parameter names', () => {

--- a/test/model-builder.test.js
+++ b/test/model-builder.test.js
@@ -46,6 +46,11 @@ describe('ModelBuilder', () => {
         const MyModel = builder.define('Grand\tchild');
         MyModel.should.have.property('name', 'ModelConstructor');
       });
+
+      it('supports model names that match parameter names', () => {
+        builder.define('data').should.not.throw();
+        builder.define('options').should.not.throw();
+      });
     });
 
     function givenModelBuilderInstance() {


### PR DESCRIPTION
### Description

Building a function out of a string with `new Function` isn’t necessary to set its name.

This isn’t strictly backwards-compatible because names that aren’t valid identifiers after replacing `[-.:]` won’t become `ModelConstructor` anymore. That’s in order to avoid something silly like:

```js
try {
  void new Function(`
    void function ${name}(data, options) {
      if (!(this instanceof ${name})) {}
    };
    ${JSON.stringify(name)};`);
} catch (error) {
  name = 'ModelConstructor';
}
```

(which still doesn’t cover everything from the original if you take into account names designed to break it.)

### Checklist

- [X] New tests added or existing tests modified to cover all changes
- [X] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide.html)
