### PR TITLE
Fix types to describe native Promise

### DIFF
--- a/types/common.d.ts
+++ b/types/common.d.ts
@@ -23,6 +23,6 @@ export type Callback<T = any> = (err?: any | null, result?: T) => void;
 /**
  * Return export type for promisified Node.js async methods.
  *
- * Note that juggler uses Bluebird, not the native Promise.
+ * Note that starting with version 4.0, juggler uses native Promises.
  */
-export type PromiseOrVoid<T = any> = PromiseLike<T> | void;
+export type PromiseOrVoid<T = any> = Promise<T> | void;


### PR DESCRIPTION
### Description

In version 4.0.0, we switched from Bluebird to native Promises - see https://github.com/strongloop/loopback-datasource-juggler/pull/1631

#### Related issues

I discovered the inconsistency between the implementation and the typings while experimenting with optimizing dependencies of `@loopback/repository` (loosely related to https://github.com/strongloop/loopback-next/issues/3126).

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)