### PR TITLE
feat: call after operation hook in case of errors

### DIFF
--- a/lib/observer.js
+++ b/lib/observer.js
@@ -7,6 +7,7 @@
 
 const async = require('async');
 const utils = require('./utils');
+const debug = require('debug')('loopback:observer');
 
 module.exports = ObserverMixin;
 
@@ -232,7 +233,24 @@ ObserverMixin.notifyObserversAround = function(operation, context, fn, callback)
 
       function cbForWork(err) {
         const args = [].slice.call(arguments, 0);
-        if (err) return callback.apply(null, args);
+        if (err) {
+          // call observer in case of error to hook response
+          context.error = err;
+          self.notifyObserversOf('after ' + operation + ' error', context,
+            function(_err, context) {
+              if (_err && err) {
+                debug(
+                  'Operation %j failed and "after %s error" hook returned an error too. ' +
+                    'Calling back with the hook error only.' +
+                    '\nOriginal error: %s\nHook error: %s\n',
+                  err.stack || err,
+                  _err.stack || _err
+                );
+              }
+              callback.call(null, _err || err, context);
+            });
+          return;
+        }
         // Find the list of params from the callback in addition to err
         const returnedArgs = args.slice(1);
         // Set up the array of results


### PR DESCRIPTION
### Description

The connector hook "after operation"  is not called in case of an error caused by the connector.
This for example does not allow to change the HTTP status code for specific errors. Instead HTTP 500 Internal Server Error is returned. 
This PR calls the "after operation" even in such situations. The original error is passed with `ctx.res.err` to allow inspection and manipulation as described in https://loopback.io/doc/en/lb3/Connector-hooks.html#error-handling.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
- connect to <link_to_referenced_issue>
-->

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
