### PR TITLE
update LTS in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This module adopts the [Module Long Term Support (LTS)](http://github.com/CloudN
 | Version    | Status          | Published | EOL                  |
 | ---------- | --------------- | --------- | -------------------- |
 | 4.x        | Current         | Oct 2018  | Apr 2021 _(minimum)_ |
-| 3.x        | Active LTS      | Dec 2016  | Dec 2019             |
+| 3.x        | Active LTS      | Dec 2016  | Dec 2020             |
 | 2.x        | End-of-Life | Jul 2014  | Apr 2019             |
 
 Learn more about our LTS plan in the [LoopBack documentation](http://loopback.io/doc/en/contrib/Long-term-support.html).


### PR DESCRIPTION
### Description
Since we've extended the EOL date for LB3 to be Dec 2020, we should change the EOL for this module for v3.x accordingly.

Related: strongloop-internal/scrum-loopback#1438
