### PR TITLE
array_type_field_filter: Adds contains filter for postgresDB

### DIFF
--- a/lib/model-utils.js
+++ b/lib/model-utils.js
@@ -88,6 +88,7 @@ const operators = {
   ilike: 'ILIKE',
   nilike: 'NOT ILIKE',
   regexp: 'REGEXP',
+  contains: '@>',
 };
 
 /*
@@ -449,6 +450,7 @@ ModelUtils._coerce = function(where, options, modelDef) {
             case 'inq':
             case 'nin':
             case 'between':
+            case 'contains':
               try {
                 val = coerceArray(val);
               } catch (e) {


### PR DESCRIPTION
Adds contains filter to make searches on Array type field.


Fixes #342 of [loopback-postgres connector](https://github.com/strongloop/loopback-connector-postgresql/pull/460)

## Checklist

- [X] [Sign off your commits](https://loopback.io/doc/en/contrib/code-contrib.html) with DCO (Developer Certificate of Origin)
- [X] `npm test` passes on your machine
- [X] New tests added or existing tests modified to cover all changes
- [X] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [X] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
