### PR TITLE
Fix implementation of Operation Hooks for "near" (geo) queries

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1569,7 +1569,8 @@ DataAccessObject.find = function find(query, options, cb) {
       return cb.promise;
     }
   }
-  function geoCallbackWithoutNotify(err, data) {
+
+  function geoCallback(err, data) {
     const memory = new Memory();
     const modelName = self.modelName;
 
@@ -1588,37 +1589,14 @@ DataAccessObject.find = function find(query, options, cb) {
         });
       });
 
-      // FIXME: apply "includes" and other transforms - see allCb below
       memory.all(modelName, geoQueryObject, options, allCb);
     } else {
       cb(null, []);
     }
   }
 
-  function geoCallbackWithNotify(err, data) {
-    if (err) return cb(err);
-
-    async.map(data, function(item, next) {
-      const context = {
-        Model: self,
-        data: item,
-        isNewInstance: false,
-        hookState: hookState,
-        options: options,
-      };
-
-      self.notifyObserversOf('loaded', context, function(err) {
-        if (err) return next(err);
-        next(null, context.data);
-      });
-    }, function(err, results) {
-      if (err) return cb(err);
-      geoCallbackWithoutNotify(null, results);
-    });
-  }
   function queryGeo(query) {
     geoQueryObject = query;
-    const geoCallback = options.notify === false ? geoCallbackWithoutNotify : geoCallbackWithNotify;
     invokeConnectorMethod(connector, 'all', self, [{}], options, geoCallback);
   }
 

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1535,7 +1535,7 @@ DataAccessObject.find = function find(query, options, cb) {
 
   this.applyScope(query);
 
-  const near = query && geo.nearFilter(query.where);
+  let near = query && geo.nearFilter(query.where);
   const supportsGeo = !!connector.buildNearFilter;
   let geoQueryObject;
 
@@ -1597,6 +1597,7 @@ DataAccessObject.find = function find(query, options, cb) {
 
   function queryGeo(query) {
     geoQueryObject = query;
+    near = query && geo.nearFilter(query.where);
     invokeConnectorMethod(connector, 'all', self, [{}], options, geoCallback);
   }
 

--- a/test/memory.test.js
+++ b/test/memory.test.js
@@ -917,6 +917,9 @@ describe('Unoptimized connector', function() {
   ds.connector.findOrCreate = false;
   ds.connector.upsertWithWhere = false;
 
+  // disable native location queries
+  ds.connector.buildNearFilter = false;
+
   require('./persistence-hooks.suite')(ds, should, {
     replaceOrCreateReportsNewInstance: true,
   });


### PR DESCRIPTION
The first commit is reworking the setup of the Operation Hooks test suite for memory connector so that the "unoptimized" variant disables not only atomic CRUD operations, but also geo queries.

This way we can test both "near" querying implementations:
 - When the connectors supports "near" queries natively.
 - When "near" queries are executed at LoopBack side in-memory.

The second commit fixes "loaded" hook for unoptimized "near" queries (as demonstrated by a failing test).

The third commit fixes "access" hook for unoptimized "near" queries (as demonstrated by a failing test).

These changes are needed to make MongoDB connector tests pass when running against juggler v4.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- https://github.com/strongloop-internal/scrum-apex/issues/416

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
