### PR TITLE
Remove kv-extreme-scale connector from downstream test

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "downstreamIgnoreList": [
       "loopback-connector-db2z",
       "loopback-connector-informix",
-      "loopback-connector-mqlight"
+      "loopback-connector-mqlight",
+      "loopback-connector-kv-extreme-scale"
     ]
   }
 }


### PR DESCRIPTION
### Description
CI for `loopback-datasource-juggler` is failing because one of the downstream `loopback-connector-kv-extreme-scale` failed.  
From @bajtos, we used to have an instance for testing but not anymore.  Since `loopback-connector-kv-extreme-scale` has low usage, we have decided to:
- have https://github.com/strongloop/loopback-connector-kv-extreme-scale/issues/23 to keep track of the CI failure
- remove this from downstream of juggler, so that we can get the more important PRs to land first. 

Related to: https://github.com/strongloop/loopback-datasource-juggler/pull/1705#issuecomment-480254509