### PR TITLE
detect options in parameters of findById in case of using async/await

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1314,6 +1314,11 @@ DataAccessObject.findById = function findById(id, filter, options, cb) {
       cb = filter;
       filter = {};
     }
+    else if (typeof filter === 'object' && !(filter.include || filter.fields)) {
+      // If filter doesn't have include or fields, assuming it's options
+      options = filter;
+      filter = {};
+    }
   } else if (cb === undefined) {
     if (typeof options === 'function') {
       // findById(id, query, cb)


### PR DESCRIPTION
This happened because if the `options` is `null `and the cb is `null `(which is the case if you didn't pass any `include`, or `fields`, and use `async/await`, then it will not be caught in the those if cases.

Description
In case you want to pass `options `to Model query methods like `find`, `findById`, ... to use it in an operation hook, for example, there is a bug if you try to do that using `async/await`

consider the following code:

`const user = await User.findById(23, options);`

if you have an operation hook on access the User model like so:

```
Model.observe("access", async function(ctx) { 
 const options = ctx.options; //options here will be undefined
});
```
This is because of the following wrong if in dao.js

```
DataAccessObject.findById = function findById(id, filter, options, cb) {
  var connectionPromise = stillConnecting(this.getDataSource(), this, arguments);
  if (connectionPromise) {
    return connectionPromise;
  }

  assert(arguments.length >= 1, 'The id argument is required');

  if (options === undefined && cb === undefined) {
    if (typeof filter === 'function') {
      // findById(id, cb)
      cb = filter;
      filter = {};
    }
   //-----> this is the missing else if to fix the issue
    else if (typeof filter === 'object' && !(filter.include || filter.fields)) {
      // If filter doesn't have include or fields, assuming it's options
      options = filter;
      filter = {};
    }
  } else if (cb === undefined) {
    if (typeof options === 'function') {
      // findById(id, query, cb)
      cb = options;
      options = {};
      if (typeof filter === 'object' && !(filter.include || filter.fields)) {
        // If filter doesn't have include or fields, assuming it's options
        options = filter;
        filter = {};
      }
    }
  }
```
This happened because if the options is null and the cb is null (which is the case if you didn't pass any include, or fields, and use `async/await`, then it will not be caught in the those if cases.