### PR TITLE
fix: nested property coercion and resolution

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -2301,6 +2301,7 @@ DataAccessObject.updateAll = function(where, data, options, cb) {
         if (!(data instanceof Model)) {
           try {
             inst = new Model(data, {applyDefaultValues: false});
+            ctx.data = inst.toObject(true);
           } catch (err) {
             return cb(err);
           }

--- a/lib/list.js
+++ b/lib/list.js
@@ -67,8 +67,14 @@ function List(items, itemType, parent) {
     if (isClass(this.itemType)) {
       return new this.itemType(item);
     } else {
-      if (Array.isArray(item)) return item;
-      else return this.itemType(item);
+      if (Array.isArray(item)) {
+        return item;
+      } else if (this.itemType === Date) {
+        if (item === null) return null;
+        return new Date(item);
+      } else {
+        return this.itemType(item);
+      }
     }
   };
 

--- a/test/basic-querying.test.js
+++ b/test/basic-querying.test.js
@@ -1055,6 +1055,40 @@ describe('basic-querying', function() {
     });
   });
 
+  describe('updateAll', function() {
+    it('coerces primitive datatypes on update', async () => {
+      const numAndDateModel = db.define('numAndDateModel', {
+        dateProp: Date,
+        dateArray: [Date],
+        numProp: Number,
+        numArray: [Number],
+      });
+      const createDate = new Date('2019-02-21T12:00:00').toISOString();
+      const createData = {
+        dateProp: createDate,
+        dateArray: [createDate, createDate],
+        numProp: '1',
+        numArray: ['1', '2'],
+      };
+      const updateDate = new Date('2019-04-15T12:00:00').toISOString();
+      const updateData = {
+        dateProp: updateDate,
+        dateArray: [updateDate, updateDate],
+        numProp: '3',
+        numArray: ['3', '4'],
+      };
+      const created = await numAndDateModel.create(createData);
+      const updated = await numAndDateModel.updateAll({id: created.id}, updateData);
+      const found = await numAndDateModel.findById(created.id);
+      found.dateProp.should.deepEqual(new Date(updateDate));
+      found.dateArray[0].should.deepEqual(new Date(updateDate));
+      found.dateArray[1].should.deepEqual(new Date(updateDate));
+      found.numProp.should.equal(3);
+      found.numArray[0].should.equal(3);
+      found.numArray[1].should.equal(4);
+    });
+  });
+
   context('regexp operator', function() {
     const invalidDataTypes = [0, true, {}, [], Function, null];
 

--- a/test/datatype.test.js
+++ b/test/datatype.test.js
@@ -52,6 +52,54 @@ describe('datatypes', function() {
     });
     Account.definition.properties.item.type.should.not.equal(String);
   });
+  it('should resolve array prop with connector specific metadata', function() {
+    const model = db.define('test', {
+      randomReview: {
+        type: [String],
+        mongodb: {
+          dataType: 'Decimal128',
+        },
+      },
+    });
+    model.definition.properties.randomReview.type.should.deepEqual(Array(String));
+    model.definition.properties.randomReview.mongodb.should.deepEqual({dataType: 'Decimal128'});
+  });
+
+  it('should coerce array of dates from string', async () => {
+    const dateArrayModel = db.define('dateArrayModel', {
+      bunchOfDates: [Date],
+      bunchOfOtherDates: {
+        type: [Date],
+      },
+    });
+    const dateVal = new Date('2019-02-21T12:00:00').toISOString();
+    const created = await dateArrayModel.create({
+      bunchOfDates: [dateVal,
+        dateVal,
+        dateVal],
+      bunchOfOtherDates: [dateVal,
+        dateVal,
+        dateVal],
+    });
+    created.bunchOfDates[0].should.be.an.instanceOf(Date);
+    created.bunchOfDates[0].should.deepEqual(new Date(dateVal));
+    created.bunchOfOtherDates[0].should.be.an.instanceOf(Date);
+    created.bunchOfOtherDates[0].should.deepEqual(new Date(dateVal));
+  });
+
+  it('should coerce array of numbers from string', async () => {
+    const numArrayModel = db.define('numArrayModel', {
+      bunchOfNums: [Number],
+    });
+    const dateVal = new Date('2019-02-21T12:00:00').toISOString();
+    const created = await numArrayModel.create({
+      bunchOfNums: ['1',
+        '2',
+        '3'],
+    });
+    created.bunchOfNums[0].should.be.an.instanceOf(Number);
+    created.bunchOfNums[0].should.equal(1);
+  });
 
   it('should return 400 when property of type array is set to string value',
     function(done) {

--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -2366,7 +2366,7 @@ describe('manipulation', function() {
     it('should not coerce invalid values provided in where conditions', function(done) {
       Person.update({name: 'Brett Boe'}, {dob: 'notadate'}, function(err) {
         should.exist(err);
-        err.message.should.equal('Invalid date: notadate');
+        err.message.should.equal('Invalid date: Invalid Date');
         done();
       });
     });


### PR DESCRIPTION
### Description
Ensure that nested array properties maintain connector-specific data type metadata and also coerce string values for array of primitive properties into their type. Connect to https://github.com/strongloop/loopback-connector-mongodb/issues/493.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
