### PR TITLE
Convert error from a property setter to a rejected promise

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -334,7 +334,10 @@ DataAccessObject.create = function(data, options, cb) {
     this.applyProperties(enforced, obj);
     obj.setAttributes(enforced);
   } catch (err) {
-    return cb(err);
+    process.nextTick(function() {
+      cb(err);
+    });
+    return cb.promise;
   }
 
   Model = this.lookupModel(data); // data-specific
@@ -2606,7 +2609,10 @@ DataAccessObject.replaceById = function(id, data, options, cb) {
     this.applyProperties(enforced, inst);
     inst.setAttributes(enforced);
   } catch (err) {
-    return cb(err);
+    process.nextTick(function() {
+      cb(err);
+    });
+    return cb.promise;
   }
 
   Model = this.lookupModel(data); // data-specific


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

Model Creation wiht `create` and replacement with `replaceById`, when error in model initialization they now properly return the rejected promise instead of leaving it unhandled and missing the return value.

Fixes #1789 

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-datasource-juggler) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
