### PR TITLE
feat: added persistDefaultValues

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -299,6 +299,10 @@ ModelBaseClass.prototype._initProperties = function(data, options) {
       }
     }
 
+    if (ignoresMatchedDefault(properties[p]) && properties[p].default === propVal) {
+      delete self.__data[p];
+    }
+
     // Set default value using a named function
     if (applyDefaultValues && propVal === undefined) {
       const defn = properties[p].defaultFn;
@@ -361,6 +365,13 @@ ModelBaseClass.prototype._initProperties = function(data, options) {
   }
   this.trigger('initialize');
 };
+
+// Implementation of persistDefaultValues property
+function ignoresMatchedDefault(property) {
+  if (property && property.persistDefaultValues === false) {
+    return true;
+  }
+}
 
 // Helper function for determing the applyDefaultOnWrites value of a property
 function appliesDefaultsOnWrites(property) {

--- a/test/defaults.test.js
+++ b/test/defaults.test.js
@@ -130,4 +130,48 @@ describe('defaults', function() {
       found.qualities.length.should.equal(1);
     });
   });
+
+  context('persistDefaultValues', function() {
+    it('removes property if value matches default', async () => {
+      const Apple = db.define('Apple', {
+        color: {type: String, default: 'red', persistDefaultValues: false},
+        taste: {type: String, default: 'sweet'},
+      }, {applyDefaultsOnReads: false});
+
+      const apple = await Apple.create({color: 'red', taste: 'sweet'});
+      const found = await Apple.findById(apple.id);
+      should(found.color).be.undefined();
+      found.taste.should.equal('sweet');
+    });
+
+    it('removes property if value matches default in an object', async () => {
+      const Apple = db.define('Apple', {
+        name: {type: String},
+        qualities: {
+          color: {type: String, default: 'red', persistDefaultValues: false},
+          taste: {type: String, default: 'sweet'},
+        },
+      }, {applyDefaultsOnReads: false});
+
+      const apple = await Apple.create({name: 'Honeycrisp', qualities: {taste: 'sweet'}});
+      const found = await Apple.findById(apple.id);
+      should(found.qualities.color).be.undefined();
+      found.qualities.taste.should.equal('sweet');
+    });
+
+    it('removes property if value matches default in an array', async () => {
+      const Apple = db.define('Apple', {
+        name: {type: String},
+        qualities: [
+          {color: {type: String, default: 'red', persistDefaultValues: false}},
+          {taste: {type: String, default: 'sweet'}},
+        ],
+      }, {applyDefaultsOnReads: false});
+
+      const apple = await Apple.create({name: 'Honeycrisp', qualities: [{taste: 'sweet'}]});
+      const found = await Apple.findById(apple.id);
+      should(found.qualities[0].color).be.undefined();
+      found.qualities.length.should.equal(1);
+    });
+  });
 });


### PR DESCRIPTION
Ignores value if it matches default value.

**Use case**: User wants to reduce noise in the database, since the defaults will be filled in by LoopBack or the front-end framework. Makes a big difference if there are thousands of such properties in millions of records.
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-datasource-juggler) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
