### PR TITLE
chore: remove loopback-connector-ibmi from downstream list

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   "ci": {
     "downstreamIgnoreList": [
       "loopback-connector-db2z",
+      "loopback-connector-ibmi",
       "loopback-connector-informix",
       "loopback-connector-mqlight",
       "loopback-connector-kv-extreme-scale"


### PR DESCRIPTION
We don't have any IBMi instances suitable for running CI builds for this connector.

See also https://github.com/strongloop/loopback-connector/pull/159

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-datasource-juggler) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [ ] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
