### PR TITLE
chore: reduce identifier length [3.x]

### DIFF
--- a/test/basic-querying.test.js
+++ b/test/basic-querying.test.js
@@ -1103,11 +1103,12 @@ describe('basic-querying', function() {
         dateProp: Date,
         numProp: Number,
       });
-      numAndDateArrayModel = db.define('numAndDateArrayModel', {
+      // 'numAndDateArrayModel' is too long an identifier name for Oracle DB
+      numAndDateArrayModel = db.define('numAndDateArrMod', {
         dateArray: [Date],
         numArray: [Number],
       });
-      return db.automigrate(['numAndDateModel', 'numAndDateArrayModel']);
+      return db.automigrate(['numAndDateModel', 'numAndDateArrMod']);
     });
 
     it('coerces primitive datatypes on update', function() {

--- a/test/datatype.test.js
+++ b/test/datatype.test.js
@@ -25,7 +25,8 @@ describe('datatypes', function() {
       nested: Nested,
     };
     Model = db.define('Model', modelTableSchema);
-    modelWithDecimalArray = db.define('modelWithDecimalArray', {
+    // 'modelWithDecimalArray' is too long an identifier name for Oracle DB
+    modelWithDecimalArray = db.define('modelWithDecArr', {
       randomReview: {
         type: [String],
         mongodb: {
@@ -42,7 +43,7 @@ describe('datatypes', function() {
     numArrayModel = db.define('numArrayModel', {
       bunchOfNums: [Number],
     });
-    db.automigrate(['Model', 'modelWithDecimalArray', 'dateArrayModel', 'numArrayModel'], done);
+    db.automigrate(['Model', 'modelWithDecArr', 'dateArrayModel', 'numArrayModel'], done);
   });
 
   it('should resolve top-level "type" property correctly', function() {


### PR DESCRIPTION
Existing identifier length exceeds Oracle DB's limit.

#### Related issues

https://github.com/strongloop/loopback-connector-oracle/issues/183
