### PR TITLE
chore: add beginTransaction API to declaration file

### DIFF
--- a/types/persisted-model.d.ts
+++ b/types/persisted-model.d.ts
@@ -6,6 +6,7 @@
 import {Callback, Options, PromiseOrVoid} from './common';
 import {ModelBase, ModelData} from './model';
 import {Filter, Where} from './query';
+import {Transaction} from './transaction-mixin';
 
 /**
  * Data object for persisted models
@@ -476,6 +477,58 @@ export declare class PersistedModel extends ModelBase {
     options?: Options,
     callback?: Callback<boolean>,
   ): PromiseOrVoid<boolean>;
+
+/**
+ * Begin a new transaction.
+ *
+ * A transaction can be committed or rolled back. If timeout happens, the
+ * transaction will be rolled back. Please note a transaction is typically
+ * associated with a pooled connection. Committing or rolling back a transaction
+ * will release the connection back to the pool.
+ *
+ * Once the transaction is committed or rolled back, the connection property
+ * will be set to null to mark the transaction to be inactive. Trying to commit
+ * or rollback an inactive transaction will receive an error from the callback.
+ *
+ * Please also note that the transaction is only honored with the same data
+ * source/connector instance. CRUD methods will not join the current transaction
+ * if its model is not attached the same data source.
+ *
+ * Example:
+ *
+ * To pass the transaction context to one of the CRUD methods, use the `options`
+ * argument with `transaction` property, for example,
+ *
+ * ```js
+ * MyModel.beginTransaction('READ COMMITTED', function(err, tx) {
+  *   MyModel.create({x: 1, y: 'a'}, {transaction: tx}, function(err, inst) {
+  *     MyModel.find({x: 1}, {transaction: tx}, function(err, results) {
+  *       // ...
+  *       tx.commit(function(err) {...});
+  *     });
+  *   });
+  * });
+  * ```
+  *
+  * @param {Object|String} options Options to be passed upon transaction.
+  *
+  * Can be one of the forms:
+  *  - Object: {isolationLevel: '...', timeout: 1000}
+  *  - String: isolationLevel
+  *
+  * Valid values of `isolationLevel` are:
+  *
+  * - Transaction.READ_COMMITTED = 'READ COMMITTED'; // default
+  * - Transaction.READ_UNCOMMITTED = 'READ UNCOMMITTED';
+  * - Transaction.SERIALIZABLE = 'SERIALIZABLE';
+  * - Transaction.REPEATABLE_READ = 'REPEATABLE READ';
+  * @callback {Function} cb Callback function.
+  * @returns {Promise|undefined} Returns a callback promise.
+  */
+  beginTransaction(
+    options?: string | Options,
+    callback?: Callback<Transaction>,
+  ): PromiseOrVoid<Transaction>;
 
   /**
    * Reload object from persistence.  Requires `id` member of `object` to be able to call `find`.


### PR DESCRIPTION
### Description
Connect to https://github.com/strongloop/loopback-next/issues/2614. We need to add `beginTransaction()` to the persisted model declaration file in order to utilize it with LB4 repositories.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
