### PR TITLE
chore: update LTS status

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This module adopts the [Module Long Term Support (LTS)](http://github.com/CloudN
 | ---------- | --------------- | --------- | -------------------- |
 | 4.x        | Current         | Oct 2018  | Apr 2021 _(minimum)_ |
 | 3.x        | Active LTS      | Dec 2016  | Dec 2019             |
-| 2.x        | Maintenance LTS | Jul 2014  | Apr 2019             |
+| 2.x        | End-of-Life | Jul 2014  | Apr 2019             |
 
 Learn more about our LTS plan in the [LoopBack documentation](http://loopback.io/doc/en/contrib/Long-term-support.html).
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "Juggler",
     "ORM"
   ],
+  "author": "IBM Corp.",
   "engines": {
     "node": ">=8"
   },


### PR DESCRIPTION
### Description
- Update `README` on LTS status. Related to https://github.com/strongloop/loopback/issues/4180
- add `"author": "IBM Corp.",` in package.json so that `slt copyright` command can generate the right header.

There will be 109 files with copyright year changes, so I'll submit it in a separate PR for easier review.
