### PR TITLE
feat: add unique index support on create for in-memory connector

### DIFF
--- a/lib/connectors/memory.js
+++ b/lib/connectors/memory.js
@@ -255,12 +255,14 @@ Memory.prototype._createSync = function(model, data, fn) {
     this.collection(model, {});
   }
 
-  for (var p in props) {
-    if (props[p].index && props[p].index.unique === true) {
+  var indexes = this._models[model].model.definition.indexes();
+  for (var idx in indexes) {
+    var idxPropName = idx.substring(0, idx.indexOf('_index'));
+    if (indexes[idx].unique === true) {
       for (var instId in this.cache[model]) {
         var inst = JSON.parse(this.cache[model][instId]);
-        if (inst[p] === data[p]) {
-          var duplicateIndexError = new Error(g.f('Duplicate entry for %s.%s', model, p));
+        if (inst[idxPropName] === data[idxPropName]) {
+          var duplicateIndexError = new Error(g.f('Duplicate entry for %s.%s', model, idxPropName));
           duplicateIndexError.statusCode = duplicateIndexError.status = 409;
           return fn(duplicateIndexError);
         }

--- a/lib/connectors/memory.js
+++ b/lib/connectors/memory.js
@@ -255,6 +255,19 @@ Memory.prototype._createSync = function(model, data, fn) {
     this.collection(model, {});
   }
 
+  for (var p in props) {
+    if (props[p].index && props[p].index.unique === true) {
+      for (var instId in this.cache[model]) {
+        var inst = JSON.parse(this.cache[model][instId]);
+        if (inst[p] === data[p]) {
+          var duplicateIndexError = new Error(g.f('Duplicate entry for %s.%s', model, p));
+          duplicateIndexError.statusCode = duplicateIndexError.status = 409;
+          return fn(duplicateIndexError);
+        }
+      }
+    }
+  }
+
   if (this.collection(model)[id]) {
     var error = new Error(g.f('Duplicate entry for %s.%s', model, idName));
     error.statusCode = error.status = 409;

--- a/test/memory.test.js
+++ b/test/memory.test.js
@@ -677,6 +677,24 @@ describe('Memory connector', function() {
     });
   });
 
+  it('should refuse to create object with duplicate unique index', function(done) {
+    var ds = new DataSource({connector: 'memory'});
+    var Product = ds.define('ProductTest', {name: {type: String, index: {unique: true}}}, {forceId: false});
+    ds.automigrate('ProductTest', function(err) {
+      if (err) return done(err);
+
+      Product.create({name: 'a-name'}, function(err, p) {
+        if (err) return done(err);
+        Product.create({name: 'a-name'}, function(err) {
+          should.exist(err);
+          err.message.should.match(/Duplicate/i);
+          err.statusCode.should.equal(409);
+          done();
+        });
+      });
+    });
+  });
+
   describe('automigrate', function() {
     var ds;
     beforeEach(function() {


### PR DESCRIPTION
### Description
Connect to https://github.com/strongloop/loopback-next/pull/2126. Goal is to add support for unique indexes for `in-memory` connector. So far I've added logic to throw on duplicate entries for unique index properties. I'm sure there is more to add as I'm not familiar with how the connector works.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
