### PR TITLE
Modify logic around some query tests to fix test failures

### DIFF
--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -382,11 +382,7 @@ describe('manipulation', function() {
             if (!err) {
               return done(new Error('Create should have rejected duplicate id.'));
             }
-            if (db.adapter.name === 'ibmi') {
-              err.odbcErrors[0].message.should.match(/duplicate/i);
-            } else {
-              err.message.should.match(/duplicate/i);
-            }
+            err.message.should.match(/duplicate/i);
             done();
           });
         });

--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -382,7 +382,11 @@ describe('manipulation', function() {
             if (!err) {
               return done(new Error('Create should have rejected duplicate id.'));
             }
-            err.message.should.match(/duplicate/i);
+            if (db.adapter.name === 'ibmi') {
+              err.odbcErrors[0].message.should.match(/duplicate/i);
+            } else {
+              err.message.should.match(/duplicate/i);
+            }
             done();
           });
         });


### PR DESCRIPTION
Several `basic-querying.test.js` tests fail when running with `loopback-connector-ibmi`. Explanations can be found in issue #1809. This PR fixes the tests on v3 (LTS) branch.

Part of #1809 

## Checklist

- [X] `npm test` passes on your machine
- [X] New tests added or existing tests modified to cover all changes
- [X] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [X] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
