### PR TITLE
feat: allows different naming conventions for db  columns for discover

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -28,6 +28,8 @@ const g = require('strong-globalize')();
 const juggler = require('..');
 const deprecated = require('depd')('loopback-datasource-juggler');
 const Transaction = require('loopback-connector').Transaction;
+const pascalCase = require('change-case').pascalCase;
+const camelCase = require('change-case').camelCase;
 
 if (process.env.DEBUG === 'loopback') {
   // For back-compatibility
@@ -1450,17 +1452,22 @@ function capitalize(str) {
   return str.charAt(0).toUpperCase() + ((str.length > 1) ? str.slice(1).toLowerCase() : '');
 }
 
-function fromDBName(dbName, camelCase) {
-  if (!dbName) {
-    return dbName;
+/**
+ * Renames db column names with different naming conventions:
+ * camelCase for property names as it's LB default naming convention for properties,
+ * or keep the name the same if needed.
+ *
+ * @param {*} name name defined in database
+ * @param {*} caseFunction optional. A function to convert the name into different case.
+ */
+function fromDBName(name, caseFunction) {
+  if (!name) {
+    return name;
   }
-  const parts = dbName.split(/-|_/);
-  parts[0] = camelCase ? parts[0].toLowerCase() : capitalize(parts[0]);
-
-  for (let i = 1; i < parts.length; i++) {
-    parts[i] = capitalize(parts[i]);
+  if (typeof caseFunction === 'function') {
+    return caseFunction(name);
   }
-  return parts.join('');
+  return name;
 }
 
 /**
@@ -1567,13 +1574,14 @@ DataSource.prototype.discoverSchemas = function(tableName, options, cb) {
     cb = options;
     options = {};
   }
-
   cb = cb || utils.createPromiseCallback();
 
   const self = this;
   const dbType = this.connector.name;
 
   let nameMapper;
+  const disableCamelCase = !!options.disableCamelCase;
+
   if (options.nameMapper === null) {
     // No mapping
     nameMapper = function(type, name) {
@@ -1586,11 +1594,19 @@ DataSource.prototype.discoverSchemas = function(tableName, options, cb) {
     // Default name mapper
     nameMapper = function mapName(type, name) {
       if (type === 'table' || type === 'model') {
-        return fromDBName(name, false);
+        return fromDBName(name, pascalCase);
       } else if (type == 'fk') {
-        return fromDBName(name + 'Rel', true);
+        if (disableCamelCase) {
+          return fromDBName(name + 'Rel');
+        } else {
+          return fromDBName(name + 'Rel', camelCase);
+        }
       } else {
-        return fromDBName(name, true);
+        if (disableCamelCase) {
+          return fromDBName(name);
+        } else {
+          return fromDBName(name, camelCase);
+        }
       }
     };
   }
@@ -1770,12 +1786,17 @@ DataSource.prototype.discoverSchemasSync = function(modelName, options) {
   if (!columns || columns.length === 0) {
     return [];
   }
+  const disableCamelCase = !!options.disableCamelCase;
 
   const nameMapper = options.nameMapper || function mapName(type, name) {
     if (type === 'table' || type === 'model') {
-      return fromDBName(name, false);
+      return fromDBName(name, pascalCase);
     } else {
-      return fromDBName(name, true);
+      if (disableCamelCase) {
+        return fromDBName(name);
+      } else {
+        return fromDBName(name, camelCase);
+      }
     }
   };
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   },
   "dependencies": {
     "async": "^3.1.0",
+    "change-case": "^4.1.1",
     "debug": "^4.1.0",
     "depd": "^2.0.0",
     "inflection": "^1.6.0",

--- a/test/discovery.test.js
+++ b/test/discovery.test.js
@@ -73,7 +73,7 @@ describe('Memory connector with mocked discovery', function() {
     };
   });
 
-  it('should convert table/column names to camel cases', function(done) {
+  it('should convert table names to pascal cases and column names to camel case', function(done) {
     ds.discoverSchemas('INVENTORY', {}, function(err, schemas) {
       if (err) return done(err);
       schemas.should.have.property('STRONGLOOP.INVENTORY');
@@ -81,6 +81,19 @@ describe('Memory connector with mocked discovery', function() {
       s.name.should.be.eql('Inventory');
       Object.keys(s.properties).should.be.eql(
         ['productId', 'locationId', 'available', 'total'],
+      );
+      done();
+    });
+  });
+
+  it('should keep the column names the same as database', function(done) {
+    ds.discoverSchemas('INVENTORY', {disableCamelCase: true}, function(err, schemas) {
+      if (err) return done(err);
+      schemas.should.have.property('STRONGLOOP.INVENTORY');
+      const s = schemas['STRONGLOOP.INVENTORY'];
+      s.name.should.be.eql('Inventory');
+      Object.keys(s.properties).should.be.eql(
+        ['PRODUCT_ID', 'LOCATION_ID', 'AVAILABLE', 'TOTAL'],
       );
       done();
     });


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

Connects to https://github.com/strongloop/loopback-next/issues/3343

Allows users to keep the property name as the same as the db columns names. It can be set by `options.useDefaultCase` to false.

To close #3343, we need to:
1. modify Juggler (this PR)
2. update LB3 docs ( https://github.com/strongloop/loopback.io/pull/928)
3. update `lb4 discover` CLI and docs ( need this PR to be landed first)

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-datasource-juggler) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
