### PR TITLE
fix: prevent max listeners warning

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -188,6 +188,11 @@ util.inherits(DataSource, EventEmitter);
 DataSource.DataAccessObject = DataAccessObject;
 
 /**
+ * Global maximum number of event listeners
+ */
+DataSource.DEFAULT_MAX_OFFLINE_REQUESTS = 16;
+
+/**
  * Set up the connector instance for backward compatibility with JugglingDB schema/adapter
  * @private
  */
@@ -200,6 +205,10 @@ DataSource.prototype._setupConnector = function() {
       this.connector.dataSource = this;
     }
     const dataSource = this;
+
+    // Set max listeners to a default/configured value
+    dataSource.setMaxListeners(dataSource.getMaxOfflineRequests());
+
     this.connector.log = function(query, start) {
       dataSource.log(query, start);
     };
@@ -2592,6 +2601,27 @@ DataSource.prototype.ping = function(cb) {
     });
   }
   return cb.promise;
+};
+
+/**
+ * Get the maximum number of event listeners
+ */
+DataSource.prototype.getMaxOfflineRequests = function() {
+  // Set max listeners to a default value
+  // Override this default value with a datasource setting
+  // 'maxOfflineRequests' from an application's datasources.json
+
+  let maxOfflineRequests = DataSource.DEFAULT_MAX_OFFLINE_REQUESTS;
+  if (
+    this.settings &&
+    this.settings.maxOfflineRequests
+  ) {
+    if (typeof this.settings.maxOfflineRequests !== 'number')
+      throw new Error('maxOfflineRequests must be a number');
+
+    maxOfflineRequests = this.settings.maxOfflineRequests;
+  }
+  return maxOfflineRequests;
 };
 
 /*! The hidden property call is too expensive so it is not used that much

--- a/test/datasource.test.js
+++ b/test/datasource.test.js
@@ -352,4 +352,26 @@ describe('DataSource', function() {
         .should.not.containEql('TestModel');
     });
   });
+
+  describe('getMaxOfflineRequests', () => {
+    let ds;
+    beforeEach(() => ds = new DataSource('ds', {connector: 'memory'}));
+
+    it('sets the default maximum number of event listeners to 16', () => {
+      ds.getMaxOfflineRequests().should.be.eql(16);
+    });
+
+    it('uses provided number of listeners', () => {
+      ds.settings.maxOfflineRequests = 17;
+      ds.getMaxOfflineRequests().should.be.eql(17);
+    });
+
+    it('throws an error if a non-number is provided for the max number of listeners', () => {
+      ds.settings.maxOfflineRequests = '17';
+
+      (function() {
+        return ds.getMaxOfflineRequests();
+      }).should.throw('maxOfflineRequests must be a number');
+    });
+  });
 });


### PR DESCRIPTION
### Description
If establishing a database connection is slow
and database migration runs and there are many
models, sql operations are queued up and this
leads to the node.js max emitters exceeded
warning.

A default value for max emitters has now
been introduced, and it can also be configured
in datasources.json.

Cherry-pick from https://github.com/strongloop/loopback-datasource-juggler/pull/1767.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
