### PR TITLE
Fix value equality test to avoid toString

### DIFF
--- a/lib/connectors/memory.js
+++ b/lib/connectors/memory.js
@@ -613,8 +613,8 @@ function applyFilter(filter) {
       return value.match(example);
     }
 
-    if (example === undefined) {
-      return undefined;
+    if (example == null) {
+      return value == null;
     }
 
     if (typeof example === 'object' && example !== null) {
@@ -682,9 +682,13 @@ function applyFilter(filter) {
         return true;
       }
     }
+
+    // compare date
+    if (example instanceof Date && value instanceof Date) {
+      return example.getTime() === value.getTime();
+    }
     // not strict equality
-    return (example !== null ? example.toString() : example) ==
-      (value != null ? value.toString() : value);
+    return example == value;
   }
 
   /**

--- a/test/memory.test.js
+++ b/test/memory.test.js
@@ -339,6 +339,15 @@ describe('Memory connector', function() {
         });
     });
 
+    it('should successfully extract 1 user (Lennon) from the db by date', function(done) {
+      User.find({where: {birthday: new Date('1980-12-08')}},
+        function(err, users) {
+          should(users.length).be.equal(1);
+          should(users[0].name).be.equal('John Lennon');
+          done();
+        });
+    });
+
     it('should successfully extract 2 users from the db', function(done) {
       User.find({where: {birthday: {between: [new Date(1940, 0), new Date(1990, 0)]}}},
         function(err, users) {
@@ -562,6 +571,33 @@ describe('Memory connector', function() {
             sirpaul.vip.should.be.instanceOf(Boolean);
             done();
           });
+      });
+    });
+
+    it('should handle constructor.prototype', function(done) {
+      User.find({where: {'constructor.prototype': {toString: 'Not a function'}}}, function(err,
+        users) {
+        should.not.exist(err);
+        users.length.should.equal(0);
+        done();
+      });
+    });
+
+    it('should handle constructor/prototype', function(done) {
+      User.find({where: {constructor: {prototype: {toString: 'Not a function'}}}}, function(err,
+        users) {
+        should.not.exist(err);
+        users.length.should.equal(0);
+        done();
+      });
+    });
+
+    it('should handle toString', function(done) {
+      User.find({where: {toString: 'Not a function'}}, function(err,
+        users) {
+        should.not.exist(err);
+        users.length.should.equal(0);
+        done();
       });
     });
 


### PR DESCRIPTION
Fix issues discovered by https://github.com/strongloop/loopback-next/pull/6676

- The where statement can be something like {toString: 'not a function'}
- Avoid object string comparison

Signed-off-by: Raymond Feng <enjoyjava@gmail.com>

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] [Sign off your commits](https://loopback.io/doc/en/contrib/code-contrib.html) with DCO (Developer Certificate of Origin)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
