### PR TITLE
Make sure invalid RegExp string is properly sanitized in query

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -29,6 +29,7 @@ exports.idName = idName;
 exports.rankArrayElements = rankArrayElements;
 exports.idsHaveDuplicates = idsHaveDuplicates;
 exports.isClass = isClass;
+exports.escapeRegExp = escapeRegExp;
 
 const g = require('strong-globalize')();
 const traverse = require('traverse');
@@ -318,6 +319,36 @@ function isProhibited(key, prohibitedKeys) {
 }
 
 /**
+ * Accept an operator key and return whether it is used for a regular expression query or not
+ * @param {string} operator
+ * @returns {boolean}
+ */
+function isRegExpOperator(operator) {
+  return ['like', 'nlike', 'ilike', 'nilike', 'regexp'].includes(operator);
+}
+
+/**
+ * Accept a RegExp string and make sure that any special characters for RegExp are escaped in case they
+ * create an invalid Regexp
+ * @param {string} str
+ * @returns {string}
+ */
+function escapeRegExp(str) {
+  assert.strictEqual(typeof str, 'string', 'String required for regexp escaping');
+  try {
+    new RegExp(str); // try to parse string as regexp
+    return str;
+  } catch (unused) {
+    console.warn(
+      'Auto-escaping invalid RegExp value %j supplied by the caller. ' +
+      'Please note this behavior may change in the future.',
+      str
+    );
+    return str.replace(/[\-\[\]\/\{\}\(\)\+\?\.\\\^\$\|]/g, '\\$&');
+  }
+}
+
+/**
  * Sanitize the query object
  * @param query {object} The query object
  * @param options
@@ -390,6 +421,10 @@ function sanitizeQuery(query, options) {
       // This object is not a plain object
       this.update(x, true); // Stop navigating into this object
       return x;
+    }
+
+    if (isRegExpOperator(this.key) && typeof x === 'string') { // we have regexp supporting operator and string to escape
+      return escapeRegExp(x);
     }
 
     return x;

--- a/test/basic-querying.test.js
+++ b/test/basic-querying.test.js
@@ -23,6 +23,7 @@ describe('basic-querying', function() {
       birthday: {type: Date, index: true},
       role: {type: String, index: true},
       order: {type: Number, index: true, sort: true},
+      tag: {type: String, index: true},
       vip: {type: Boolean},
       address: {
         street: String,
@@ -591,6 +592,12 @@ describe('basic-querying', function() {
             });
         });
 
+      it('should sanitize invalid usage of like', async () => {
+        const users = await User.find({where: {tag: {like: '['}}});
+        users.should.have.length(1);
+        users[0].should.have.property('name', 'John Lennon');
+      });
+
       it('should support "like" that is not satisfied',
         function(done) {
           User.find({where: {name: {like: 'Bob'}}},
@@ -615,6 +622,11 @@ describe('basic-querying', function() {
           users.length.should.equal(0);
           done();
         });
+      });
+
+      it('should properly sanitize invalid ilike filter', async () => {
+        const users = await User.find({where: {name: {ilike: '['}}});
+        users.should.be.empty();
       });
     });
 
@@ -825,7 +837,7 @@ describe('basic-querying', function() {
 
       sample({name: true}).expect(['name']);
       sample({name: false}).expect([
-        'id', 'seq', 'email', 'role', 'order', 'birthday', 'vip', 'address', 'friends', 'addressLoc',
+        'id', 'seq', 'email', 'role', 'order', 'birthday', 'vip', 'address', 'friends', 'addressLoc', 'tag',
       ]);
       sample({name: false, id: true}).expect(['id']);
       sample({id: true}).expect(['id']);
@@ -1311,6 +1323,7 @@ function seed(done) {
       birthday: new Date('1980-12-08'),
       order: 2,
       vip: true,
+      tag: '[singer]',
       address: {
         street: '123 A St',
         city: 'San Jose',

--- a/test/memory.test.js
+++ b/test/memory.test.js
@@ -201,6 +201,7 @@ describe('Memory connector', function() {
       birthday: {type: Date, index: true},
       role: {type: String, index: true},
       order: {type: Number, index: true, sort: true},
+      tag: {type: String, index: true},
       vip: {type: Boolean},
       address: {
         street: String,
@@ -229,6 +230,12 @@ describe('Memory connector', function() {
       });
     });
 
+    it('should properly sanitize like  invalid query', async () => {
+      const users = await User.find({where: {tag: {like: '['}}});
+      users.should.have.length(1);
+      users[0].should.have.property('name', 'John Lennon');
+    });
+
     it('should allow to find using like with regexp', function(done) {
       User.find({where: {name: {like: /.*St.*/}}}, function(err, posts) {
         should.not.exist(err);
@@ -251,6 +258,11 @@ describe('Memory connector', function() {
         posts.should.have.property('length', 4);
         done();
       });
+    });
+
+    it('should sanitize nlike invalid query', async () => {
+      const users = await User.find({where: {name: {nlike: '['}}});
+      users.should.have.length(6);
     });
 
     it('should allow to find using nlike with regexp', function(done) {
@@ -513,7 +525,7 @@ describe('Memory connector', function() {
       });
 
     it('should support the regexp operator with regex strings', function(done) {
-      User.find({where: {name: {regexp: '^J'}}}, function(err, users) {
+      User.find({where: {name: {regexp: 'non$'}}}, function(err, users) {
         should.not.exist(err);
         users.length.should.equal(1);
         users[0].name.should.equal('John Lennon');
@@ -562,6 +574,7 @@ describe('Memory connector', function() {
           role: 'lead',
           birthday: new Date('1980-12-08'),
           vip: true,
+          tag: '[singer]',
           address: {
             street: '123 A St',
             city: 'San Jose',

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -115,6 +115,28 @@ describe('util.sanitizeQuery', function() {
     sanitizeQuery(q2, {prohibitedKeys: ['secret']});
     q2.should.eql({and: [{}, {x: 1}]});
   });
+
+  it('should allow proper structured regexp string', () => {
+    const q1 = {where: {name: {like: '^J'}}};
+    sanitizeQuery(q1).should.eql({where: {name: {like: '^J'}}});
+  });
+
+  it('should properly sanitize regexp string operators', () => {
+    const q1 = {where: {name: {like: '['}}};
+    sanitizeQuery(q1).should.eql({where: {name: {like: '\\['}}});
+
+    const q2 = {where: {name: {nlike: '['}}};
+    sanitizeQuery(q2).should.eql({where: {name: {nlike: '\\['}}});
+
+    const q3 = {where: {name: {ilike: '['}}};
+    sanitizeQuery(q3).should.eql({where: {name: {ilike: '\\['}}});
+
+    const q4 = {where: {name: {nilike: '['}}};
+    sanitizeQuery(q4).should.eql({where: {name: {nilike: '\\['}}});
+
+    const q5 = {where: {name: {regexp: '['}}};
+    sanitizeQuery(q5).should.eql({where: {name: {regexp: '\\['}}});
+  });
 });
 
 describe('util.parseSettings', function() {


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->
Fix the case where an invalid RegExp string is queried on a model. Instead of crashing the app,
we first check if the query can be successfully converted to RegExp and if not, it is sanitized.

Fixes #1781 

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-datasource-juggler) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
