### PR TITLE
Fix autoupdate queueing automigrate instead

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -1138,7 +1138,7 @@ DataSource.prototype.autoupdate = function(models, cb) {
   }
 
   const args = [models, cb];
-  args.callee = this.automigrate;
+  args.callee = this.autoupdate;
   const queued = this.ready(this, args);
   if (queued) {
     // waiting to connect


### PR DESCRIPTION
### Description

The autoupdate method was queueing `automigrate`. This bug was introduced in 40286fcd28cc0119e8530d56ff0d82bc55f4517d.

#### Related issues

- Fixes #1761

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
