### PR TITLE
Fix model coerce

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1607,6 +1607,7 @@ DataAccessObject._coerce = function(where, props) {
         self._coerce(clauses[k]);
       }
 
+      where[p] = clauses;
       continue;
     }
 


### PR DESCRIPTION
Investigate the failure on vm node 12 https://github.com/strongloop/loopback-datasource-juggler/pull/1805

There are 3 failures on Node.js 12, this PR fixes the first two. 
The third one will be fixed in anther PR.

Error report see [link](https://cis-jenkins.swg-devops.com/job/nb/job/loopback-datasource-juggler~2.x/label=x64%20&&%20linux%20&&%20nvm,nodeVersion=12/21/console)

Copy it here:

```
  3 failing
14:32:14 
14:32:14   1) DataAccessObject coerces where clause with array-like objects {"and":{"0":{"age":"10"},"1":{"vip":"true"}}}:
14:32:14 
14:32:14       AssertionError [ERR_ASSERTION]: Expected values to be loosely deep-equal:
14:32:14 
14:32:14 {
14:32:14   and: {
14:32:14     '0': {
14:32:14       age: 10
14:32:14     },
14:32:14     '1': {
14:32:14       vip: true
14:32:14     }
14:32:14   }
14:32:14 }
14:32:14 
14:32:14 should loosely deep-equal
14:32:14 
14:32:14 {
14:32:14   and: [
14:32:14     {
14:32:14       age: 10
14:32:14     },
14:32:14     {
14:32:14       vip: true
14:32:14     }
14:32:14   ]
14:32:14 }
14:32:14       + expected - actual
14:32:14 
14:32:14        {
14:32:14       -  "and": {
14:32:14       -    "0": {
14:32:14       +  "and": [
14:32:14       +    {
14:32:14              "age": 10
14:32:14            }
14:32:14       -    "1": {
14:32:14       +    {
14:32:14              "vip": true
14:32:14            }
14:32:14       -  }
14:32:14       +  ]
14:32:14        }
14:32:14       
14:32:14       at Context.<anonymous> (test/loopback-dl.test.js:1535:14)
14:32:14       at processImmediate (internal/timers.js:439:21)
14:32:14 
14:32:14   2) DataAccessObject coerces where clause with array-like objects {"or":{"0":{"age":"10"},"1":{"vip":"true"}}}:
14:32:14 
14:32:14       AssertionError [ERR_ASSERTION]: Expected values to be loosely deep-equal:
14:32:14 
14:32:14 {
14:32:14   or: {
14:32:14     '0': {
14:32:14       age: 10
14:32:14     },
14:32:14     '1': {
14:32:14       vip: true
14:32:14     }
14:32:14   }
14:32:14 }
14:32:14 
14:32:14 should loosely deep-equal
14:32:14 
14:32:14 {
14:32:14   or: [
14:32:14     {
14:32:14       age: 10
14:32:14     },
14:32:14     {
14:32:14       vip: true
14:32:14     }
14:32:14   ]
14:32:14 }
14:32:14       + expected - actual
14:32:14 
14:32:14        {
14:32:14       -  "or": {
14:32:14       -    "0": {
14:32:14       +  "or": [
14:32:14       +    {
14:32:14              "age": 10
14:32:14            }
14:32:14       -    "1": {
14:32:14       +    {
14:32:14              "vip": true
14:32:14            }
14:32:14       -  }
14:32:14       +  ]
14:32:14        }
14:32:14       
14:32:14       at Context.<anonymous> (test/loopback-dl.test.js:1535:14)
14:32:14       at processImmediate (internal/timers.js:439:21)
14:32:14 
14:32:14   3) validations invalid value formatting should exclude colors from Model values:
14:32:14 
14:32:14       AssertionError: expected '`user` is invalid (value: ModelConstructor {\n  __cach...}).' to be '`user` is invalid (value: { email: \'test@example.com\' }).'
14:32:14       + expected - actual
14:32:14 
14:32:14       -`user` is invalid (value: ModelConstructor {
14:32:14       -  __cach...}).
14:32:14       +`user` is invalid (value: { email: 'test@example.com' }).
14:32:14       
14:32:14       at Assertion.fail (node_modules/should/lib/assertion.js:92:17)
14:32:14       at Assertion.value (node_modules/should/lib/assertion.js:164:19)
14:32:14       at Context.<anonymous> (test/validations.test.js:650:35)
14:32:14       at processImmediate (internal/timers.js:439:21)
14:32:14 
```