### PR TITLE
Fix tests for empty vs. default values to pass on SQL

### DIFF
--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -985,25 +985,25 @@ describe('manipulation', function() {
     it('preserves empty values from the database', async () => {
       // https://github.com/strongloop/loopback-datasource-juggler/issues/1692
 
-      // Initially, all Products were always active, no property was needed
-      const Product = db.define('Product', {name: String});
+      // Initially, all Players were always active, no property was needed
+      const Player = db.define('Player', {name: String});
 
-      await db.automigrate('Product');
-      const created = await Product.create({name: 'Pen'});
+      await db.automigrate('Player');
+      const created = await Player.create({name: 'Pen'});
 
       // Later on, we decide to introduce `active` property
-      Product.defineProperty('active', {
+      Player.defineProperty('active', {
         type: Boolean,
         default: false,
       });
+      await db.autoupdate('Player');
 
       // And updateOrCreate an existing record
-      const found = await Product.updateOrCreate({id: created.id, name: 'updated'});
-      found.toObject().should.eql({
-        id: created.id,
-        name: 'updated',
-        active: undefined,
-      });
+      const found = await Player.updateOrCreate({id: created.id, name: 'updated'});
+      should(found.toObject().active).be.oneOf([
+        undefined, // databases supporting `undefined` value
+        null, // databases representing `undefined` as `null`
+      ]);
     });
   });
 
@@ -1647,25 +1647,25 @@ describe('manipulation', function() {
     it('preserves empty values from the database', async () => {
       // https://github.com/strongloop/loopback-datasource-juggler/issues/1692
 
-      // Initially, all Products were always active, no property was needed
-      const Product = db.define('Product', {name: String});
+      // Initially, all Players were always active, no property was needed
+      const Player = db.define('Player', {name: String});
 
-      await db.automigrate('Product');
-      const created = await Product.create({name: 'Pen'});
+      await db.automigrate('Player');
+      const created = await Player.create({name: 'Pen'});
 
       // Later on, we decide to introduce `active` property
-      Product.defineProperty('active', {
+      Player.defineProperty('active', {
         type: Boolean,
         default: false,
       });
+      await db.autoupdate('Player');
 
       // And findOrCreate an existing record
-      const [found] = await Product.findOrCreate({id: created.id}, {name: 'updated'});
-      found.toObject().should.eql({
-        id: created.id,
-        name: 'Pen',
-        active: undefined,
-      });
+      const [found] = await Player.findOrCreate({id: created.id}, {name: 'updated'});
+      should(found.toObject().active).be.oneOf([
+        undefined, // databases supporting `undefined` value
+        null, // databases representing `undefined` as `null`
+      ]);
     });
   });
 


### PR DESCRIPTION
~~Strangely enough, the changes made to `test/manipulation.test.js` by #1707 are not present in the current `master` branch. This pull request is (re)introducing them back again.~~

The changes made by #1707 were not fixing all new tests to pass on SQL. This patch applies the same changes on other tests and thus makes the shared test suite pass with SQL connectors.

See also #1692