### PR TITLE
Modify query tests to fix failures (v4)

### DIFF
--- a/test/basic-querying.test.js
+++ b/test/basic-querying.test.js
@@ -49,7 +49,8 @@ describe('basic-querying', function() {
 
     db = getSchema();
     // connectors that do not support geo-point types
-    connectorCapabilities.geoPoint = (db.adapter.name != 'dashdb') && (db.adapter.name != 'db2') &&
+    connectorCapabilities.geoPoint = (db.adapter.name != 'dashdb') &&
+    (db.adapter.name != 'db2') && (db.adapter.name !== 'ibmi') &&
     (db.adapter.name != 'informix') && (db.adapter.name != 'cassandra');
     if (connectorCapabilities.geoPoint) userModelDef.addressLoc = {type: 'GeoPoint'};
     User = db.define('User', userModelDef);
@@ -480,12 +481,23 @@ describe('basic-querying', function() {
       });
 
     it('should support string "gt" that is not satisfied', function(done) {
-      User.find({where: {name: {'gt': 'xyz'},
-      }}, function(err, users) {
-        should.not.exist(err);
-        users.should.have.property('length', 0);
-        done();
-      });
+      // IBM i tables are coded in EBCDIC by default, need to modify the query
+      // so that it returns no results
+      if (db.adapter.name === 'ibmi') {
+        User.find({where: {name: {'gt': 'XYZ'},
+        }}, function(err, users) {
+          should.not.exist(err);
+          users.should.have.property('length', 0);
+          done();
+        });
+      } else {
+        User.find({where: {name: {'gt': 'xyz'},
+        }}, function(err, users) {
+          should.not.exist(err);
+          users.should.have.property('length', 0);
+          done();
+        });
+      }
     });
 
     bdd.itIf(connectorCapabilities.cloudantCompatible !== false,
@@ -653,7 +665,7 @@ describe('basic-querying', function() {
       });
     });
 
-    describe('geo queries', function() {
+    bdd.describeIf(connectorCapabilities.geoPoint, 'geo queries', function() {
       describe('near filter', function() {
         it('supports a basic "near" query', function(done) {
           User.find({

--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -382,11 +382,7 @@ describe('manipulation', function() {
             if (!err) {
               return done(new Error('Create should have rejected duplicate id.'));
             }
-            if (db.adapter.name === 'ibmi') {
-              err.odbcErrors[0].message.should.match(/duplicate/i);
-            } else {
-              err.message.should.match(/duplicate/i);
-            }
+            err.message.should.match(/duplicate/i);
             done();
           });
         });

--- a/test/manipulation.test.js
+++ b/test/manipulation.test.js
@@ -382,7 +382,11 @@ describe('manipulation', function() {
             if (!err) {
               return done(new Error('Create should have rejected duplicate id.'));
             }
-            err.message.should.match(/duplicate/i);
+            if (db.adapter.name === 'ibmi') {
+              err.odbcErrors[0].message.should.match(/duplicate/i);
+            } else {
+              err.message.should.match(/duplicate/i);
+            }
             done();
           });
         });


### PR DESCRIPTION
Several `basic-querying.test.js` tests fail when running with `loopback-connector-ibmi`. Explanations can be found in issue #1809. This PR fixes the tests on v3 (LTS) branch.

Part of #1809 

## Checklist

- [X] `npm test` passes on your machine
- [X] New tests added or existing tests modified to cover all changes
- [X] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [X] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
