### PR TITLE
chore: remove irrelevant test

### DIFF
--- a/test/transaction.test.js
+++ b/test/transaction.test.js
@@ -71,13 +71,6 @@ describe('Transactions on test connector without execute()', () => {
     }, done);
   });
 
-  it('beginTransaction returns a transaction', async () => {
-    const promise = db.beginTransaction(Transaction.READ_UNCOMMITTED);
-    promise.should.be.Promise();
-    const transaction = await promise;
-    transaction.should.be.instanceof(EventEmitter);
-  });
-
   it('exposes and caches slave models', done => {
     testModelCaching(tx.models, db.models);
     done();


### PR DESCRIPTION
`db.beginTransaction` does not return a promise. Why is the code testing for promise?
