### PR TITLE
Update LTS status

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This module adopts the [Module Long Term Support (LTS)](http://github.com/CloudN
 | Version    | Status          | Published | EOL                  |
 | ---------- | --------------- | --------- | -------------------- |
 | 4.x        | Current         | Oct 2018  | Apr 2022 _(minimum)_ |
-| 3.x        | Active LTS      | Dec 2016  | Dec 2020             |
+| 3.x        | Maintenance LTS | Dec 2016  | Dec 2020             |
 | 2.x        | End-of-Life | Jul 2014  | Apr 2019             |
 
 Learn more about our LTS plan in the [LoopBack documentation](http://loopback.io/doc/en/contrib/Long-term-support.html).

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This module adopts the [Module Long Term Support (LTS)](http://github.com/CloudN
 
 | Version    | Status          | Published | EOL                  |
 | ---------- | --------------- | --------- | -------------------- |
-| 4.x        | Current         | Oct 2018  | Apr 2021 _(minimum)_ |
+| 4.x        | Current         | Oct 2018  | Apr 2022 _(minimum)_ |
 | 3.x        | Active LTS      | Dec 2016  | Dec 2020             |
 | 2.x        | End-of-Life | Jul 2014  | Apr 2019             |
 


### PR DESCRIPTION
- 4.x will be supported at least until April 2022 (to match Node.js 12.x)
- 3.x is in Maintenance LTS now

See https://github.com/strongloop/loopback/issues/4306

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-datasource-juggler) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
