### PR TITLE
feat: add DataSource.deleteAllModels() API

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -845,6 +845,16 @@ DataSource.prototype.deleteModelByName = function(modelName) {
 };
 
 /**
+ * Remove all models from the registry, but keep the connector instance
+ * (including the pool of database connections).
+ */
+DataSource.prototype.deleteAllModels = function() {
+  for (const m in this.modelBuilder.models) {
+    this.deleteModelByName(m);
+  }
+};
+
+/**
  * Mixin DataAccessObject methods.
  *
  * @param {Function} ModelCtor The model constructor

--- a/test/datasource.test.js
+++ b/test/datasource.test.js
@@ -517,6 +517,34 @@ describe('DataSource', function() {
       });
     }
   });
+
+  describe('deleteAllModels', () => {
+    it('removes all model definitions', () => {
+      const ds = new DataSource({connector: 'memory'});
+      ds.define('Category');
+      ds.define('Product');
+
+      Object.keys(ds.modelBuilder.definitions)
+        .should.deepEqual(['Category', 'Product']);
+      Object.keys(ds.modelBuilder.models)
+        .should.deepEqual(['Category', 'Product']);
+      Object.keys(ds.connector._models)
+        .should.deepEqual(['Category', 'Product']);
+
+      ds.deleteAllModels();
+
+      Object.keys(ds.modelBuilder.definitions).should.be.empty();
+      Object.keys(ds.modelBuilder.models).should.be.empty();
+      Object.keys(ds.connector._models).should.be.empty();
+    });
+
+    it('preserves the connector instance', () => {
+      const ds = new DataSource({connector: 'memory'});
+      const connector = ds.connector;
+      ds.deleteAllModels();
+      ds.connector.should.equal(connector);
+    });
+  });
 });
 
 function givenMockConnector(props) {

--- a/types/datasource.d.ts
+++ b/types/datasource.d.ts
@@ -111,6 +111,19 @@ export declare class DataSource extends EventEmitter {
   getModel(modelName: string): ModelBaseClass | undefined;
 
   /**
+   * Remove a model from the registry.
+   *
+   * @param modelName
+   */
+  deleteModelByName(modelName: string): void;
+
+  /**
+   * Remove all models from the registry, but keep the connector instance
+   * (including the pool of database connections).
+   */
+  deleteAllModels(): void;
+
+  /**
    * Attach an existing model to a data source.
    * This will mixin all of the data access object functions (DAO) into your
    * modelClass definition.


### PR DESCRIPTION
When writing tests, for performance reasons we often want to reuse the same data-source instance for many tests suites. At the same time, we want to keep such test suites independent and allow them to reuse the same model name for different model classes.

Juggler does support redefinition of a model with the same name.

This change is adding a new API called `dataSource.reset()` that allows tests to remove all old models before creating new ones (typically from a `before` hook).

#### Related issues

This is very loosely related to https://github.com/strongloop/loopback-next/pull/3387.

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)