### PR TITLE
datasource: copy settings object in constructor

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -126,6 +126,12 @@ function DataSource(name, settings, modelBuilder) {
     settings = utils.parseSettings(settings);
   }
 
+  // Shallow-clone the settings so that updates to `ds.settings`
+  // do not modify the original object provided via constructor arguments
+  if (settings) settings = Object.assign({}, settings);
+  // It's possible to provide settings object via the "name" arg too!
+  if (typeof name === 'object') name = Object.assign({}, name);
+
   this.modelBuilder = modelBuilder || new ModelBuilder();
   this.models = this.modelBuilder.models;
   this.definitions = this.modelBuilder.definitions;

--- a/test/datasource.test.js
+++ b/test/datasource.test.js
@@ -9,6 +9,15 @@ const should = require('./init.js');
 const DataSource = require('../lib/datasource.js').DataSource;
 
 describe('DataSource', function() {
+  it('clones settings to prevent surprising changes in passed args', () => {
+    const config = {connector: 'memory'};
+
+    const ds = new DataSource(config);
+    ds.settings.extra = true;
+
+    config.should.eql({connector: 'memory'});
+  });
+
   it('reports helpful error when connector init throws', function() {
     const throwingConnector = {
       name: 'loopback-connector-throwing',


### PR DESCRIPTION
### Description

Fix DataSource constructor to create a shallow copy of the settings object provided by the caller. This prevents surprising behavio where changes made to `ds.settings` were picked up by the provided config object, as observed e.g. in tests of our MongoDB connector.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- https://github.com/strongloop-internal/scrum-apex/issues/416

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)