### PR TITLE
Fix Promisification of DAO create methods when a type constructor throws

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -493,8 +493,8 @@ function createPromiseCallback() {
 
   var promise = new Promise(function(resolve, reject) {
     cb = function(err, data) {
-      if (err) return reject(err);
-      return resolve(data);
+      err ? reject(err) : resolve(data);
+      return promise;
     };
   });
   cb.promise = promise;

--- a/test/datatype.test.js
+++ b/test/datatype.test.js
@@ -61,6 +61,19 @@ describe('datatypes', function() {
       });
     });
 
+  it('throws an error when property of type Date is set to an invalid value using promises',
+    function() {
+      var myModel = db.define('myModel', {
+        date: {type: Date},
+      });
+
+      return myModel
+        .create({date: 'invalid'})
+        .catch(function(err) {
+          (err.message).should.equal('Invalid date: invalid');
+        });
+    });
+
   it('should keep types when get read data from db', function(done) {
     var d = new Date, id;
 


### PR DESCRIPTION

### Description

The issue can be exhibited by using  ```Model.create({date: 'bad data that'})```.


When calling DAO.create without a callback,

- the DAO tries to `applyProperties` https://github.com/strongloop/loopback-datasource-juggler/blob/2.x/lib/dao.js#L294.
- this trigger the DateType to throw in its constructor https://github.com/strongloop/loopback-datasource-juggler/blob/2.x/lib/dao.js#L1518
- because of the error, the create method returns early without ever returning the promise.

The fix ensures that when this occurs, we always return the promise. This should fix any other instances of the same bug.

#### Related issues

I'm sure I've read issues related to this previously but can't find them anywhere. 
The issues usually refer to custom types introduced with `registerType`

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
