### PR TITLE
types: allow no `models` argument for automigrate

### DIFF
--- a/types/datasource.d.ts
+++ b/types/datasource.d.ts
@@ -140,13 +140,13 @@ export declare class DataSource extends EventEmitter {
    */
   attach(modelClass: ModelBaseClass): ModelBaseClass;
 
-  automigrate(models: string | string[]): Promise<void>;
+  automigrate(models?: string | string[]): Promise<void>;
   // legacy callback style
-  automigrate(models: string | string[], callback: Callback): void;
+  automigrate(models: string | string[] | undefined, callback: Callback): void;
 
-  autoupdate(models: string | string[]): Promise<void>;
+  autoupdate(models?: string | string[]): Promise<void>;
   // legacy callback style
-  autoupdate(models: string | string[], callback: Callback): void;
+  autoupdate(models: string | string[] | undefined, callback: Callback): void;
 
   discoverModelDefinitions(
     options?: Options,


### PR DESCRIPTION
Fix type definitions to allow zero-argument invocation of the following database migration methods:
  - `DataSource.automigrate()`
  - `DataSource.autoupdate()`

Implementation-wise, when no model names are specified, then ALL models attached to the datasource are migrated.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-datasource-juggler) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [ ] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
