### PR TITLE
fix: use only promises for beginTransaction

### DIFF
--- a/types/datasource.d.ts
+++ b/types/datasource.d.ts
@@ -209,5 +209,5 @@ export declare class DataSource extends EventEmitter {
  */
   beginTransaction(
     options?: IsolationLevel | Options,
-  ): PromiseOrVoid<Transaction>;
+  ): Promise<Transaction>;
 }


### PR DESCRIPTION
### Description

Related to https://github.com/strongloop/loopback-next/issues/2614 and https://github.com/strongloop/loopback-next/pull/3397.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes (N/A)
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
