### PR TITLE
Update strong-globalize and async to their latest versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "typescript": "^3.2.2"
   },
   "dependencies": {
-    "async": "^2.6.0",
+    "async": "^3.1.0",
     "debug": "^4.1.0",
     "depd": "^2.0.0",
     "inflection": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "minimatch": "^3.0.3",
     "qs": "^6.5.0",
     "shortid": "^2.2.6",
-    "strong-globalize": "^4.1.1",
+    "strong-globalize": "^5.0.2",
     "traverse": "^0.6.6",
     "uuid": "^3.0.1"
   },


### PR DESCRIPTION
`async@3.0.0` release notes: https://github.com/caolan/async/blob/master/CHANGELOG.md#v300

AFAICT, the only breaking change introduced by `strong-globalize@5.0.0` is requiring Node.js 8.9 or newer.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-datasource-juggler) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
