### PR TITLE
feat: add OperationHookContext interface

### DIFF
--- a/types/observer-mixin.d.ts
+++ b/types/observer-mixin.d.ts
@@ -4,8 +4,22 @@
 // License text available at https://opensource.org/licenses/MIT
 
 import {Callback, PromiseOrVoid} from './common';
+import {PersistedModel, PersistedModelClass} from './persisted-model';
 
-export type Listener = (ctx: object, next: (err?: any) => void) => void;
+export interface OperationHookContext<T extends typeof PersistedModel> {
+  /**
+   * The constructor of the model that triggered the operation.
+   */
+  Model: T;
+
+  /**
+   * Additional context properties, not typed yet.
+   * See https://loopback.io/doc/en/lb3/Operation-hooks.html#hooks
+   */
+  [property: string]: any;
+}
+
+export type Listener<Ctx> = (ctx: Ctx, next: (err?: any) => void) => void;
 
 export interface ObserverMixin {
   /**
@@ -36,7 +50,7 @@ export interface ObserverMixin {
    * `this` set to the model constructor, e.g. `User`.
    * @end
    */
-  observe(operation: string, listener: Listener): void;
+  observe(operation: string, listener: Listener<OperationHookContext<PersistedModelClass>>): void;
 
   /**
    * Unregister an asynchronous observer for the given operation (event).
@@ -54,7 +68,7 @@ export interface ObserverMixin {
    * @callback {function} listener The listener function.
    * @end
    */
-  removeObserver(operation: string, listener: Listener): Listener | undefined;
+  removeObserver(operation: string, listener: Listener<OperationHookContext<PersistedModelClass>>): Listener<OperationHookContext<PersistedModelClass>> | undefined;
 
   /**
    * Unregister all asynchronous observers for the given operation (event).


### PR DESCRIPTION
Added typings for supporting operation hooks in LB4. Part of addressing https://github.com/strongloop/loopback-next/issues/3952.

Signed-off-by: Hage Yaapa <hage.yaapa@in.ibm.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-datasource-juggler) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
