### PR TITLE
fix: use existing field in exclude test

### DIFF
--- a/test/include.test.js
+++ b/test/include.test.js
@@ -77,7 +77,7 @@ describe('include', function() {
   });
 
   it('should report errors if the PK is excluded', function(done) {
-    User.find({include: 'posts', fields: 'posts'}, function(err) {
+    User.find({include: 'posts', fields: 'name'}, function(err) {
       should.exist(err);
       err.message.should.match(/ID property "id" is missing/);
       done();


### PR DESCRIPTION
### Description
Fix include test which was using an unknown property name in `fields` object so downstream PRs and tests can pass. The `posts` property doesn't exist on `User` model, so use `name` instead.

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
