### PR TITLE
Move List.prototype.toItem out of inner init

### DIFF
--- a/lib/list.js
+++ b/lib/list.js
@@ -68,21 +68,6 @@ function List(items, itemType, parent) {
     });
   }
 
-  List.prototype.toItem = function(item) {
-    if (isClass(this.itemType)) {
-      return new this.itemType(item);
-    } else {
-      if (Array.isArray(item)) {
-        return item;
-      } else if (this.itemType === Date) {
-        if (item === null) return null;
-        return new Date(item);
-      } else {
-        return this.itemType(item);
-      }
-    }
-  };
-
   items.forEach(function(item, i) {
     if (itemType && !(item instanceof itemType)) {
       arr[i] = arr.toItem(item);
@@ -97,6 +82,21 @@ function List(items, itemType, parent) {
 util.inherits(List, Array);
 
 const _push = List.prototype.push;
+
+List.prototype.toItem = function(item) {
+  if (isClass(this.itemType)) {
+    return new this.itemType(item);
+  } else {
+    if (Array.isArray(item)) {
+      return item;
+    } else if (this.itemType === Date) {
+      if (item === null) return null;
+      return new Date(item);
+    } else {
+      return this.itemType(item);
+    }
+  }
+};
 
 List.prototype.push = function(obj) {
   const item = this.itemType && (obj instanceof this.itemType) ? obj : this.toItem(obj);


### PR DESCRIPTION
Move wrong re-initialization of `List.prototype.toItem` on every instatiation, to proper prototype usage.

This was separated from #1787 by @bajtos  to be landed separately and backported

See also #1787 

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-datasource-juggler) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
