### PR TITLE
fix: using regexp in where filter on additional props

### DIFF
--- a/lib/model-utils.js
+++ b/lib/model-utils.js
@@ -399,39 +399,6 @@ ModelUtils._coerce = function(where, options, modelDef) {
 
       continue;
     }
-    let DataType = props[p] && props[p].type;
-    if (!DataType) {
-      continue;
-    }
-
-    if ((Array.isArray(DataType) || DataType === Array) && !isNestedModel(DataType)) {
-      DataType = DataType[0];
-    }
-    if (DataType === Date) {
-      DataType = DateType;
-    } else if (DataType === Boolean) {
-      DataType = BooleanType;
-    } else if (DataType === Number) {
-      // This fixes a regression in mongodb connector
-      // For numbers, only convert it produces a valid number
-      // LoopBack by default injects a number id. We should fix it based
-      // on the connector's input, for example, MongoDB should use string
-      // while RDBs typically use number
-      DataType = NumberType;
-    }
-
-    if (!DataType) {
-      continue;
-    }
-
-    if (DataType === geo.GeoPoint) {
-      // Skip the GeoPoint as the near operator breaks the assumption that
-      // an operation has only one property
-      // We should probably fix it based on
-      // http://docs.mongodb.org/manual/reference/operator/query/near/
-      // The other option is to make operators start with $
-      continue;
-    }
 
     let val = where[p];
     if (val === null || val === undefined) {
@@ -493,6 +460,45 @@ ModelUtils._coerce = function(where, options, modelDef) {
           break;
         }
       }
+    }
+
+    if (operator === 'regexp' && val instanceof RegExp) {
+      where[p] = val;
+      return where[p];
+    }
+
+    let DataType = props[p] && props[p].type;
+    if (!DataType) {
+      continue;
+    }
+
+    if ((Array.isArray(DataType) || DataType === Array) && !isNestedModel(DataType)) {
+      DataType = DataType[0];
+    }
+    if (DataType === Date) {
+      DataType = DateType;
+    } else if (DataType === Boolean) {
+      DataType = BooleanType;
+    } else if (DataType === Number) {
+      // This fixes a regression in mongodb connector
+      // For numbers, only convert it produces a valid number
+      // LoopBack by default injects a number id. We should fix it based
+      // on the connector's input, for example, MongoDB should use string
+      // while RDBs typically use number
+      DataType = NumberType;
+    }
+
+    if (!DataType) {
+      continue;
+    }
+
+    if (DataType === geo.GeoPoint) {
+      // Skip the GeoPoint as the near operator breaks the assumption that
+      // an operation has only one property
+      // We should probably fix it based on
+      // http://docs.mongodb.org/manual/reference/operator/query/near/
+      // The other option is to make operators start with $
+      continue;
     }
 
     try {

--- a/test/model-utils.test.js
+++ b/test/model-utils.test.js
@@ -4,10 +4,11 @@
 // License text available at https://opensource.org/licenses/MIT
 
 'use strict';
+const should = require('./init.js');
 let db;
 
 describe('model-utils', () => {
-  context('coerce', () => {
+  context('property-based coercion', () => {
     before(() => {
       // eslint-disable-next-line no-undef
       db = getSchema();
@@ -95,5 +96,24 @@ describe('model-utils', () => {
     function assertInstanceOf(val, type) {
       val.should.be.instanceOf(type);
     }
+  });
+  context('operator-based coercion', () => {
+    let model;
+    let data;
+    beforeEach(() => {
+      // eslint-disable-next-line no-undef
+      db = getSchema();
+      model = db.define('model', {
+        rootProp: {},
+      });
+      data = {
+        rootProp: {},
+      };
+    });
+    it('coerces regexp', () => {
+      const where = {random: {regexp: '/k/'}};
+      const coercedData = model._coerce(where, {}, data);
+      should.deepEqual(coercedData, /k/);
+    });
   });
 });

--- a/test/model-utils.test.js
+++ b/test/model-utils.test.js
@@ -111,7 +111,7 @@ describe('model-utils', () => {
       };
     });
     it('coerces regexp', () => {
-      const where = {random: {regexp: '/k/'}};
+      const where = {extra: {regexp: '/k/'}};
       const coercedData = model._coerce(where, {}, data);
       should.deepEqual(coercedData, /k/);
     });


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->
Fixes [#5741](https://github.com/strongloop/loopback-next/issues/5741)


additional properties not defined in a model can't be searched for using a regexp filter
for example, this filter `{"where":{"and":[{"c_range": {"regexp" : "/etern/i"}}]}}` does not work when `c_range` is an additional property added to the data but not defined in the model. However, the same filter done on a property which is defined in the model works fine.

## Checklist

- [x] [Sign off your commits](https://loopback.io/doc/en/contrib/code-contrib.html) with DCO (Developer Certificate of Origin)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [ ] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
