### PR TITLE
Fix DateString constructor to accept DateString instances

### DIFF
--- a/lib/date-string.js
+++ b/lib/date-string.js
@@ -53,6 +53,10 @@ function DateString(value) {
     return new DateString(value);
   }
 
+  if (value instanceof DateString) {
+    value = value.when;
+  }
+
   if (typeof(value) !== 'string') {
     throw new Error('Input must be a string');
   }

--- a/test/date-string.test.js
+++ b/test/date-string.test.js
@@ -44,6 +44,13 @@ describe('DateString', function() {
       // The internal date representation should also be updated!
       date._date.toString().should.eql(d.toString());
     });
+
+    it('should accept DateString instance', function() {
+      const input = new DateString('2015-01-01');
+      const inst = new DateString(input);
+      inst.toString().should.equal('2015-01-01');
+    });
+
     it('should return custom inspect output', function() {
       const date = new DateString('2015-01-01');
       const result = inspect(date);


### PR DESCRIPTION
Quoting from https://github.com/strongloop/loopback-datasource-juggler/pull/1591:

> The issue happens when using PersistedModel.upsert or PersistedModel.upsertWithWhere methods - that for some reason instance values twice - with model that uses DateString type

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- resolves #1591

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)