### PR TITLE
feat: add applyDefaultOnWrites property [3.x]

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -431,6 +431,8 @@ DataAccessObject.create = function(data, options, cb) {
           });
         }
 
+        val = applyDefaultsOnWrites(val, Model.definition);
+
         context = {
           Model: Model,
           data: val,
@@ -451,6 +453,19 @@ DataAccessObject.create = function(data, options, cb) {
 
   return cb.promise;
 };
+
+// Implementation of applyDefaultOnWrites property
+function applyDefaultsOnWrites(obj, modelDefinition) {
+  for (const key in modelDefinition.properties) {
+    const prop = modelDefinition.properties[key];
+    if ('applyDefaultOnWrites' in prop && !prop.applyDefaultOnWrites &&
+      prop.default !== undefined && prop.default === obj[key]) {
+      delete obj[key];
+    }
+  }
+
+  return obj;
+}
 
 function stillConnecting(dataSource, obj, args) {
   if (typeof args[args.length - 1] === 'function') {

--- a/test/defaults.test.js
+++ b/test/defaults.test.js
@@ -76,4 +76,29 @@ describe('defaults', function() {
       });
     });
   });
+
+  context('applyDefaultOnWrites', function() {
+    it('does not affect default behavior when not set', async () => {
+      const Apple = db.define('Apple', {
+        color: {type: String, default: 'red'},
+        taste: {type: String, default: 'sweet'},
+      }, {applyDefaultsOnReads: false});
+
+      const apple = await Apple.create();
+      apple.color.should.equal('red');
+      apple.taste.should.equal('sweet');
+    });
+
+    it('removes the property when set to `false`', async () => {
+      const Apple = db.define('Apple', {
+        color: {type: String, default: 'red', applyDefaultOnWrites: false},
+        taste: {type: String, default: 'sweet'},
+      }, {applyDefaultsOnReads: false});
+
+      const apple = await Apple.create({color: 'red', taste: 'sweet'});
+      const found = await Apple.findById(apple.id);
+      should(found.color).be.undefined();
+      found.taste.should.equal('sweet');
+    });
+  });
 });


### PR DESCRIPTION
### Description

Adds the ability to ignore writing default values to the database.

#### Related issues
<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to https://github.com/strongloop/loopback-connector-mongodb/issues/534

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
