### PR TITLE
Fixes #1745 - coerceArray coerces empty object into array

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1558,7 +1558,14 @@ function coerceArray(val) {
     throw new Error(g.f('Value is not an {{array}} or {{object}} with sequential numeric indices'));
   }
 
-  var arrayVal = new Array(Object.keys(val).length);
+  // It is an object, check if empty
+  var props = Object.keys(val);
+
+  if (props.length === 0) {
+    throw new Error(g.f('Value is an empty {{object}}'));
+  }
+
+  var arrayVal = new Array(props.length);
   for (var i = 0; i < arrayVal.length; ++i) {
     if (!val.hasOwnProperty(i)) {
       throw new Error(g.f('Value is not an {{array}} or {{object}} with sequential numeric indices'));

--- a/test/loopback-dl.test.js
+++ b/test/loopback-dl.test.js
@@ -1381,6 +1381,8 @@ describe('DataAccessObject', function() {
       },
       location: 'GeoPoint',
       scores: [Number],
+      array: 'array',
+      object: 'object',
     });
   });
 
@@ -1638,7 +1640,7 @@ describe('DataAccessObject', function() {
     assert(error, 'An error should have been thrown');
   });
 
-  it('throws an error if the filter.limit property is nagative', function() {
+  it('throws an error if the filter.limit property is negative', function() {
     try {
       // The limit param must be a valid number
       filter = model._normalize({limit: -1});
@@ -1717,6 +1719,18 @@ describe('DataAccessObject', function() {
   it('does not coerce undefined values', function() {
     where = model._coerce({date: undefined});
     assert.deepEqual(where, {date: undefined});
+  });
+
+  it('does not coerce empty objects to arrays', function() {
+    where = model._coerce({object: {}});
+    where.object.should.not.be.an.Array();
+    where.object.should.be.an.Object();
+  });
+
+  it('does not coerce an empty array', function() {
+    where = model._coerce({array: []});
+    where.array.should.be.an.Array();
+    where.array.should.have.length(0);
   });
 
   it('does not coerce to a number for a simple value that produces NaN', function() {


### PR DESCRIPTION
### Description

In the v2 of the library when perfroming a static update (update with where clause) empy objects are being coerced into empty arrays which is a major bug and causes lots of issues down the line...

#### Related issues

#1745

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
