### PR TITLE
Fix callback for find queries with near filters

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1531,6 +1531,7 @@ DataAccessObject.find = function find(query, options, cb) {
 
   const near = query && geo.nearFilter(query.where);
   const supportsGeo = !!connector.buildNearFilter;
+  let geoQueryObject;
 
   if (near) {
     if (supportsGeo) {
@@ -1558,65 +1559,64 @@ DataAccessObject.find = function find(query, options, cb) {
           queryGeo(ctx.query);
         });
       }
-
-      function queryGeo(query) {
-        function geoCallbackWithoutNotify(err, data) {
-          const memory = new Memory();
-          const modelName = self.modelName;
-
-          if (err) {
-            cb(err);
-          } else if (Array.isArray(data)) {
-            memory.define({
-              properties: self.dataSource.definitions[modelName].properties,
-              settings: self.dataSource.definitions[modelName].settings,
-              model: self,
-            });
-
-            data.forEach(function(obj) {
-              memory.create(modelName, obj, options, function() {
-                // noop
-              });
-            });
-
-            // FIXME: apply "includes" and other transforms - see allCb below
-            memory.all(modelName, query, options, cb);
-          } else {
-            cb(null, []);
-          }
-        }
-
-        function geoCallbackWithNotify(err, data) {
-          if (err) return cb(err);
-
-          async.map(data, function(item, next) {
-            const context = {
-              Model: self,
-              data: item,
-              isNewInstance: false,
-              hookState: hookState,
-              options: options,
-            };
-
-            self.notifyObserversOf('loaded', context, function(err) {
-              if (err) return next(err);
-              next(null, context.data);
-            });
-          }, function(err, results) {
-            if (err) return cb(err);
-            geoCallbackWithoutNotify(null, results);
-          });
-        }
-
-        const geoCallback = options.notify === false ? geoCallbackWithoutNotify : geoCallbackWithNotify;
-        invokeConnectorMethod(connector, 'all', self, [{}], options, geoCallback);
-      }
       // already handled
       return cb.promise;
     }
   }
+  function geoCallbackWithoutNotify(err, data) {
+    const memory = new Memory();
+    const modelName = self.modelName;
 
-  const allCb = function(err, data) {
+    if (err) {
+      cb(err);
+    } else if (Array.isArray(data)) {
+      memory.define({
+        properties: self.dataSource.definitions[modelName].properties,
+        settings: self.dataSource.definitions[modelName].settings,
+        model: self,
+      });
+
+      data.forEach(function(obj) {
+        memory.create(modelName, obj, options, function() {
+          // noop
+        });
+      });
+
+      // FIXME: apply "includes" and other transforms - see allCb below
+      memory.all(modelName, geoQueryObject, options, allCb);
+    } else {
+      cb(null, []);
+    }
+  }
+
+  function geoCallbackWithNotify(err, data) {
+    if (err) return cb(err);
+
+    async.map(data, function(item, next) {
+      const context = {
+        Model: self,
+        data: item,
+        isNewInstance: false,
+        hookState: hookState,
+        options: options,
+      };
+
+      self.notifyObserversOf('loaded', context, function(err) {
+        if (err) return next(err);
+        next(null, context.data);
+      });
+    }, function(err, results) {
+      if (err) return cb(err);
+      geoCallbackWithoutNotify(null, results);
+    });
+  }
+  function queryGeo(query) {
+    geoQueryObject = query;
+    const geoCallback = options.notify === false ? geoCallbackWithoutNotify : geoCallbackWithNotify;
+    invokeConnectorMethod(connector, 'all', self, [{}], options, geoCallback);
+  }
+
+  function allCb(err, data) {
     if (!err && Array.isArray(data)) {
       async.map(data, function(item, next) {
         const Model = self.lookupModel(item);
@@ -1709,7 +1709,7 @@ DataAccessObject.find = function find(query, options, cb) {
     } else {
       cb(err, data || []);
     }
-  };
+  }
 
   if (options.notify === false) {
     invokeConnectorMethod(connector, 'all', self, [query], options, allCb);

--- a/test/basic-querying.test.js
+++ b/test/basic-querying.test.js
@@ -654,6 +654,7 @@ describe('basic-querying', function() {
             if (err) done(err);
             users.should.have.property('length', 3);
             users[0].name.should.equal('John Lennon');
+            users[0].should.be.instanceOf(User);
             users[0].addressLoc.should.not.be.null();
             done();
           });
@@ -677,6 +678,7 @@ describe('basic-querying', function() {
             if (err) done(err);
             users.should.have.property('length', 2);
             users[0].name.should.equal('John Lennon');
+            users[0].should.be.instanceOf(User);
             users[0].addressLoc.should.not.be.null();
             users[0].vip.should.be.true();
             done();
@@ -708,6 +710,7 @@ describe('basic-querying', function() {
             if (err) done(err);
             users.should.have.property('length', 1);
             users[0].name.should.equal('John Lennon');
+            users[0].should.be.instanceOf(User);
             users[0].addressLoc.should.not.be.null();
             users[0].vip.should.be.true();
             users[0].order.should.equal(2);
@@ -738,6 +741,7 @@ describe('basic-querying', function() {
             users.should.have.property('length', 2);
             users[0].addressLoc.should.not.be.null();
             users[0].name.should.equal('Paul McCartney');
+            users[0].should.be.instanceOf(User);
             users[1].addressLoc.should.not.equal(null);
             users[1].name.should.equal('John Lennon');
             done();
@@ -775,6 +779,7 @@ describe('basic-querying', function() {
             users.should.have.property('length', 1);
             users[0].addressLoc.should.not.be.null();
             users[0].name.should.equal('John Lennon');
+            users[0].should.be.instanceOf(User);
             users[0].vip.should.be.true();
             done();
           });


### PR DESCRIPTION
### Description

When using [near](https://loopback.io/doc/en/lb2/Where-filter.html#near) operator in a filter for find operations, The code path taken for memory connector is different than other connectors which support this feature. 

For memory connector, the call stack is as follows: DAO.find() -> invokeConnectorMethod() with the callback provided as `allCb` -> (after connector's all/find method returns) allCb() does some processing (converting model PDO (plain data object) to model instance) and calls utils.createPromiseCallback(). 

For MySQL/MongoDB, the call stack is: DAO.find() -> invokeConnectorMethod() with `geoCallBack` being the cb function -> eventually geoCallBackWithoutNotify() is called which creates a model instance with a memory connector and calls `memory.all()` but this time supplies `utils.createPromiseCallback()` as the callback and thus does not get to change the model PDO to model instance when it returns. 

In this PR, the first commit moves the functions `geoCallBackWithoutNotify` and `geoCallBackWithNotify` outside `geoQuery` so `allCb` can be called from within `geoCallBackWithoutNotify` (refactor). The second commit is changing the callback provided to `Memory.all()` call within `geoCallBackWithoutNotify` from `utils.createPromiseCallBack()` (plain cb) to `allCb`. I have a test case for this (https://github.com/strongloop/loopback-next/blob/bcaa0e4935ab5268f2dd2c0240ba5478dd2200f2/packages/repository/test/unit/repositories/legacy-juggler-bridge.unit.ts#L186-L206) which I would like to move to a common test suite in juggler to verify the fix. ~Thoughts on where it should go?~

EDIT: In https://github.com/strongloop/loopback-datasource-juggler/pull/1690/commits/47bd60b50487dd1de2c8194564b7b8c8f59389d0 I've added assertions in our common test suite for geo queries to verify the fix.

Fixes https://github.com/strongloop/loopback-next/issues/1419
Related to https://github.com/strongloop/loopback-next/pull/2299/files

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
