### PR TITLE
fix(security): avoid prototype pollution on model create and update

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -63,6 +63,8 @@ function getIdValue(m, data) {
 
 function copyData(from, to) {
   for (var key in from) {
+    // Don't traverse down prototype chain
+    if (!from.hasOwnProperty(key)) continue;
     to[key] = from[key];
   }
 }
@@ -70,6 +72,8 @@ function copyData(from, to) {
 function convertSubsetOfPropertiesByType(inst, data) {
   var typedData = {};
   for (var key in data) {
+    // Don't traverse down prototype chain
+    if (!data.hasOwnProperty(key)) continue;
     // Convert the properties by type
     typedData[key] = inst[key];
     if (typeof typedData[key] === 'object' &&
@@ -2822,6 +2826,10 @@ DataAccessObject.prototype.remove =
  * @param {Mixed} value Value of property
  */
 DataAccessObject.prototype.setAttribute = function setAttribute(name, value) {
+  // security: Avoid prototype pollution
+  if (name === '__proto__') return;
+  // security: remove __proto__ and undefined if we're setting a nested object
+  if (typeof value === 'object' && value) value = removeUndefined(value);
   this[name] = value; // TODO [fabien] - currently not protected by applyProperties
 };
 
@@ -2855,6 +2863,8 @@ DataAccessObject.prototype.setAttributes = function setAttributes(data) {
 
   // update instance's properties
   for (var key in data) {
+    // Don't traverse down prototype chain
+    if (!data.hasOwnProperty(key)) continue;
     inst.setAttribute(key, data[key]);
   }
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -177,6 +177,10 @@ ModelBaseClass.prototype._initProperties = function(data, options) {
   var p, propVal;
   for (var k = 0; k < size; k++) {
     p = keys[k];
+    // security: Avoid prototype pollution
+    if (p === '__proto__') {
+      continue;
+    }
     propVal = data[p];
     if (typeof propVal === 'function') {
       continue;
@@ -257,6 +261,10 @@ ModelBaseClass.prototype._initProperties = function(data, options) {
 
   for (k = 0; k < size; k++) {
     p = keys[k];
+    // security: Avoid prototype pollution
+    if (p === '__proto__') {
+      continue;
+    }
     propVal = self.__data[p];
     var type = properties[p].type;
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -298,7 +298,7 @@ function selectFields(fields) {
 }
 
 /**
- * Remove undefined values from the queury object
+ * Remove undefined values from the query object
  * @param query
  * @param handleUndefined {String} either "nullify", "throw" or "ignore" (default: "ignore")
  * @returns {exports.map|*}
@@ -309,7 +309,11 @@ function removeUndefined(query, handleUndefined) {
   }
   // WARNING: [rfeng] Use map() will cause mongodb to produce invalid BSON
   // as traverse doesn't transform the ObjectId correctly
-  return traverse(query).forEach(function(x) {
+  return traverse(query).forEach(function(x, k) {
+    // security: Avoid prototype pollution
+    if (this.key === '__proto__') {
+      this.delete(true);
+    }
     if (x === undefined) {
       switch (handleUndefined) {
         case 'nullify':
@@ -328,10 +332,7 @@ function removeUndefined(query, handleUndefined) {
         x.constructor !== Object)) {
       // This object is not a plain object
       this.update(x, true); // Stop navigating into this object
-      return x;
     }
-
-    return x;
   });
 }
 


### PR DESCRIPTION
Without this protection, incoming objects from the network can overwrite
the ModelConstructor prototype.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-datasource-juggler) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
