### PR TITLE
feat: support array within array in 3.x

### DIFF
--- a/lib/list.js
+++ b/lib/list.js
@@ -64,7 +64,12 @@ function List(items, itemType, parent) {
   }
 
   List.prototype.toItem = function(item) {
-    return isClass(this.itemType) ? new this.itemType(item) : this.itemType(item);
+    if (isClass(this.itemType)) {
+      return new this.itemType(item);
+    } else {
+      if (Array.isArray(item)) return item;
+      else return this.itemType(item);
+    }
   };
 
   items.forEach(function(item, i) {
@@ -91,7 +96,10 @@ List.prototype.push = function(obj) {
 List.prototype.toObject = function(onlySchema, removeHidden, removeProtected) {
   const items = [];
   this.forEach(function(item) {
-    if (item && typeof item === 'object' && item.toObject) {
+    if (item && Array.isArray(item) && item.toArray) {
+      const subArray = item.toArray();
+      items.push(subArray);
+    } else if (item && typeof item === 'object' && item.toObject) {
       items.push(item.toObject(onlySchema, removeHidden, removeProtected));
     } else {
       items.push(item);

--- a/test/introspection.test.js
+++ b/test/introspection.test.js
@@ -27,6 +27,9 @@ const json = {
     {label: 'work', id: 'x@sample.com'},
     {label: 'home', id: 'x@home.com'},
   ],
+  nestedArray: [
+    [{msg: 'Hi'}],
+  ],
   tags: [],
 };
 


### PR DESCRIPTION
### Description

POST request body:
```
 { items": [
    [
      {"name": "APPLE"},
      {"serial": 67}
    ]
  ]
}
```

Currently stored as: 
```
 { "items": [
    {
      "0": {
        "name": "APPLE"
      },
      "1": {
        "serial": 67
      }
    }
  ]
}
```

Will be stored as:

```
 { items": [
    [
      {
        "name": "APPLE"
      },
      {
        "serial": 67
      }
    ]
  ]}
```
#### Related issues

https://github.com/strongloop/loopback/issues/4132

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
