### PR TITLE
feat: implement DataSource.stop()

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -2221,6 +2221,14 @@ DataSource.prototype.disconnect = function disconnect(cb) {
 };
 
 /**
+ * An alias for `disconnect` to make the datasource a LB4 life-cycle observer.
+ * Please note that we are intentionally not providing a `start` method,
+ * because the logic for establishing connection(s) is more complex
+ * and usually started immediately from the datasoure constructor.
+ */
+DataSource.prototype.stop = DataSource.prototype.disconnect;
+
+/**
  * Copy the model from Master.
  * @param {Function} Master The model constructor
  * @returns {Model} A copy of the Model object constructor

--- a/test/datasource.test.js
+++ b/test/datasource.test.js
@@ -330,6 +330,31 @@ describe('DataSource', function() {
     });
   });
 
+  it('provides stop() API calling disconnect', function(done) {
+    const mockConnector = {
+      name: 'loopback-connector-mock',
+      initialize: function(ds, cb) {
+        ds.connector = mockConnector;
+        process.nextTick(function() {
+          cb(null);
+        });
+      },
+    };
+
+    const dataSource = new DataSource(mockConnector);
+    dataSource.on('connected', function() {
+      // DataSource is now connected
+      // connected: true, connecting: false
+      dataSource.connected.should.be.true();
+      dataSource.connecting.should.be.false();
+
+      dataSource.stop(() => {
+        dataSource.connected.should.be.false();
+        done();
+      });
+    });
+  });
+
   describe('deleteModelByName()', () => {
     it('removes the model from ModelBuilder registry', () => {
       const ds = new DataSource('ds', {connector: 'memory'});

--- a/types/datasource.d.ts
+++ b/types/datasource.d.ts
@@ -287,6 +287,9 @@ export declare class DataSource extends EventEmitter {
   // legacy callback style
   disconnect(callback: Callback): void;
 
+  // Only promise variant, callback is intentionally not described.
+  stop(): Promise<void>;
+
   ping(): Promise<void>;
   // legacy callback style
   ping(callback: Callback): void;


### PR DESCRIPTION
Implement `stop` as an alias for `disconnect`. This way LB4 applications don't have to include custom `stop` implementation in every datasource file.

Intended datasource file:
```ts
@lifeCycleObserver('datasource')
export class DbDataSource extends juggler.DataSource
  implements LifeCycleObserver {
  static dataSourceName = 'db';

  constructor(
    @inject('datasources.config.db', {optional: true})
    dsConfig: object = config,
  ) {
    super(dsConfig);
  }
}
```

Compare with the current template:

```ts
@lifeCycleObserver('datasource')
export class DbDataSource extends juggler.DataSource
  implements LifeCycleObserver {
  static dataSourceName = 'db';

  constructor(
    @inject('datasources.config.db', {optional: true})
    dsConfig: object = config,
  ) {
    super(dsConfig);
  }

  /**
   * Start the datasource when application is started
   */
  start(): ValueOrPromise<void> {
    // Add your logic here to be invoked when the application is started
  }

  /**
   * Disconnect the datasource when application is stopped. This allows the
   * application to be shut down gracefully.
   */
  stop(): ValueOrPromise<void> {
    return super.disconnect();
  }
}
```

Please note this change still allows app developers to add custom logic to start/stop step:

```ts
@lifeCycleObserver('datasource')
export class DbDataSource extends juggler.DataSource
  implements LifeCycleObserver {
  static dataSourceName = 'db';

  constructor(
    @inject('datasources.config.db', {optional: true})
    dsConfig: object = config,
  ) {
    super(dsConfig);
  }

  stop(): ValueOrPromise<void> {
    // add my custom shutdown steps
    return super.stop();
  }
}
```
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-datasource-juggler) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
