### PR TITLE
Fix issue with broken compatibility with array constructor

### DIFF
--- a/lib/list.js
+++ b/lib/list.js
@@ -27,6 +27,11 @@ function List(items, itemType, parent) {
     }
   }
 
+  if (typeof items === 'number') {
+    // trying to initialise empty array with a length
+    items = [...new Array(items)];
+  }
+
   const arr = [];
   arr.__proto__ = List.prototype;
 

--- a/test/list.test.js
+++ b/test/list.test.js
@@ -38,6 +38,16 @@ function PhoneCtor(label, num) {
   this.num = num;
 }
 
+describe('Does not break default Array functionality', function() {
+  it('allows creating an empty length with a specified length', function() {
+    const list = new List(4);
+    list.should.be.an.instanceOf(Array);
+    list.length.should.be.eql(4);
+    should.not.exist(list.itemType);
+    list.toJSON().should.eql([undefined, undefined, undefined, undefined]);
+  });
+});
+
 describe('list of items typed by a class', function() {
   it('allows itemType to be a class', function() {
     const phones = givenPhones();


### PR DESCRIPTION
- You can do new Array(4) to generate an array with 4 empty items
- Doing the same with list caused an error
- This broke lodash.deepclone
- This PR restores compatibility with the array constructor

Fixes #1798
## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-datasource-juggler) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
