### PR TITLE
Fix implementation of Operation Hooks for "near" (geo) queries [3.x]

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1536,7 +1536,7 @@ DataAccessObject.find = function find(query, options, cb) {
 
   this.applyScope(query);
 
-  const near = query && geo.nearFilter(query.where);
+  let near = query && geo.nearFilter(query.where);
   const supportsGeo = !!connector.buildNearFilter;
 
   if (near) {
@@ -1567,6 +1567,8 @@ DataAccessObject.find = function find(query, options, cb) {
       }
 
       function queryGeo(query) {
+        near = query && geo.nearFilter(query.where);
+
         function geoCallbackWithoutNotify(err, data) {
           const memory = new Memory();
           const modelName = self.modelName;

--- a/test/memory.test.js
+++ b/test/memory.test.js
@@ -917,6 +917,9 @@ describe('Unoptimized connector', function() {
   ds.connector.findOrCreate = false;
   ds.connector.upsertWithWhere = false;
 
+  // disable native location queries
+  ds.connector.buildNearFilter = false;
+
   require('./persistence-hooks.suite')(ds, should, {
     replaceOrCreateReportsNewInstance: true,
   });


### PR DESCRIPTION
The first commit is reworking the setup of the Operation Hooks test suite for memory connector so that the "unoptimized" variant disables not only atomic CRUD operations, but also geo queries.

This way we can test both "near" querying implementations:
 - When the connectors supports "near" queries natively.
 - When "near" queries are executed at LoopBack side in-memory.

The second commit fixes "access" hook for unoptimized "near" queries (as demonstrated by a failing test).

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- this pull request is back-porting https://github.com/strongloop/loopback-datasource-juggler/pull/1739 to 3.x

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
