### PR TITLE
types: make DataSource.stop compatible with LB4

### DIFF
--- a/types/datasource.d.ts
+++ b/types/datasource.d.ts
@@ -288,7 +288,10 @@ export declare class DataSource extends EventEmitter {
   disconnect(callback: Callback): void;
 
   // Only promise variant, callback is intentionally not described.
-  stop(): Promise<void>;
+  // Note we must use `void | PromiseLike<void>` to avoid breaking
+  // existing LoopBack 4 applications.
+  // TODO(semver-major): change the return type to `Promise<void>`
+  stop(): void | PromiseLike<void>;
 
   ping(): Promise<void>;
   // legacy callback style


### PR DESCRIPTION
This is a follow-up for https://github.com/strongloop/loopback-datasource-juggler/pull/1835.

Change the return value of `DataSource.stop()` from `Promise<void>` to `void | PromiseLike<void>` to avoid breaking existing LoopBack 4 applications, where DataSource subclasses are scaffolded with `stop(): ValueOrPromise<void>`.

Before the change, build of loopback-next was failing with the following errors (see https://github.com/strongloop/loopback-next/pull/5261)

https://travis-ci.com/github/strongloop/loopback-next/jobs/323793285
```
> loopback-next@0.1.0 build /home/travis/build/strongloop/loopback-next
> node packages/build/bin/compile-package -b

examples/multi-tenancy/src/datasources/db.datasource.ts:40:3 - error TS2416: Property 'stop' in type 'DbDataSource' is not assignable to the same property in base type 'DataSource'.
  Type '() => ValueOrPromise<void>' is not assignable to type '() => Promise<void>'.
    Type 'ValueOrPromise<void>' is not assignable to type 'Promise<void>'.
      Type 'void' is not assignable to type 'Promise<void>'.

40   stop(): ValueOrPromise<void> {
     ~~~~
(...)
```

I have manually verified that the new typings are fixing loopback-next build:
```
$ (cd packages/repository && npm link {path-to-juggler})
$ npm run build
```

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-datasource-juggler) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
