### PR TITLE
chore: drop Node.js 20 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [20, 22, 24]
+        node-version: [22, 24, 26]
         include:
           - os: macos-latest
             node-version: 22
@@ -34,12 +34,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Update NPM (Node.js v10)
-        if: matrix.node-version == 10
-        run: npm install --global npm@7
-      - name: Update NPM
-        if: matrix.node-version != 10
-        run: npm install --global npm@8
       - name: Bootstrap project
         run: npm ci --ignore-scripts
       - name: Build project

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "author": "IBM Corp. and LoopBack contributors",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
BREAKING CHANGE: drop Node.js 20 support

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] [Sign off your commits](https://loopback.io/doc/en/contrib/code-contrib.html) with DCO (Developer Certificate of Origin)
- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
