### PR TITLE
Add support for Node.js 12.x [3.x]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ node_js:
   - "6"
   - "8"
   - "10"
+  - "12"
 
 after_success: npm run coverage

--- a/lib/date-string.js
+++ b/lib/date-string.js
@@ -97,3 +97,10 @@ DateString.prototype.inspect = function(depth, options) {
     _date: this._date,
   });
 };
+
+if (inspect.custom) {
+  // Node.js 12+ no longer recognizes "inspect" method,
+  // it uses "inspect.custom" symbol as the key instead
+  // TODO(semver-major) always use the symbol key only (requires Node.js 8+).
+  DateString.prototype[inspect.custom] = DateString.prototype.inspect;
+}

--- a/lib/model-utils.js
+++ b/lib/model-utils.js
@@ -385,6 +385,8 @@ ModelUtils._coerce = function(where, options) {
         self._coerce(clauses[k], options);
       }
 
+      where[p] = clauses;
+
       continue;
     }
     let DataType = props[p] && props[p].type;

--- a/lib/model.js
+++ b/lib/model.js
@@ -637,6 +637,13 @@ ModelBaseClass.prototype.inspect = function(depth) {
   });
 };
 
+if (util.inspect.custom) {
+  // Node.js 12+ no longer recognizes "inspect" method,
+  // it uses "inspect.custom" symbol as the key instead
+  // TODO(semver-major) always use the symbol key only (requires Node.js 8+).
+  ModelBaseClass.prototype[util.inspect.custom] = ModelBaseClass.prototype.inspect;
+}
+
 /**
  *
  * @param {String} anotherClass could be string or class. Name of the class or the class itself


### PR DESCRIPTION
Back-port https://github.com/strongloop/loopback-datasource-juggler/pull/1728:

- Fix code to pass all tests on Node.js 12
- Add Node.js 12 to the list of Travis CI platforms
