### PR TITLE
feat: Support "type" key in sub-properties in 2.x

### DIFF
--- a/lib/model-builder.js
+++ b/lib/model-builder.js
@@ -677,46 +677,46 @@ ModelBuilder.prototype.getSchemaName = function(name) {
 /**
  * Resolve the type string to be a function, for example, 'String' to String.
  * Returns {Function} if the type is resolved
- * @param {String} type The type string, such as 'number', 'Number', 'boolean', or 'String'. It's case insensitive
+ * @param {String | Object | Array} prop The object whose type is to be resolved
  */
-ModelBuilder.prototype.resolveType = function(type) {
-  if (!type) {
-    return type;
+ModelBuilder.prototype.resolveType = function(prop, isSubProperty) {
+  if (!prop) {
+    return prop;
   }
-  if (Array.isArray(type) && type.length > 0) {
+  if (Array.isArray(prop) && prop.length > 0) {
     // For array types, the first item should be the type string
-    var itemType = this.resolveType(type[0]);
+    var itemType = this.resolveType(prop[0]);
     if (typeof itemType === 'function') {
       return [itemType];
     } else {
       return itemType; // Not resolved, return the type string
     }
   }
-  if (typeof type === 'string') {
-    var schemaType = ModelBuilder.schemaTypes[type.toLowerCase()] || this.models[type];
+  if (typeof prop === 'string') {
+    var schemaType = ModelBuilder.schemaTypes[prop.toLowerCase()] || this.models[prop];
     if (schemaType) {
       return schemaType;
     } else {
       // The type cannot be resolved, let's create a place holder
-      type = this.define(type, {}, {unresolved: true});
-      return type;
+      prop = this.define(prop, {}, {unresolved: true});
+      return prop;
     }
-  } else if (type.constructor.name === 'Object') {
+  } else if (prop.constructor.name === 'Object') {
     // We also support the syntax {type: 'string', ...}
-    if (type.type) {
-      return this.resolveType(type.type);
+    if (!isSubProperty && prop.type) {
+      return this.resolveType(prop.type, true);
     } else {
       return this.define(this.getSchemaName(null),
-        type, {
+        prop, {
           anonymous: true,
           idInjection: false,
           strict: this.settings.strictEmbeddedModels || false,
         });
     }
-  } else if ('function' === typeof type) {
-    return type;
+  } else if ('function' === typeof prop) {
+    return prop;
   }
-  return type;
+  return prop;
 };
 
 /**

--- a/test/datatype.test.js
+++ b/test/datatype.test.js
@@ -26,6 +26,24 @@ describe('datatypes', function() {
     db.automigrate(['Model'], done);
   });
 
+  it('should resolve top-level "type" property correctly', function() {
+    var Account = db.define('Account', {
+      type: String,
+      id: String,
+    });
+    Account.definition.properties.type.type.should.equal(String);
+  });
+
+  it('should resolve "type" sub-property correctly', function() {
+    var Account = db.define('Account', {
+      item: {type: {
+        itemname: {type: String},
+        type: {type: String},
+      }},
+    });
+    Account.definition.properties.item.type.should.not.equal(String);
+  });
+
   it('should return 400 when property of type array is set to string value',
     function(done) {
       var myModel = db.define('myModel', {


### PR DESCRIPTION
### Description

Currently, a model definition like this:

```
  "properties": {
    "items": {
      "type" : {
        "itemname": { "type": "string"},
        "type": { "type": "string" }
      }
    }
  }
```
results in invalid data.

`{ items: [object Object] }`

It is caused by the sub-property `type` conflicting with the type resolution object.

This PR, allows sub-property `type` to be used without any problem.

#### Related issues

https://github.com/strongloop/loopback/issues/4131

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
