### PR TITLE
Add default generic arg value to `Listener` type

### DIFF
--- a/types/observer-mixin.d.ts
+++ b/types/observer-mixin.d.ts
@@ -19,7 +19,9 @@ export interface OperationHookContext<T extends typeof PersistedModel> {
   [property: string]: any;
 }
 
-export type Listener<Ctx> = (ctx: Ctx, next: (err?: any) => void) => void;
+export type Listener<Ctx = OperationHookContext<PersistedModelClass>> = (
+  ctx: Ctx, next: (err?: any) => void
+) => void;
 
 export interface ObserverMixin {
   /**


### PR DESCRIPTION
The changes introduced by dcfda58 (#1820) may break existing consumers of our typings. This commit fixes this problem by adding a default value to the recently introduced generic argument of `Listener` type.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-datasource-juggler) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
