### PR TITLE
feat: support applyDefaultOnWrites in nested properties

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -278,7 +278,7 @@ ModelBaseClass.prototype._initProperties = function(data, options) {
     const type = properties[p].type;
 
     // Set default values
-    if (applyDefaultValues && propVal === undefined) {
+    if (applyDefaultValues && propVal === undefined && appliesDefaultsOnWrites(properties[p])) {
       let def = properties[p]['default'];
       if (def !== undefined) {
         if (typeof def === 'function') {
@@ -361,6 +361,14 @@ ModelBaseClass.prototype._initProperties = function(data, options) {
   }
   this.trigger('initialize');
 };
+
+// Helper function for determing the applyDefaultOnWrites value of a property
+function appliesDefaultsOnWrites(property) {
+  if (property && ('applyDefaultOnWrites' in property)) {
+    return property.applyDefaultOnWrites;
+  }
+  return true;
+}
 
 /**
  * Define a property on the model.

--- a/test/defaults.test.js
+++ b/test/defaults.test.js
@@ -100,5 +100,35 @@ describe('defaults', function() {
       should(found.color).be.undefined();
       found.taste.should.equal('sweet');
     });
+
+    it('removes nested property in an object when set to `false`', async () => {
+      const Apple = db.define('Apple', {
+        name: {type: String},
+        qualities: {
+          color: {type: String, default: 'red', applyDefaultOnWrites: false},
+          taste: {type: String, default: 'sweet'},
+        },
+      }, {applyDefaultsOnReads: false});
+
+      const apple = await Apple.create({name: 'Honeycrisp', qualities: {taste: 'sweet'}});
+      const found = await Apple.findById(apple.id);
+      should(found.qualities.color).be.undefined();
+      found.qualities.taste.should.equal('sweet');
+    });
+
+    it('removes nested property in an array when set to `false', async () => {
+      const Apple = db.define('Apple', {
+        name: {type: String},
+        qualities: [
+          {color: {type: String, default: 'red', applyDefaultOnWrites: false}},
+          {taste: {type: String, default: 'sweet'}},
+        ],
+      }, {applyDefaultsOnReads: false});
+
+      const apple = await Apple.create({name: 'Honeycrisp', qualities: [{taste: 'sweet'}]});
+      const found = await Apple.findById(apple.id);
+      should(found.qualities[0].color).be.undefined();
+      found.qualities.length.should.equal(1);
+    });
   });
 });


### PR DESCRIPTION
Adds support for `applyDefaultOnWrites` in nested properties.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-datasource-juggler) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
