### PR TITLE
fix: report errors from automigrate/autoupdate

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -136,6 +136,7 @@ function DataSource(name, settings, modelBuilder) {
   this.models = this.modelBuilder.models;
   this.definitions = this.modelBuilder.definitions;
   this.juggler = juggler;
+  this._queuedInvocations = 0;
 
   // operation metadata
   // Initialize it before calling setup as the connector might register operations
@@ -477,18 +478,22 @@ DataSource.prototype.setup = function(dsName, settings) {
       if (this.connected) {
         debug('DataSource %s is now connected to %s', this.name, this.connector.name);
         this.emit('connected');
-      } else {
+      } else if (err) {
         // The connection fails, let's report it and hope it will be recovered in the next call
-        if (err) {
-          // Reset the connecting to `false`
-          this.connecting = false;
+        // Reset the connecting to `false`
+        this.connecting = false;
+        if (this._queuedInvocations) {
+          // Another operation is already waiting for connect() result,
+          // let them handle the connection error.
+          debug('Connection fails: %s\nIt will be retried for the next request.', err);
+        } else {
           g.error('Connection fails: %s\nIt will be retried for the next request.', err);
           this.emit('error', err);
-        } else {
-          // Either lazyConnect or connector initialize() defers the connection
-          debug('DataSource %s will be connected to connector %s', this.name,
-            this.connector.name);
         }
+      } else {
+        // Either lazyConnect or connector initialize() defers the connection
+        debug('DataSource %s will be connected to connector %s', this.name,
+          this.connector.name);
       }
     }.bind(this);
 
@@ -1053,6 +1058,14 @@ DataSource.prototype.automigrate = function(models, cb) {
     }
   }
 
+  const args = [models, cb];
+  args.callee = this.automigrate;
+  const queued = this.ready(this, args);
+  if (queued) {
+    // waiting to connect
+    return cb.promise;
+  }
+
   this.connector.automigrate(models, cb);
   return cb.promise;
 };
@@ -1112,6 +1125,14 @@ DataSource.prototype.autoupdate = function(models, cb) {
       });
       return cb.promise;
     }
+  }
+
+  const args = [models, cb];
+  args.callee = this.automigrate;
+  const queued = this.ready(this, args);
+  if (queued) {
+    // waiting to connect
+    return cb.promise;
   }
 
   this.connector.autoupdate(models, cb);
@@ -2514,12 +2535,15 @@ function(obj, args) {
     return false;
   }
 
+  this._queuedInvocations++;
+
   const method = args.callee;
   // Set up a callback after the connection is established to continue the method call
 
   let onConnected = null, onError = null, timeoutHandle = null;
   onConnected = function() {
     debug('Datasource %s is now connected - executing method %s', self.name, method.name);
+    this._queuedInvocations--;
     // Remove the error handler
     self.removeListener('error', onError);
     if (timeoutHandle) {
@@ -2542,6 +2566,7 @@ function(obj, args) {
   };
   onError = function(err) {
     debug('Datasource %s fails to connect - aborting method %s', self.name, method.name);
+    this._queuedInvocations--;
     // Remove the connected listener
     self.removeListener('connected', onConnected);
     if (timeoutHandle) {
@@ -2563,6 +2588,7 @@ function(obj, args) {
   timeoutHandle = setTimeout(function() {
     debug('Datasource %s fails to connect due to timeout - aborting method %s',
       self.name, method.name);
+    this._queuedInvocations--;
     self.connecting = false;
     self.removeListener('error', onError);
     self.removeListener('connected', onConnected);
@@ -2575,7 +2601,11 @@ function(obj, args) {
 
   if (!this.connecting) {
     debug('Connecting datasource %s to connector %s', this.name, this.connector.name);
-    this.connect();
+    // When no callback is provided to `connect()`, it returns a Promise.
+    // We are not handling that promise and thus UnhandledPromiseRejection
+    // warning is triggered when the connection could not be established.
+    // We are avoiding this problem by providing a no-op callback.
+    this.connect(() => {});
   }
   return true;
 };


### PR DESCRIPTION
Defer automigrate/autoupdate until we are connected, so that connection errors can be reported back to callers.

Fix `postInit` handler to not report connection error to `console.log` and via dataSource "error" event in case there is already an operation queued. When this happens, we want the error to be handled by the queued operation and reported to its caller.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- fixes https://github.com/strongloop/loopback-next/issues/3044

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)