### PR TITLE
feat: improve `dataSource.execute` to support more flavors

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -2690,19 +2690,10 @@ DataSource.prototype.ping = function(cb) {
  * Execute an arbitrary command. The commands are connector specific,
  * please refer to the documentation of your connector for more details.
  *
- * @param command String|Object The command to execute, e.g. an SQL query.
- * @param [args] Array Parameters values to set in the command.
- * @param [options] Object Additional options, e.g. the transaction to use.
+ * @param [...params] Array The command and its arguments, e.g. an SQL query.
  * @returns Promise A promise of the result
  */
-DataSource.prototype.execute = function(command, args = [], options = {}) {
-  assert(typeof command === 'string' || typeof command === 'object',
-    '"command" must be a string or an object.');
-  assert(typeof args === 'object',
-    '"args" must be an object, an array or undefined.');
-  assert(typeof options === 'object',
-    '"options" must be an object or undefined.');
-
+DataSource.prototype.execute = function(...params) {
   if (!this.connector) {
     return Promise.reject(errorNotImplemented(
       `DataSource "${this.name}" is missing a connector to execute the command.`,
@@ -2717,7 +2708,7 @@ DataSource.prototype.execute = function(command, args = [], options = {}) {
   }
 
   return new Promise((resolve, reject) => {
-    this.connector.execute(command, args, options, onExecuted);
+    this.connector.execute(...params, onExecuted);
     function onExecuted(err, result) {
       if (err) return reject(err);
       if (arguments.length > 2) {


### PR DESCRIPTION
Add support for the following variants:

- `execute(collection, command, ...params, options)` (MongoDB)
- `execute(...params)` (forward-compatibility & other databases)

This is a follow-up for #1855, which added type descriptions for `execute` variants that turned out to be rejected by the actual (runtime) implementation. See also https://github.com/strongloop/loopback-next/issues/3342

The changes is pushing the responsibility for processing optional arguments (`(cmd)`, `(cmd, args)`, `(cmd, args, options)`) to the connector. This should be fine because the base `SqlConnector` already handles optional arguments (see [lib/sql.js#L551-L563](https://github.com/strongloop/loopback-connector/blob/bce6fa8c1f498340a5185dcd21545972a3cce7a7/lib/sql.js#L551-L563)), and we weren't really supporting non-SQL `execute` before.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-datasource-juggler) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
