### PR TITLE
chore: improve Listener signature

### DIFF
--- a/types/observer-mixin.d.ts
+++ b/types/observer-mixin.d.ts
@@ -21,7 +21,7 @@ export interface OperationHookContext<T extends typeof ModelBase> {
 
 export type Listener<Ctx = OperationHookContext<typeof ModelBase>> = (
   ctx: Ctx, next: (err?: any) => void
-) => void;
+) => PromiseOrVoid<void>;
 
 export interface ObserverMixin {
   /**


### PR DESCRIPTION
Improved Listener signature so it can accept callback or promise.

Addresses https://github.com/strongloop/loopback-next/pull/4730/files#r385912758, required for landing PR https://github.com/strongloop/loopback-next/pull/4730/.

The `observe` and `removeObserver` methods of a class implementing `ObserverMixin` can accept a callback or a promise. The current typing does not allow that. This PR re-defines the `Listener` type to be either a callback that returns `void` or a promise that resolves to `void`. 

The problem this PR solves manifests only in TS projects, like LB next, hence it cannot be tested in the Juggler repository.

Before settling on this change, we tried another approach:

```ts
export interface Listener<Ctx = OperationHookContext<typeof ModelBase>> {
  (ctx: Ctx, next: (err?: any) => void): void;
  (ctx: Ctx): Promise<void>;
}
```
but the overloaded interfaced did not work as expected.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-datasource-juggler) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
