### PR TITLE
Do not apply default values on data from database [2.x]

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1065,8 +1065,15 @@ DataAccessObject.findOrCreate = function findOrCreate(query, data, options, cb) 
         var obj, Model = self.lookupModel(data);
 
         if (data) {
-          obj = new Model(data, {fields: query.fields, applySetters: false,
-            persisted: true});
+          var ctorOpts = {
+            fields: query.fields,
+            applySetters: false,
+            persisted: true,
+          };
+          if (Model.settings.applyDefaultsOnReads === false) {
+            ctorOpts.applyDefaultValues = false;
+          }
+          obj = new Model(data, ctorOpts);
         }
 
         if (created) {
@@ -1936,7 +1943,15 @@ DataAccessObject.find = function find(query, options, cb) {
       if (!err && Array.isArray(data)) {
         async.map(data, function(item, next) {
           var Model = self.lookupModel(item);
-          var obj = new Model(item, {fields: query.fields, applySetters: false, persisted: true});
+          var ctorOpts = {
+            fields: query.fields,
+            applySetters: false,
+            persisted: true,
+          };
+          if (Model.settings.applyDefaultsOnReads === false) {
+            ctorOpts.applyDefaultValues = false;
+          }
+          var obj = new Model(item, ctorOpts);
 
           if (query && query.include) {
             if (query.collect) {


### PR DESCRIPTION
Before this change, when a property was configured with a default value at LoopBack side and the database was returned a record with a missing value for such property, then we would supply use the configured default.

This behavior is problematic for reasons explained in #1692.

In this commit, we are introducing a new model-level setting called `applyDefaultsOnReads`, which is enabled by default for backwards compatibility.

When this setting is set to `false`, operations like `find` and `findOrCreate` will NOT apply default property values on data returned by the database (connector).

Please note that most of the other CRUD methods did not apply default values on database data as long as the connector provided native implementation of the operation, that aspect is not changing.

Also note that default values are applied only on properties with `undefined` values. The value `null` does not trigger application of default values. This is important because SQL connectors return `null` for properties with no value set.


#### Related issues

This is a back-port of #1705, which is a backport of #1704. Compared to #1704 (master/4.x), we are preserving backwards compatibility by introducing a new feature flag.

See also #1692.

/cc @sharathmuthu6 @snarjuna

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)